### PR TITLE
Fix ge_or_none usage in cluster delete

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1357,7 +1357,9 @@ class Cluster(ClusterBase):
     def delete(self):
         capi_cluster = objects.Cluster.objects(
             self.api, namespace="magnum-system"
-        ).get_or_none(utils.get_or_generate_cluster_api_name(self.api, self.cluster))
+        ).get_or_none(
+            name=utils.get_or_generate_cluster_api_name(self.api, self.cluster)
+        )
         capi_cluster.delete()
 
 


### PR DESCRIPTION
i missed test https://github.com/vexxhost/magnum-cluster-api/pull/23.
This is the fix after test