### PR TITLE
chore: Update CAPO version to 0.7.1

### DIFF
--- a/hack/stack.sh
+++ b/hack/stack.sh
@@ -102,7 +102,7 @@ clusterctl init \
   --core cluster-api:v1.3.3 \
   --bootstrap kubeadm:v1.3.3 \
   --control-plane kubeadm:v1.3.3 \
-  --infrastructure openstack:v0.7.0
+  --infrastructure openstack:v0.7.1
 
 # Install Skopeo
 sudo curl -Lo /usr/local/bin/skopeo https://github.com/lework/skopeo-binary/releases/download/v1.10.0/skopeo-linux-amd64


### PR DESCRIPTION
includes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1493

fix https://github.com/vexxhost/magnum-cluster-api/issues/72