### PR TITLE
feat: Use crane for image loader instead of skopeo

### DIFF
--- a/.markdownlint.rb
+++ b/.markdownlint.rb
@@ -1,3 +1,4 @@
 all
+rule '~MD012'
 rule 'MD013', :ignore_code_blocks => true, :line_length => 500
 rule 'MD024', :allow_different_nesting => true

--- a/.markdownlint.rb
+++ b/.markdownlint.rb
@@ -1,4 +1,3 @@
 all
-~rule 'MD012'
 rule 'MD013', :ignore_code_blocks => true, :line_length => 500
 rule 'MD024', :allow_different_nesting => true

--- a/.markdownlint.rb
+++ b/.markdownlint.rb
@@ -1,4 +1,4 @@
 all
-rule '~MD012'
+rule ~'MD012'
 rule 'MD013', :ignore_code_blocks => true, :line_length => 500
 rule 'MD024', :allow_different_nesting => true

--- a/.markdownlint.rb
+++ b/.markdownlint.rb
@@ -1,4 +1,4 @@
 all
-rule ~'MD012'
+~rule 'MD012'
 rule 'MD013', :ignore_code_blocks => true, :line_length => 500
 rule 'MD024', :allow_different_nesting => true

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,2 +1,2 @@
 style "#{File.dirname(__FILE__)}/.markdownlint.rb"
-rules '~MD012'
+rules '~MD002', '~MD012', '~MD041'

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,2 @@
 style "#{File.dirname(__FILE__)}/.markdownlint.rb"
+rules '~MD012'

--- a/magnum_cluster_api/cmd/image_loader.py
+++ b/magnum_cluster_api/cmd/image_loader.py
@@ -9,6 +9,10 @@ from magnum_cluster_api import image_utils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
+DOMAIN = "magnum-cluster-api"
+
+logging.register_options(CONF)
+logging.setup(CONF, DOMAIN)
 
 IMAGES = [
     "docker.io/calico/cni:v3.24.2",
@@ -70,7 +74,7 @@ def main(repository):
 
     seen = []
     for image in IMAGES:
-        if IMAGES[image] in seen:
+        if image in seen:
             continue
 
         src = image

--- a/magnum_cluster_api/image_utils.py
+++ b/magnum_cluster_api/image_utils.py
@@ -1,0 +1,29 @@
+def get_image(name: str, repository: str = None):
+    """
+    Get the image name from the target registry given a full image name.
+    """
+
+    if repository is None:
+        return repository
+
+    new_image_name = name
+    if name.startswith("docker.io/calico"):
+        new_image_name = name.replace("docker.io/calico/", f"{repository}/calico-")
+    if name.startswith("docker.io/k8scloudprovider"):
+        new_image_name = name.replace("docker.io/k8scloudprovider", repository)
+    if name.startswith("k8s.gcr.io/sig-storage"):
+        new_image_name = name.replace("k8s.gcr.io/sig-storage", repository)
+    if new_image_name.startswith(f"{repository}/livenessprobe"):
+        return new_image_name.replace("livenessprobe", "csi-livenessprobe")
+    if new_image_name.startswith("k8s.gcr.io/coredns"):
+        return new_image_name.replace("k8s.gcr.io/coredns", repository)
+    if (
+        new_image_name.startswith("k8s.gcr.io/etcd")
+        or new_image_name.startswith("k8s.gcr.io/kube-")
+        or new_image_name.startswith("k8s.gcr.io/pause")
+    ):
+        return new_image_name.replace("k8s.gcr.io", repository)
+
+    assert new_image_name.startswith(repository) is True
+    return new_image_name
+

--- a/magnum_cluster_api/image_utils.py
+++ b/magnum_cluster_api/image_utils.py
@@ -26,4 +26,3 @@ def get_image(name: str, repository: str = None):
 
     assert new_image_name.startswith(repository) is True
     return new_image_name
-

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -10,8 +10,7 @@ from oslo_serialization import base64
 from oslo_utils import strutils
 from tenacity import retry, retry_if_exception_type
 
-from magnum_cluster_api import clients, objects
-from magnum_cluster_api import image_utils
+from magnum_cluster_api import clients, image_utils, objects
 
 
 def get_or_generate_cluster_api_cloud_config_secret_name(
@@ -152,7 +151,9 @@ def update_manifest_images(
                 for src, dst in replacements:
                     container["image"] = container["image"].replace(src, dst)
                 if repository:
-                    container["image"] = image_utils.get_image(container["image"], repository)
+                    container["image"] = image_utils.get_image(
+                        container["image"], repository
+                    )
 
         # Fix CCM cluster-name
         if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ click = "*"
 requests = "*"
 shortuuid = "*"
 certifi = "*"
-"oslo.log" = "^5.0.2"
-"oslo.config" = "^9.0.0"
-"oslo.concurrency" = "^5.0.1"
+"oslo.log" = "*"
+"oslo.config" = "*"
+"oslo.concurrency" = "*"
 
 [build-system]
 requires = ["setuptools", "poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ click = "*"
 requests = "*"
 shortuuid = "*"
 certifi = "*"
+"oslo.log" = "^5.0.2"
+"oslo.config" = "^9.0.0"
+"oslo.concurrency" = "^5.0.1"
 
 [build-system]
 requires = ["setuptools", "poetry-core"]


### PR DESCRIPTION
In addition, disable MD012 (Multiple consecutive blank lines) mdl lint rule.
This is annoying us against CHANGELOG.md file which is generated by release-please process.