### PR TITLE
fix(mhc): increase max unhealthy to 80%

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -694,7 +694,7 @@ class ClusterClass(Base):
                             },
                         },
                         "machineHealthCheck": {
-                            "maxUnhealthy": "33%",
+                            "maxUnhealthy": "80%",
                             "unhealthyConditions": [
                                 {
                                     "type": "Ready",
@@ -737,7 +737,7 @@ class ClusterClass(Base):
                                     },
                                 },
                                 "machineHealthCheck": {
-                                    "maxUnhealthy": "33%",
+                                    "maxUnhealthy": "80%",
                                     "unhealthyConditions": [
                                         {
                                             "type": "Ready",


### PR DESCRIPTION
With a low maxUnhealthy of 33%, it is possible that a small cluster
with a single node failure will not actually trigger a failover
when in a 3 node cluster.
