### PR TITLE
fix: Add missing autoscaler chart manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Cluster API driver for Magnum"
 authors = ["Mohammed Naser <mnaser@vexxhost.com>"]
 readme = "README.md"
 packages = [{include = "magnum_cluster_api"}]
+include = ["magnum_cluster_api/charts/**/*"]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Explicitly declaring charts dir in include to negate .gitignore