### PR TITLE
Override delete method of ClusterResourcesConfigMap

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -201,6 +201,16 @@ class ClusterResourcesConfigMap(ClusterBase):
             },
         )
 
+    def get_or_none(self) -> objects.Cluster:
+        return pykube.ConfigMap.objects(
+            self.api, namespace="magnum-system"
+        ).get_or_none(name=self.cluster.uuid)
+
+    def delete(self):
+        cr_cm = self.get_or_none()
+        if cr_cm:
+            cr_cm.delete()
+
 
 class ClusterResourceSet(ClusterBase):
     def get_object(self) -> objects.ClusterResourceSet:


### PR DESCRIPTION
Now get_object method has an assert. Once this assertion is negative, deletion is failed as well as creation. By overriding the deletion method using the config map name directly, it avoids deletion failure. Also, it will reduce API requests.