### PR TITLE
fix: Missed context argument in resources.CloudConfigSecret.delete() call

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -158,7 +158,8 @@ class BaseDriver(driver.Driver):
             except keystoneauth1.exceptions.http.NotFound:
                 pass
 
-            resources.CloudConfigSecret(self.k8s_api, cluster).delete()
+            resources.CloudConfigSecret(
+                context, self.k8s_api, cluster).delete()
             resources.ApiCertificateAuthoritySecret(
                 context, self.k8s_api, cluster
             ).delete()

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -158,8 +158,7 @@ class BaseDriver(driver.Driver):
             except keystoneauth1.exceptions.http.NotFound:
                 pass
 
-            resources.CloudConfigSecret(
-                context, self.k8s_api, cluster).delete()
+            resources.CloudConfigSecret(context, self.k8s_api, cluster).delete()
             resources.ApiCertificateAuthoritySecret(
                 context, self.k8s_api, cluster
             ).delete()


### PR DESCRIPTION
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall [-] Fixed interval looping call 'magnum.service.periodic.ClusterUpdateJob.update_status' failed: TypeError: __init__() missing 1 required positional argument: 'cluster' 2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall Traceback (most recent call last):
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall   File "/var/lib/kolla/venv/lib/python3.9/site-packages/oslo_service/loopingcall.py", line 150, in _run_loop
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall     result = func(*self.args, **self.kw)
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall   File "/var/lib/kolla/venv/lib/python3.9/site-packages/magnum/service/periodic.py", line 72, in update_status
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall     cdriver.update_cluster_status(self.ctx, self.cluster)
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall   File "/var/lib/kolla/venv/lib/python3.9/site-packages/magnum_cluster_api/driver.py", line 161, in update_cluster_status
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall     resources.CloudConfigSecret(self.k8s_api, cluster).delete()
2023-10-10 04:06:21.169 7 ERROR oslo.service.loopingcall TypeError: __init__() missing 1 required positional argument: 'cluster'