### PR TITLE
fix: Use public auth_url for CloudConfigSecret

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -37,7 +37,7 @@ class BaseDriver(driver.Driver):
         resources.CloudConfigSecret(
             self.k8s_api,
             cluster,
-            osc.url_for(service_type='identity', interface="public"),
+            osc.url_for(service_type="identity", interface="public"),
             osc.cinder_region_name(),
             credential,
         ).apply()

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -34,9 +34,9 @@ class BaseDriver(driver.Driver):
             description=f"Magnum cluster ({cluster.uuid})",
         )
 
-        resources.CloudConfigSecret(
-            self.k8s_api, cluster, osc.auth_url, osc.cinder_region_name(), credential
-        ).apply()
+        resources.CloudConfigSecret(self.k8s_api, cluster,
+            osc.url_for(service_type='identity', interface="public"),
+            osc.cinder_region_name(), credential).apply()
 
         resources.ApiCertificateAuthoritySecret(self.k8s_api, cluster).apply()
         resources.EtcdCertificateAuthoritySecret(self.k8s_api, cluster).apply()

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -34,9 +34,13 @@ class BaseDriver(driver.Driver):
             description=f"Magnum cluster ({cluster.uuid})",
         )
 
-        resources.CloudConfigSecret(self.k8s_api, cluster,
+        resources.CloudConfigSecret(
+            self.k8s_api,
+            cluster,
             osc.url_for(service_type='identity', interface="public"),
-            osc.cinder_region_name(), credential).apply()
+            osc.cinder_region_name(),
+            credential,
+        ).apply()
 
         resources.ApiCertificateAuthoritySecret(self.k8s_api, cluster).apply()
         resources.EtcdCertificateAuthoritySecret(self.k8s_api, cluster).apply()

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -67,6 +67,7 @@ def generate_cloud_controller_manager_config(
         region={cloud_config["clouds"]["default"]["region_name"]}
         application-credential-id={cloud_config["clouds"]["default"]["auth"]["application_credential_id"]}
         application-credential-secret={cloud_config["clouds"]["default"]["auth"]["application_credential_secret"]}
+        tls-insecure={not cloud_config["clouds"]["default"]["verify"]}
         """
     )
 


### PR DESCRIPTION
CloudConfigSecret is used to generate the configuration of ccm which will be deployed on coe clusters.
Internal auth_url is not resolvable inside coe clusters. This PR uses public auth_url.

In addition, add `tls_insecure` field in ccm config to support self-signed certs