### PR TITLE
chore: Migrate cluster api CRD version from v1alpha6 to v1alpha7

### DIFF
--- a/hack/run-functional-tests.sh
+++ b/hack/run-functional-tests.sh
@@ -66,16 +66,18 @@ openstack coe cluster create \
   k8s-cluster
 
 # Wait for cluster creation to be queued
+set +e
 for i in {1..5}; do
-  output=$(openstack coe cluster show k8s-cluster 2>&1)
+  openstack coe cluster show k8s-cluster 2>&1
   exit_status=$?
   if [ $exit_status -eq 0 ]; then
       break
   else
-      echo "Error: $output"
+      echo "Error: Cluster k8s-cluster could not be found."
       sleep 1
   fi
 done
+set -e
 
 # Wait for cluster to be "CREATE_COMPLETE".
 for i in {1..240}; do

--- a/hack/run-functional-tests.sh
+++ b/hack/run-functional-tests.sh
@@ -65,6 +65,18 @@ openstack coe cluster create \
   --node-count ${NODE_COUNT} \
   k8s-cluster
 
+# Wait for cluster creation to be queued
+for i in {1..5}; do
+  output=$(openstack coe cluster show k8s-cluster 2>&1)
+  exit_status=$?
+  if [ $exit_status -eq 0 ]; then
+      break
+  else
+      echo "Error: $output"
+      sleep 1
+  fi
+done
+
 # Wait for cluster to be "CREATE_COMPLETE".
 for i in {1..240}; do
   CLUSTER_STATUS=$(openstack coe cluster show k8s-cluster -c status -f value)

--- a/magnum_cluster_api/objects.py
+++ b/magnum_cluster_api/objects.py
@@ -47,7 +47,7 @@ class ClusterResourceSet(NamespacedAPIObject):
 
 
 class OpenStackMachineTemplate(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha6"
+    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
     endpoint = "openstackmachinetemplates"
     kind = "OpenStackMachineTemplate"
 
@@ -83,13 +83,13 @@ class Machine(NamespacedAPIObject):
 
 
 class OpenStackClusterTemplate(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha6"
+    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
     endpoint = "openstackclustertemplates"
     kind = "OpenStackClusterTemplate"
 
 
 class OpenStackCluster(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha6"
+    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
     endpoint = "openstackclusters"
     kind = "OpenStackCluster"
 


### PR DESCRIPTION
fix #235