### PR TITLE
fix: allow configuring tls-cipher-suites

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -166,6 +166,14 @@ is often accomplished by deploying a driver on each node.
 
    Default value: `true`
 
+* `tls_cipher_suites`
+
+   Specify the list of TLS cipher suites to use for the Kubernetes API server,
+   separated by commas.  If not specified, the default list of cipher suites
+   will be used using the [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/#server=go&config=intermediate).
+
+   Default value: `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305`
+
 ## OIDC
 
 * `oidc_issuer_url`

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -781,6 +781,15 @@ class ClusterClass(Base):
                             },
                         },
                         {
+                            "name": "apiServerTLSCipherSuites",
+                            "required": True,
+                            "schema": {
+                                "openAPIV3Schema": {
+                                    "type": "string",
+                                },
+                            },
+                        },
+                        {
                             "name": "openidConnect",
                             "required": True,
                             "schema": {
@@ -1554,6 +1563,13 @@ class ClusterClass(Base):
                                     "jsonPatches": [
                                         {
                                             "op": "add",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/tls-cipher-suites",  # noqa: E501
+                                            "valueFrom": {
+                                                "variable": "apiServerTLSCipherSuites",
+                                            },
+                                        },
+                                        {
+                                            "op": "add",
                                             "path": "/spec/template/spec/kubeadmConfigSpec/files/-",
                                             "valueFrom": {
                                                 "template": textwrap.dedent(
@@ -1832,6 +1848,14 @@ class Cluster(ClusterBase):
                                 "value": {
                                     "enabled": self.cluster.master_lb_enabled,
                                 },
+                            },
+                            {
+                                "name": "apiServerTLSCipherSuites",
+                                "value": utils.get_cluster_label(
+                                    self.cluster,
+                                    "tls_cipher_suites",
+                                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",  # noqa: E501
+                                ),
                             },
                             {
                                 "name": "openidConnect",


### PR DESCRIPTION
This patch allows you to configure TLS cipher suites for the
API server with a sane set of secure defaults.

Closes #251
