### PR TITLE
feat: Support Flatcar OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-2204
+          - flatcar
         kube:
           - v1.24.16
           - v1.25.12
@@ -166,7 +169,7 @@ jobs:
         timeout-minutes: 30
         run: |
           magnum-cluster-api-image-builder \
-            --operating-system ubuntu-2204 \
+            --operating-system ${{ matrix.os }} \
             --version ${{ matrix.kube }}
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -174,14 +177,17 @@ jobs:
       - name: Upload built image
         uses: actions/upload-artifact@v3
         with:
-          name: ubuntu-2204-kube-${{ matrix.kube }}.qcow2
-          path: ubuntu-2204-kube-${{ matrix.kube }}.qcow2
+          name: ${{ matrix.os }}-kube-${{ matrix.kube }}.qcow2
+          path: ${{ matrix.os }}-kube-${{ matrix.kube }}.qcow2
 
   functional:
     runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-2204
+          - flatcar
         kube:
           - v1.24.16
           - v1.25.12
@@ -222,13 +228,14 @@ jobs:
         if: contains(github.event.pull_request.body, '/build-new-image')
         uses: actions/download-artifact@v3
         with:
-          name: ubuntu-2204-kube-${{ matrix.kube }}.qcow2
+          name: ${{ matrix.os }}-kube-${{ matrix.kube }}.qcow2
 
       - name: Run functional tests
         run: |
           ./hack/run-functional-tests.sh
         env:
           BUILD_NEW_IMAGE: "${{ contains(github.event.pull_request.body, '/build-new-image') }}"
+          OS: "${{ matrix.os }}"
           KUBE_TAG: "${{ matrix.kube }}"
           NODE_COUNT: 2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,6 +214,8 @@ jobs:
 
       - name: Install Magnum with Cluster API
         run: ./hack/stack.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup "tmate" session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,9 @@ jobs:
           - v1.25.12
           - v1.26.7
           - v1.27.4
+    concurrency:
+      group: ${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
+      cancel-in-progress: true
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
@@ -194,7 +197,7 @@ jobs:
           - v1.26.7
           - v1.27.4
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.kube }}
+      group: ${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
       cancel-in-progress: true
     steps:
       - name: Checkout project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: "build-images (${{ matrix.kube }})"
+          check-name: "build-images (${{ matrix.os }}, ${{ matrix.kube }})"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,7 @@ jobs:
           - v1.26.7
           - v1.27.4
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
+      group: build-images-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
       cancel-in-progress: true
     steps:
       - name: Checkout project
@@ -197,7 +197,7 @@ jobs:
           - v1.26.7
           - v1.27.4
     concurrency:
-      group: ${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
+      group: functional-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
       cancel-in-progress: true
     steps:
       - name: Checkout project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,12 +189,12 @@ jobs:
       fail-fast: false
       matrix:
         os_distro:
-          # - ubuntu-2204
+          - ubuntu
           - flatcar
         kube:
-          # - v1.24.16
-          # - v1.25.12
-          # - v1.26.7
+          - v1.24.16
+          - v1.25.12
+          - v1.26.7
           - v1.27.4
     concurrency:
       group: functional-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os_distro }}
@@ -217,8 +217,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup "tmate" session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup "tmate" session
+      #   uses: mxschmitt/action-tmate@v3
 
       - name: Wait for images
         if: contains(github.event.pull_request.body, '/build-new-image')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,12 +189,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-2204
+          # - ubuntu-2204
           - flatcar
         kube:
-          - v1.24.16
-          - v1.25.12
-          - v1.26.7
+          # - v1.24.16
+          # - v1.25.12
+          # - v1.26.7
           - v1.27.4
     concurrency:
       group: functional-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
@@ -215,8 +215,8 @@ jobs:
       - name: Install Magnum with Cluster API
         run: ./hack/stack.sh
 
-      # - name: Setup "tmate" session
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Setup "tmate" session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Wait for images
         if: contains(github.event.pull_request.body, '/build-new-image')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,8 +139,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-2204
+        os_distro:
+          - ubuntu
           - flatcar
         kube:
           - v1.24.16
@@ -148,7 +148,7 @@ jobs:
           - v1.26.7
           - v1.27.4
     concurrency:
-      group: build-images-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
+      group: build-images-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os_distro }}
       cancel-in-progress: true
     steps:
       - name: Checkout project
@@ -172,7 +172,7 @@ jobs:
         timeout-minutes: 30
         run: |
           magnum-cluster-api-image-builder \
-            --operating-system ${{ matrix.os }} \
+            --operating-system ${{ matrix.os_distro }} \
             --version ${{ matrix.kube }}
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -180,15 +180,15 @@ jobs:
       - name: Upload built image
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}-kube-${{ matrix.kube }}.qcow2
-          path: ${{ matrix.os }}-kube-${{ matrix.kube }}.qcow2
+          name: ${{ matrix.os_distro }}-kube-${{ matrix.kube }}.qcow2
+          path: ${{ matrix.os_distro }}-kube-${{ matrix.kube }}.qcow2
 
   functional:
     runs-on: ubuntu-latest-16-cores
     strategy:
       fail-fast: false
       matrix:
-        os:
+        os_distro:
           # - ubuntu-2204
           - flatcar
         kube:
@@ -197,7 +197,7 @@ jobs:
           # - v1.26.7
           - v1.27.4
     concurrency:
-      group: functional-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os }}
+      group: functional-${{ github.ref }}-${{ matrix.kube }}-${{ matrix.os_distro }}
       cancel-in-progress: true
     steps:
       - name: Checkout project
@@ -223,7 +223,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: "build-images (${{ matrix.os }}, ${{ matrix.kube }})"
+          check-name: "build-images (${{ matrix.os_distro }}, ${{ matrix.kube }})"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 
@@ -231,14 +231,14 @@ jobs:
         if: contains(github.event.pull_request.body, '/build-new-image')
         uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.os }}-kube-${{ matrix.kube }}.qcow2
+          name: ${{ matrix.os_distro }}-kube-${{ matrix.kube }}.qcow2
 
       - name: Run functional tests
         run: |
           ./hack/run-functional-tests.sh
         env:
           BUILD_NEW_IMAGE: "${{ contains(github.event.pull_request.body, '/build-new-image') }}"
-          OS: "${{ matrix.os }}"
+          OS_DISTRO: "${{ matrix.os_distro }}"
           KUBE_TAG: "${{ matrix.kube }}"
           NODE_COUNT: 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,11 +289,9 @@
 
 ## [0.2.0](https://github.com/vexxhost/magnum-cluster-api/compare/v0.1.2...v0.2.0) (2022-11-16)
 
-
 ### Bug Fixes
 
 * added flux + node labels ([5f04d4e](https://github.com/vexxhost/magnum-cluster-api/commit/5f04d4ed8b00ba0d45cc59edd678bdf72679b00b))
-
 
 ### Miscellaneous Chores
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ published for the latest stable release of Kubernetes.
 You can find the pre-built images for the latest stable release of Kubernetes
 at the following URL:
 
+#### Ubuntu 22.04
+
 * [v1.23.17](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.23.17.qcow2)
-* [v1.24.15](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.24.15.qcow2)
-* [v1.25.11](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.25.11.qcow2)
-* [v1.26.6](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.26.6.qcow2)
-* [v1.27.3](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.27.3.qcow2)
+* [v1.24.16](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.24.16.qcow2)
+* [v1.25.12](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.25.12.qcow2)
+* [v1.26.7](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.26.7.qcow2)
+* [v1.27.4](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.27.4.qcow2)
 
 ### Building images
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ at the following URL:
 * [v1.26.7](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.26.7.qcow2)
 * [v1.27.4](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.27.4.qcow2)
 
+#### Flatcar
+
+* [v1.24.16](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/flatcar-kube-v1.24.16.qcow2)
+* [v1.25.12](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/flatcar-kube-v1.25.12.qcow2)
+* [v1.26.7](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/flatcar-kube-v1.26.7.qcow2)
+* [v1.27.4](https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/flatcar-kube-v1.27.4.qcow2)
+
 ### Building images
 
 The Cluster API driver for Magnum provides a tool in order to build images, you

--- a/README.md
+++ b/README.md
@@ -43,52 +43,5 @@ magnum-cluster-api-image-builder
 
 ## Testing & Development
 
-In order to be able to test and develop the `magnum-cluster-api` project, you
-will need to have an existing Magnum deployment.  You can use the following
-steps to be able to test and develop the project.
-
-1. Start up a DevStack environment with all Cluster API dependencies
-
-   ```bash
-   ./hack/stack.sh
-   ```
-
-1. Upload an image to use with Magnum and create cluster templates
-
-   ```bash
-   pushd /tmp
-   source /opt/stack/openrc
-   for version in v1.23.17 v1.24.15 v1.25.11 v1.26.6 v1.27.3; do \
-      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-${version}.qcow2; \
-      openstack image create ubuntu-2204-kube-${version} --disk-format=qcow2 --container-format=bare --property os_distro=ubuntu --file=ubuntu-2204-kube-${version}.qcow2; \
-      openstack coe cluster template create \
-         --image $(openstack image show ubuntu-2204-kube-${version} -c id -f value) \
-         --external-network public \
-         --dns-nameserver 8.8.8.8 \
-         --master-lb-enabled \
-         --master-flavor m1.medium \
-         --flavor m1.medium \
-         --network-driver calico \
-         --docker-storage-driver overlay2 \
-         --coe kubernetes \
-         --label kube_tag=${version} \
-         k8s-${version};
-   done;
-   popd
-   ```
-
-1. Spin up a new cluster using the Cluster API driver
-
-   ```bash
-   openstack coe cluster create \
-     --cluster-template k8s-v1.25.11 \
-     --master-count 3 \
-     --node-count 2 \
-     k8s-v1.25.11
-   ```
-
-1. Once the cluster reaches `CREATE_COMPLETE` state, you can interact with it:
-
-   ```bash
-   eval $(openstack coe cluster config k8s-v1.25.11)
-   ```
+For more information on how to test, develop and contribute to the Cluster API
+driver for Magnum, refer to the [developer guide](https://vexxhost.github.io/magnum-cluster-api/developer/testing-and-development/).

--- a/docs/developer/testing-and-development.md
+++ b/docs/developer/testing-and-development.md
@@ -15,7 +15,7 @@ steps to be able to test and develop the project.
    ```bash
    pushd /tmp
    source /opt/stack/openrc
-   for version in v1.23.17 v1.24.15 v1.25.11 v1.26.6 v1.27.3; do \
+   for version in v1.24.16 v1.25.12 v1.26.7 v1.27.4; do \
       curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-${version}.qcow2; \
       openstack image create ubuntu-2204-kube-${version} --disk-format=qcow2 --container-format=bare --property os_distro=ubuntu --file=ubuntu-2204-kube-${version}.qcow2; \
       openstack coe cluster template create \

--- a/docs/developer/testing-and-development.md
+++ b/docs/developer/testing-and-development.md
@@ -15,12 +15,14 @@ steps to be able to test and develop the project.
    ```bash
    pushd /tmp
    source /opt/stack/openrc
+   export OS_DISTRO=ubuntu # you can change this to "flatcar" if you want to use Flatcar
    for version in v1.24.16 v1.25.12 v1.26.7 v1.27.4; do \
-      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-${version}.qcow2; \
-      openstack image create ubuntu-2204-kube-${version} --disk-format=qcow2 --container-format=bare --property os_distro=ubuntu --file=ubuntu-2204-kube-${version}.qcow2; \
+      [[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${version}" || IMAGE_NAME="flatcar-kube-${version}"; \
+      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${IMAGE_NAME}.qcow2; \
+      openstack image create ${IMAGE_NAME} --disk-format=qcow2 --container-format=bare --property os_distro=${OS_DISTRO} --file=${IMAGE_NAME}.qcow2; \
       openstack coe cluster template create \
-         --image $(openstack image show ubuntu-2204-kube-${version} -c id -f value) \
-         --external-network public \
+        --image $(openstack image show ${IMAGE_NAME} -c id -f value) \
+        --external-network public \
          --dns-nameserver 8.8.8.8 \
          --master-lb-enabled \
          --master-flavor m1.medium \
@@ -29,7 +31,7 @@ steps to be able to test and develop the project.
          --docker-storage-driver overlay2 \
          --coe kubernetes \
          --label kube_tag=${version} \
-         k8s-${version};
+       d   k8s-${version};
    done;
    popd
    ```

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -96,13 +96,13 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     to launch a cluster, the first of which are related to it's basic
     configuration, the required fields are:
 
-    * **Cluster Name**
+    * **Cluster Name**  
       The name of the cluster that will be created.
 
-    * **Cluster Template**
+    * **Cluster Template**  
       The cluster template that will be used to create the cluster.
 
-    * **Keypair**
+    * **Keypair**  
       The SSH key pair that will be used to access the cluster.
 
     In this example, we're going to create a cluster with the name of
@@ -114,22 +114,22 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     The next step is deciding on the size of the cluster and selecting if auto
     scaling will be enabled for the cluster.  The required fields are:
 
-    * **Number of Master Nodes**
+    * **Number of Master Nodes**  
       The number of master nodes that will be created in the cluster.
 
-    * **Flavor of Master Nodes**
+    * **Flavor of Master Nodes**  
       The flavor of the master nodes that will be created in the cluster.
 
-    * **Number of Worker Nodes**
+    * **Number of Worker Nodes**  
       The number of worker nodes that will be created in the cluster.
 
-    * **Flavor of Worker Nodes**
+    * **Flavor of Worker Nodes**  
       The flavor of the worker nodes that will be created in the cluster.
 
     In addition, if you want to enable auto scaling, you will need to provide the
     following information:
 
-    * **Auto-scale Worker Nodes**
+    * **Auto-scale Worker Nodes**  
       Whether or not to enable auto scaling for the worker nodes.
 
     * **Minimum Number of Worker Nodes**
@@ -162,7 +162,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
       if you want to attach the cluster to an existing network with other
       resources.
 
-    * **Cluster API**
+    * **Cluster API**  
       This setting controls if the API will get a floating IP address assigned
       to it.  You can set this to _Accessible on private network only_ if you
       are using an existing network and don't want to expose the API to the
@@ -179,7 +179,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     the cluster which automatically detects nodes that are unhealthy and
     replaces them with new nodes.  The required fields are:
 
-    * **Automatically Repair Unhealthy Nodes**
+    * **Automatically Repair Unhealthy Nodes**  
       Whether or not to enable auto-healing for the cluster.
 
     In this example, we're going to enable auto-healing for the cluster since it

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -47,7 +47,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     them using the OpenStack CLI:
 
     ```bash
-    for version in v1.23.17 v1.24.15 v1.25.11 v1.26.6 v1.27.3; do \
+    for version in v1.24.16 v1.25.12 v1.26.7 v1.27.4; do \
       curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-${version}.qcow2; \
       openstack image create ubuntu-2204-kube-${version} --disk-format=qcow2 --container-format=bare --property os_distro=ubuntu --file=ubuntu-2204-kube-${version}.qcow2; \
       openstack coe cluster template create \
@@ -96,13 +96,13 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     to launch a cluster, the first of which are related to it's basic
     configuration, the required fields are:
 
-    * **Cluster Name**  
+    * **Cluster Name**
       The name of the cluster that will be created.
 
-    * **Cluster Template**  
+    * **Cluster Template**
       The cluster template that will be used to create the cluster.
 
-    * **Keypair**  
+    * **Keypair**
       The SSH key pair that will be used to access the cluster.
 
     In this example, we're going to create a cluster with the name of
@@ -114,22 +114,22 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     The next step is deciding on the size of the cluster and selecting if auto
     scaling will be enabled for the cluster.  The required fields are:
 
-    * **Number of Master Nodes**  
+    * **Number of Master Nodes**
       The number of master nodes that will be created in the cluster.
 
-    * **Flavor of Master Nodes**  
+    * **Flavor of Master Nodes**
       The flavor of the master nodes that will be created in the cluster.
 
-    * **Number of Worker Nodes**  
+    * **Number of Worker Nodes**
       The number of worker nodes that will be created in the cluster.
 
-    * **Flavor of Worker Nodes**  
+    * **Flavor of Worker Nodes**
       The flavor of the worker nodes that will be created in the cluster.
 
     In addition, if you want to enable auto scaling, you will need to provide the
     following information:
 
-    * **Auto-scale Worker Nodes**  
+    * **Auto-scale Worker Nodes**
       Whether or not to enable auto scaling for the worker nodes.
 
     * **Minimum Number of Worker Nodes**
@@ -152,7 +152,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     The next step is managing the network configuration of the cluster.  The
     required fields are:
 
-    * **Enable Load Balancer for Master Nodes**  
+    * **Enable Load Balancer for Master Nodes**
       This is required to be **enabled** for the Cluster API driver for Magnum
       to work properly.
 
@@ -162,7 +162,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
       if you want to attach the cluster to an existing network with other
       resources.
 
-    * **Cluster API**  
+    * **Cluster API**
       This setting controls if the API will get a floating IP address assigned
       to it.  You can set this to _Accessible on private network only_ if you
       are using an existing network and don't want to expose the API to the
@@ -179,7 +179,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     the cluster which automatically detects nodes that are unhealthy and
     replaces them with new nodes.  The required fields are:
 
-    * **Automatically Repair Unhealthy Nodes**  
+    * **Automatically Repair Unhealthy Nodes**
       Whether or not to enable auto-healing for the cluster.
 
     In this example, we're going to enable auto-healing for the cluster since it

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -47,11 +47,13 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     them using the OpenStack CLI:
 
     ```bash
+    export OS_DISTRO=ubuntu # you can change this to "flatcar" if you want to use Flatcar
     for version in v1.24.16 v1.25.12 v1.26.7 v1.27.4; do \
-      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-${version}.qcow2; \
-      openstack image create ubuntu-2204-kube-${version} --disk-format=qcow2 --container-format=bare --property os_distro=ubuntu --file=ubuntu-2204-kube-${version}.qcow2; \
+      [[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${version}" || IMAGE_NAME="flatcar-kube-${version}"; \
+      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${IMAGE_NAME}.qcow2; \
+      openstack image create ${IMAGE_NAME} --disk-format=qcow2 --container-format=bare --property os_distro=${OS_DISTRO} --file=${IMAGE_NAME}.qcow2; \
       openstack coe cluster template create \
-          --image $(openstack image show ubuntu-2204-kube-${version} -c id -f value) \
+          --image $(openstack image show ${IMAGE_NAME} -c id -f value) \
           --external-network public \
           --dns-nameserver 8.8.8.8 \
           --master-lb-enabled \

--- a/hack/run-functional-tests.sh
+++ b/hack/run-functional-tests.sh
@@ -27,7 +27,7 @@ SONOBUOY_ARCH=${SONOBUOY_ARCH:-amd64}
 DNS_NAMESERVER=${DNS_NAMESERVER:-1.1.1.1}
 
 # Determine image name
-[[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${version}" || IMAGE_NAME="flatcar-kube-${version}";
+[[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${KUBE_TAG}" || IMAGE_NAME="flatcar-kube-${KUBE_TAG}";
 
 # If running inside GitHub Actions, use Azure's "168.63.129.16" for DNS
 if [[ -n "${GITHUB_ACTIONS}" ]]; then

--- a/hack/run-functional-tests.sh
+++ b/hack/run-functional-tests.sh
@@ -20,11 +20,14 @@
 
 source /opt/stack/openrc
 
-OS=${OS:-ubuntu-2204}
+OS_DISTRO=${OS_DISTRO:-ubuntu}
 NODE_COUNT=${NODE_COUNT:-2}
 SONOBUOY_VERSION=${SONOBUOY_VERSION:-0.56.16}
 SONOBUOY_ARCH=${SONOBUOY_ARCH:-amd64}
 DNS_NAMESERVER=${DNS_NAMESERVER:-1.1.1.1}
+
+# Determine image name
+[[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${version}" || IMAGE_NAME="flatcar-kube-${version}";
 
 # If running inside GitHub Actions, use Azure's "168.63.129.16" for DNS
 if [[ -n "${GITHUB_ACTIONS}" ]]; then
@@ -34,15 +37,14 @@ fi
 # If `BUILD_NEW_IMAGE` is true, then we use the provided artifact, otherwise
 # we download the latest promoted image.
 if [[ "${BUILD_NEW_IMAGE}" != "true" ]]; then
-  curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${OS}-kube-${KUBE_TAG}.qcow2
+  curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${IMAGE_NAME}.qcow2
 fi
 
 # Upload image to Glance
-IMAGE_NAME=${OS}-kube-${KUBE_TAG}
 openstack image create \
   --disk-format=qcow2 \
   --container-format=bare \
-  --property os_distro=ubuntu \
+  --property os_distro=${OS_DISTRO} \
   --file=${IMAGE_NAME}.qcow2 \
   ${IMAGE_NAME}
 

--- a/hack/run-functional-tests.sh
+++ b/hack/run-functional-tests.sh
@@ -20,6 +20,7 @@
 
 source /opt/stack/openrc
 
+OS=${OS:-ubuntu-2204}
 NODE_COUNT=${NODE_COUNT:-2}
 SONOBUOY_VERSION=${SONOBUOY_VERSION:-0.56.16}
 SONOBUOY_ARCH=${SONOBUOY_ARCH:-amd64}
@@ -33,11 +34,11 @@ fi
 # If `BUILD_NEW_IMAGE` is true, then we use the provided artifact, otherwise
 # we download the latest promoted image.
 if [[ "${BUILD_NEW_IMAGE}" != "true" ]]; then
-  curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-${KUBE_TAG}.qcow2
+  curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${OS}-kube-${KUBE_TAG}.qcow2
 fi
 
 # Upload image to Glance
-IMAGE_NAME=ubuntu-2204-kube-${KUBE_TAG}
+IMAGE_NAME=${OS}-kube-${KUBE_TAG}
 openstack image create \
   --disk-format=qcow2 \
   --container-format=bare \

--- a/hack/stack.sh
+++ b/hack/stack.sh
@@ -131,6 +131,7 @@ sudo chmod +x /usr/local/bin/clusterctl
 
 # Initialize the `clusterctl` CLI
 export EXP_CLUSTER_RESOURCE_SET=true
+export EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true #Used by the kubeadm bootstrap provider
 export CLUSTER_TOPOLOGY=true
 clusterctl init \
   --core cluster-api:${CAPI_VERSION} \

--- a/magnum_cluster_api/cmd/image_builder.py
+++ b/magnum_cluster_api/cmd/image_builder.py
@@ -56,7 +56,7 @@ def validate_version(_, __, value):
 @click.option(
     "--image-builder-version",
     show_default=True,
-    default="bab3d4d",
+    default="v0.1.19",
     help="Image builder tag (or commit) to use for building image",
 )
 def main(operating_system, version, image_builder_version):

--- a/magnum_cluster_api/cmd/image_builder.py
+++ b/magnum_cluster_api/cmd/image_builder.py
@@ -68,7 +68,8 @@ def main(ctx: click.Context, operating_system, version, image_builder_version):
     # at all
     for root, dirs, files in os.walk(output_path):
         if files:
-            message = "There are files in the output directory which will cause the build to fail.  Please remove them before continuing.\n"
+            message = "There are files in the output directory which will cause the build to fail. " \
+                      "Please remove them before continuing.\n"
             for file in files:
                 message += f"- {root}/{file}\n"
 
@@ -118,7 +119,7 @@ def main(ctx: click.Context, operating_system, version, image_builder_version):
     click.echo("- Create customization file")
     kubernetes_series = ".".join(version.split(".")[0:2])
     customization = {
-        "kubernetes_deb_version": f"{version.replace('v', '')}-00",
+        "kubernetes_deb_version": f"{version.replace('v', '')}-1.1",
         "kubernetes_semver": f"{version}",
         "kubernetes_series": f"{kubernetes_series}",
         # https://github.com/flatcar/Flatcar/issues/823

--- a/magnum_cluster_api/cmd/image_builder.py
+++ b/magnum_cluster_api/cmd/image_builder.py
@@ -42,8 +42,9 @@ def validate_version(_, __, value):
     "--operating-system",
     show_default=True,
     default="ubuntu-2204",
-    type=click.Choice(["ubuntu-2004", "ubuntu-2204"]),
+    type=click.Choice(["ubuntu-2004", "ubuntu-2204", "flatcar"]),
     help="Operating system to build image for",
+    prompt="Operating system to build image for",
 )
 @click.option(
     "--version",

--- a/magnum_cluster_api/cmd/image_builder.py
+++ b/magnum_cluster_api/cmd/image_builder.py
@@ -68,8 +68,10 @@ def main(ctx: click.Context, operating_system, version, image_builder_version):
     # at all
     for root, dirs, files in os.walk(output_path):
         if files:
-            message = "There are files in the output directory which will cause the build to fail. " \
-                      "Please remove them before continuing.\n"
+            message = (
+                "There are files in the output directory which will cause the build to fail. "
+                "Please remove them before continuing.\n"
+            )
             for file in files:
                 message += f"- {root}/{file}\n"
 

--- a/magnum_cluster_api/cmd/image_builder.py
+++ b/magnum_cluster_api/cmd/image_builder.py
@@ -114,6 +114,8 @@ def main(operating_system, version, image_builder_version):
         "kubernetes_deb_version": f"{version.replace('v', '')}-00",
         "kubernetes_semver": f"{version}",
         "kubernetes_series": f"{kubernetes_series}",
+        # https://github.com/flatcar/Flatcar/issues/823
+        "ansible_user_vars": "oem_id=openstack",
     }
 
     # NOTE(mnaser): We use the latest tested daily ISO for Ubuntu 22.04 in order

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -386,3 +386,11 @@ class UbuntuFocalDriver(UbuntuDriver):
         return [
             {"server_type": "vm", "os": "ubuntu-focal", "coe": "kubernetes"},
         ]
+
+
+class FlatcarDriver(BaseDriver):
+    @property
+    def provides(self):
+        return [
+            {"server_type": "vm", "os": "flatcar", "coe": "kubernetes"},
+        ]

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -410,10 +410,13 @@ class CertificateAuthoritySecret(ClusterBase):
             {
                 "apiVersion": pykube.Secret.version,
                 "kind": pykube.Secret.kind,
-                "type": "kubernetes.io/tls",
+                "type": "cluster.x-k8s.io/secret",
                 "metadata": {
                     "name": f"{self.cluster.stack_id}-{self.CERT}",
                     "namespace": "magnum-system",
+                    "labels": {
+                        "cluster.x-k8s.io/cluster-name": f"{self.cluster.stack_id}",
+                    },
                 },
                 "stringData": {
                     "tls.crt": encodeutils.safe_decode(ca_cert.get_certificate()),

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -543,19 +543,6 @@ class KubeadmControlPlaneTemplate(Base):
                     "template": {
                         "spec": {
                             "kubeadmConfigSpec": {
-                                "format": "ignition",
-                                "ignition": {
-                                    "containerLinuxConfig": {
-                                        "additionalConfig": "storage:\n  links:\n  - path: /etc/systemd/system/kubeadm.service.wants/containerd.service\n    target: /usr/lib/systemd/system/containerd.service\n"
-                                    },
-                                },
-                                # In Flatcar kubeadm configuration is in different directory because /run
-                                # can't be provisioned with ignition.
-                                "preKubeadmCommands": [
-                                    """
-                                    bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
-                                    """
-                                ],
                                 "clusterConfiguration": {
                                     "apiServer": {
                                         "extraArgs": {
@@ -586,7 +573,7 @@ class KubeadmControlPlaneTemplate(Base):
                                 ],
                                 "initConfiguration": {
                                     "nodeRegistration": {
-                                        "name": "__REPLACE_NODE_NAME__",
+                                        "name": "{{ local_hostname }}",
                                         "kubeletExtraArgs": {
                                             "cloud-provider": "external",
                                         },
@@ -594,7 +581,7 @@ class KubeadmControlPlaneTemplate(Base):
                                 },
                                 "joinConfiguration": {
                                     "nodeRegistration": {
-                                        "name": "__REPLACE_NODE_NAME__",
+                                        "name": "{{ local_hostname }}",
                                         "kubeletExtraArgs": {
                                             "cloud-provider": "external",
                                         },
@@ -622,23 +609,10 @@ class KubeadmConfigTemplate(Base):
                 "spec": {
                     "template": {
                         "spec": {
-                            "format": "ignition",
-                            "ignition": {
-                                "containerLinuxConfig": {
-                                    "additionalConfig": "storage:\n  links:\n  - path: /etc/systemd/system/kubeadm.service.wants/containerd.service\n    target: /usr/lib/systemd/system/containerd.service\n"
-                                },
-                            },
                             "files": [],
-                            # In Flatcar kubeadm configuration is in different directory because /run
-                            # can't be provisioned with ignition.
-                            "preKubeadmCommands": [
-                                """
-                                bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
-                                """
-                            ],
                             "joinConfiguration": {
                                 "nodeRegistration": {
-                                    "name": "__REPLACE_NODE_NAME__",
+                                    "name": "{{ local_hostname }}",
                                     "kubeletExtraArgs": {
                                         "cloud-provider": "external",
                                     },
@@ -1026,6 +1000,17 @@ class ClusterClass(Base):
                                 },
                             },
                         },
+                        {
+                            "name": "operatingSystem",
+                            "required": True,
+                            "schema": {
+                                "openAPIV3Schema": {
+                                    "type": "string",
+                                    "enum": utils.AVAILABLE_OPERATING_SYSTEMS,
+                                    "default": "ubuntu",
+                                },
+                            },
+                        },
                     ],
                     "patches": [
                         {
@@ -1181,6 +1166,93 @@ class ClusterClass(Base):
                                         },
                                     ],
                                 }
+                            ],
+                        },
+                        {
+                            "name": "flatcar",
+                            "enabledIf": '{{ if eq .operatingSystem "flatcar" }}true{{end}}',
+                            "definitions": [
+                                {
+                                    "selector": {
+                                        "apiVersion": objects.KubeadmControlPlaneTemplate.version,
+                                        "kind": objects.KubeadmControlPlaneTemplate.kind,
+                                        "matchResources": {
+                                            "controlPlane": True,
+                                        },
+                                    },
+                                    "jsonPatches": [
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/format",
+                                            "value": "ignition",
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/ignition",
+                                            "value": {
+                                                "containerLinuxConfig": {
+                                                    "additionalConfig": textwrap.dedent(
+                                                        """\
+                                                        storage:
+                                                          links:
+                                                          - path: /etc/systemd/system/kubeadm.service.wants/containerd.service
+                                                            target: /usr/lib/systemd/system/containerd.service
+                                                        """  # noqa: E501
+                                                    ),
+                                                },
+                                            },
+                                        },
+                                        {
+                                            "op": "replace",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/name",  # noqa: E501
+                                            "value": "${COREOS_OPENSTACK_HOSTNAME}",
+                                        },
+                                        {
+                                            "op": "replace",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/name",  # noqa: E501
+                                            "value": "${COREOS_OPENSTACK_HOSTNAME}",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "selector": {
+                                        "apiVersion": objects.KubeadmConfigTemplate.version,
+                                        "kind": objects.KubeadmConfigTemplate.kind,
+                                        "matchResources": {
+                                            "machineDeploymentClass": {
+                                                "names": ["default-worker"],
+                                            }
+                                        },
+                                    },
+                                    "jsonPatches": [
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/format",
+                                            "value": "ignition",
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/ignition",
+                                            "value": {
+                                                "containerLinuxConfig": {
+                                                    "additionalConfig": textwrap.dedent(
+                                                        """\
+                                                        storage:
+                                                          links:
+                                                          - path: /etc/systemd/system/kubeadm.service.wants/containerd.service
+                                                            target: /usr/lib/systemd/system/containerd.service
+                                                        """  # noqa: E501
+                                                    ),
+                                                },
+                                            },
+                                        },
+                                        {
+                                            "op": "replace",
+                                            "path": "/spec/template/spec/joinConfiguration/nodeRegistration/name",
+                                            "value": "${COREOS_OPENSTACK_HOSTNAME}",
+                                        },
+                                    ],
+                                },
                             ],
                         },
                         {
@@ -1856,6 +1928,10 @@ class Cluster(ClusterBase):
                             {
                                 "name": "sshKeyName",
                                 "value": self.cluster.keypair or "",
+                            },
+                            {
+                                "name": "operatingSystem",
+                                "value": utils.get_operating_system(self.cluster),
                             },
                         ],
                     },

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1215,6 +1215,19 @@ class ClusterClass(Base):
                                                             target: /etc/systemd/system/kubeadm.service
                                                         systemd:
                                                           units:
+                                                          - name: coreos-metadata.service
+                                                            dropins:
+                                                            - name: 20-clct-provider-override.conf
+                                                              contents: |
+                                                                [Service]
+                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
+                                                          - name: coreos-metadata-sshkeys@.service
+                                                            enabled: true
+                                                            dropins:
+                                                            - name: 20-clct-provider-override.conf
+                                                              contents: |
+                                                                [Service]
+                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
                                                           - name: kubeadm.service
                                                             dropins:
                                                             - name: 10-flatcar.conf
@@ -1290,6 +1303,19 @@ class ClusterClass(Base):
                                                             target: /etc/systemd/system/kubeadm.service
                                                         systemd:
                                                           units:
+                                                          - name: coreos-metadata.service
+                                                            dropins:
+                                                            - name: 20-clct-provider-override.conf
+                                                              contents: |
+                                                                [Service]
+                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
+                                                          - name: coreos-metadata-sshkeys@.service
+                                                            enabled: true
+                                                            dropins:
+                                                            - name: 20-clct-provider-override.conf
+                                                              contents: |
+                                                                [Service]
+                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
                                                           - name: kubeadm.service
                                                             dropins:
                                                             - name: 10-flatcar.conf

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1193,7 +1193,7 @@ class ClusterClass(Base):
                                             ],
                                         },
                                         {
-                                            "op": "add",
+                                            "op": "replace",
                                             "path": "/spec/template/spec/kubeadmConfigSpec/format",
                                             "value": "ignition",
                                         },
@@ -1204,43 +1204,20 @@ class ClusterClass(Base):
                                                 "containerLinuxConfig": {
                                                     "additionalConfig": textwrap.dedent(
                                                         """\
-                                                        storage:
-                                                          links:
-                                                          # For some reason enabling services via systemd.units doesn't work on Flatcar.
-                                                          - path: /etc/systemd/system/kubeadm.service.wants/containerd.service
-                                                            target: /usr/lib/systemd/system/containerd.service
-                                                          - path: /etc/systemd/system/multi-user.target.wants/coreos-metadata.service
-                                                            target: /usr/lib/systemd/system/coreos-metadata.service
-                                                          - path: /etc/systemd/system/multi-user.target.wants/kubeadm.service
-                                                            target: /etc/systemd/system/kubeadm.service
                                                         systemd:
                                                           units:
-                                                          - name: coreos-metadata.service
-                                                            dropins:
-                                                            - name: 20-clct-provider-override.conf
-                                                              contents: |
-                                                                [Service]
-                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
                                                           - name: coreos-metadata-sshkeys@.service
                                                             enabled: true
-                                                            dropins:
-                                                            - name: 20-clct-provider-override.conf
-                                                              contents: |
-                                                                [Service]
-                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
                                                           - name: kubeadm.service
+                                                            enabled: true
                                                             dropins:
                                                             - name: 10-flatcar.conf
                                                               contents: |
                                                                 [Unit]
-                                                                # kubeadm must run after coreos-metadata populated /run/metadata directory.
-                                                                Requires=coreos-metadata.service
-                                                                After=coreos-metadata.service
+                                                                Requires=containerd.service coreos-metadata.service
+                                                                After=containerd.service coreos-metadata.service
                                                                 [Service]
-                                                                # Ensure kubeadm service has access to kubeadm binary in /opt/bin on Flatcar.
-                                                                Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin
-                                                                # To make metadata environment variables available for pre-kubeadm commands.
-                                                                EnvironmentFile=/run/metadata/*
+                                                                EnvironmentFile=/run/metadata/flatcar
                                                         """  # noqa: E501
                                                     ),
                                                 },
@@ -1292,44 +1269,20 @@ class ClusterClass(Base):
                                                 "containerLinuxConfig": {
                                                     "additionalConfig": textwrap.dedent(
                                                         """\
-                                                        storage:
-                                                          links:
-                                                          # For some reason enabling services via systemd.units doesn't work on Flatcar.
-                                                          - path: /etc/systemd/system/kubeadm.service.wants/containerd.service
-                                                            target: /usr/lib/systemd/system/containerd.service
-                                                          - path: /etc/systemd/system/multi-user.target.wants/coreos-metadata.service
-                                                            target: /usr/lib/systemd/system/coreos-metadata.service
-                                                          - path: /etc/systemd/system/multi-user.target.wants/kubeadm.service
-                                                            target: /etc/systemd/system/kubeadm.service
                                                         systemd:
                                                           units:
-                                                          - name: coreos-metadata.service
-                                                            dropins:
-                                                            - name: 20-clct-provider-override.conf
-                                                              contents: |
-                                                                [Service]
-                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
                                                           - name: coreos-metadata-sshkeys@.service
                                                             enabled: true
-                                                            dropins:
-                                                            - name: 20-clct-provider-override.conf
-                                                              contents: |
-                                                                [Service]
-                                                                Environment=COREOS_METADATA_OPT_PROVIDER=--provider=openstack-metadata
                                                           - name: kubeadm.service
+                                                            enabled: true
                                                             dropins:
                                                             - name: 10-flatcar.conf
                                                               contents: |
                                                                 [Unit]
-                                                                # kubeadm must run after coreos-metadata populated /run/metadata directory.
-                                                                Requires=coreos-metadata.service
-                                                                After=coreos-metadata.service
+                                                                Requires=containerd.service coreos-metadata.service
+                                                                After=containerd.service coreos-metadata.service
                                                                 [Service]
-                                                                # In Flatcar /usr is immutable, so image-builder puts the binaries in /opt/bin instead.
-                                                                # Ensure kubeadm service has access to kubeadm binary in /opt/bin on Flatcar.
-                                                                Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin
-                                                                # To make metadata environment variables available for pre-kubeadm commands.
-                                                                EnvironmentFile=/run/metadata/*
+                                                                EnvironmentFile=/run/metadata/flatcar
                                                         """  # noqa: E501
                                                     ),
                                                 },

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -543,6 +543,19 @@ class KubeadmControlPlaneTemplate(Base):
                     "template": {
                         "spec": {
                             "kubeadmConfigSpec": {
+                                "format": "ignition",
+                                "ignition": {
+                                    "containerLinuxConfig": {
+                                        "additionalConfig": "storage:\n  links:\n  - path: /etc/systemd/system/kubeadm.service.wants/containerd.service\n    target: /usr/lib/systemd/system/containerd.service\n"
+                                    },
+                                },
+                                # In Flatcar kubeadm configuration is in different directory because /run
+                                # can't be provisioned with ignition.
+                                "preKubeadmCommands": [
+                                    """
+                                    bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
+                                    """
+                                ],
                                 "clusterConfiguration": {
                                     "apiServer": {
                                         "extraArgs": {
@@ -573,7 +586,7 @@ class KubeadmControlPlaneTemplate(Base):
                                 ],
                                 "initConfiguration": {
                                     "nodeRegistration": {
-                                        "name": "{{ local_hostname }}",
+                                        "name": "__REPLACE_NODE_NAME__",
                                         "kubeletExtraArgs": {
                                             "cloud-provider": "external",
                                         },
@@ -581,7 +594,7 @@ class KubeadmControlPlaneTemplate(Base):
                                 },
                                 "joinConfiguration": {
                                     "nodeRegistration": {
-                                        "name": "{{ local_hostname }}",
+                                        "name": "__REPLACE_NODE_NAME__",
                                         "kubeletExtraArgs": {
                                             "cloud-provider": "external",
                                         },
@@ -609,17 +622,30 @@ class KubeadmConfigTemplate(Base):
                 "spec": {
                     "template": {
                         "spec": {
+                            "format": "ignition",
+                            "ignition": {
+                                "containerLinuxConfig": {
+                                    "additionalConfig": "storage:\n  links:\n  - path: /etc/systemd/system/kubeadm.service.wants/containerd.service\n    target: /usr/lib/systemd/system/containerd.service\n"
+                                },
+                            },
                             "files": [],
+                            # In Flatcar kubeadm configuration is in different directory because /run
+                            # can't be provisioned with ignition.
+                            "preKubeadmCommands": [
+                                """
+                                bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
+                                """
+                            ],
                             "joinConfiguration": {
                                 "nodeRegistration": {
-                                    "name": "{{ local_hostname }}",
+                                    "name": "__REPLACE_NODE_NAME__",
                                     "kubeletExtraArgs": {
                                         "cloud-provider": "external",
                                     },
                                 },
                             },
-                        }
-                    }
+                        },
+                    },
                 },
             },
         )

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -32,8 +32,10 @@ from magnum_cluster_api import image_utils, images, objects
 
 AVAILABLE_OPERATING_SYSTEMS = ["ubuntu", "flatcar"]
 
+
 def get_cluster_api_cloud_config_secret_name(cluster: magnum_objects.Cluster) -> str:
     return f"{cluster.stack_id}-cloud-config"
+
 
 def get_or_generate_cluster_api_cloud_config_secret_name(
     api: pykube.HTTPClient, cluster: magnum_objects.Cluster
@@ -316,6 +318,8 @@ def validate_nodegroup(
     # Validate flavors
     osc = clients.get_openstack_api(ctx)
     validate_flavor_name(osc, nodegroup.flavor_id)
+
+
 def get_operating_system(cluster: magnum_objects.Cluster):
     cluster_distro = cluster.cluster_template.cluster_distro
     for ops in AVAILABLE_OPERATING_SYSTEMS:

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -30,9 +30,24 @@ from magnum_cluster_api import clients
 from magnum_cluster_api import exceptions as mcapi_exceptions
 from magnum_cluster_api import image_utils, images, objects
 
+AVAILABLE_OPERATING_SYSTEMS = ["ubuntu", "flatcar"]
 
 def get_cluster_api_cloud_config_secret_name(cluster: magnum_objects.Cluster) -> str:
     return f"{cluster.stack_id}-cloud-config"
+
+def get_or_generate_cluster_api_cloud_config_secret_name(
+    api: pykube.HTTPClient, cluster: magnum_objects.Cluster
+) -> str:
+    return f"{get_or_generate_cluster_api_name(api, cluster)}-cloud-config"
+
+
+def get_or_generate_cluster_api_name(
+    api: pykube.HTTPClient, cluster: magnum_objects.Cluster
+) -> str:
+    if cluster.stack_id is None:
+        cluster.stack_id = generate_cluster_api_name(api, cluster)
+        cluster.save()
+    return cluster.stack_id
 
 
 @retry(retry=retry_if_exception_type(exception.Conflict))
@@ -301,3 +316,9 @@ def validate_nodegroup(
     # Validate flavors
     osc = clients.get_openstack_api(ctx)
     validate_flavor_name(osc, nodegroup.flavor_id)
+def get_operating_system(cluster: magnum_objects.Cluster):
+    cluster_distro = cluster.cluster_template.cluster_distro
+    for ops in AVAILABLE_OPERATING_SYSTEMS:
+        if cluster_distro.startswith(ops):
+            return ops
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ magnum-cluster-api-proxy = "magnum_cluster_api.cmd.proxy:main"
 [tool.poetry.plugins."magnum.drivers"]
 "k8s_cluster_api_ubuntu" = "magnum_cluster_api.driver:UbuntuDriver"
 "k8s_cluster_api_ubuntu_focal" = "magnum_cluster_api.driver:UbuntuFocalDriver"
+"k8s_cluster_api_flatcar" = "magnum_cluster_api.driver:FlatcarDriver"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Based on: https://github.com/vexxhost/magnum-cluster-api/pull/44

Adapted the aforementioned PR to contain the right ignition config and also modified the secret type used for the CA cert secret.

CAPI expects a CA secret of type "cluster.x-k8s.io/secret" instead of "kubernetes.io/tls". Also, the "cluster.x-k8s.io/cluster-name" label has been added for the secret resource, containing the cluster's stack id.