### PR TITLE
fix: Set the cluster status as in_progress at the end of update_nodeg…

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -285,7 +285,15 @@ class BaseDriver(driver.Driver):
     def update_nodegroup(self, context, cluster, nodegroup):
         # TODO
 
+        # NOTE(okozachenko1203): First we save the nodegroup status because update_cluster_status()
+        #                        could be finished before update_nodegroup().
+        nodegroup.save()
         resources.apply_cluster_from_magnum_cluster(context, self.k8s_api, cluster)
+        # NOTE(okozachenko1203): We set the cluster status as UPDATE_IN_PROGRESS again at the end because
+        #                        update_cluster_status() could be finished and cluster status has been set as
+        #                        UPDATE_COMPLETE before nodegroup_conductor.Handler.nodegroup_update finished.
+        cluster.status = "UPDATE_IN_PROGRESS"
+        cluster.save()
 
     def delete_nodegroup(self, context, cluster, nodegroup):
         nodegroup.status = "DELETE_IN_PROGRESS"


### PR DESCRIPTION
…roup handler

`nodegroup_conductor.Handler.nodegroup_update()` sets the cluster obj status as `UPDATE_IN_PROGRESS` and saves it immediately. But it sets the nodegroup(ng) obj status as `UPDATE_IN_PROGRESS` and saves it after `cluster_driver.update_nodegroup()` finished. https://opendev.org/openstack/magnum/src/commit/b578bd8a78d890ad32aeb6066cc22ece165f54e2/magnum/conductor/handlers/nodegroup_conductor.py#L100-L110

Once the cluster status is `*_IN_PROGRESS`, Magnum periodic ClusterUpdateJob will trigger `cluster_driver.update_cluster_status()` for that cluster.

In the driver, if update_cluster_status() has been finished before update_nodegroup(), the nodegroup status could be set as `UPDATE_IN_PROGRESS` after cluster status has been set to `UPDATE_COMPLETED`. It means update_cluster_status() is never called again which is responsible for ng status update even if ng status is not COMPLETED.

This PR saves the ng status first in the update_nodegroup handler, and sets the cluster status as in_progress again at the end to requeue the cluster in the periodic ClusterUpdateJob again.

fix: #130 