### PR TITLE
feat: Add environment variable to set proxy port

### DIFF
--- a/magnum_cluster_api/proxy/manager.py
+++ b/magnum_cluster_api/proxy/manager.py
@@ -13,6 +13,7 @@
 # under the License.
 
 import base64
+import os
 import socket
 from datetime import datetime, timezone
 from pathlib import Path
@@ -42,7 +43,7 @@ class ProxyManager(periodic_task.PeriodicTasks):
             loader=jinja2.PackageLoader("magnum_cluster_api.proxy"),
             autoescape=jinja2.select_autoescape(),
         ).get_template("haproxy.cfg.j2")
-        self.haproxy_port = utils.find_free_port()
+        self.haproxy_port = utils.find_free_port(port_hint=int(os.getenv("PROXY_PORT", 0)))
         self.haproxy_pid = None
 
     def periodic_tasks(self, context, raise_on_error=False):

--- a/magnum_cluster_api/proxy/manager.py
+++ b/magnum_cluster_api/proxy/manager.py
@@ -43,7 +43,9 @@ class ProxyManager(periodic_task.PeriodicTasks):
             loader=jinja2.PackageLoader("magnum_cluster_api.proxy"),
             autoescape=jinja2.select_autoescape(),
         ).get_template("haproxy.cfg.j2")
-        self.haproxy_port = utils.find_free_port(port_hint=int(os.getenv("PROXY_PORT", 0)))
+        self.haproxy_port = utils.find_free_port(
+            port_hint=int(os.getenv("PROXY_PORT", 0))
+        )
         self.haproxy_pid = None
 
     def periodic_tasks(self, context, raise_on_error=False):

--- a/magnum_cluster_api/proxy/utils.py
+++ b/magnum_cluster_api/proxy/utils.py
@@ -40,6 +40,7 @@ def get_default_ip_address():
         )
         return ip_address
 
+
 def find_free_port(port_hint=0):
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         try:

--- a/magnum_cluster_api/proxy/utils.py
+++ b/magnum_cluster_api/proxy/utils.py
@@ -40,9 +40,11 @@ def get_default_ip_address():
         )
         return ip_address
 
-
-def find_free_port():
+def find_free_port(port_hint=0):
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
+        try:
+            s.bind(("", port_hint))
+        except OSError:
+            s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]


### PR DESCRIPTION
The proxy selects a random port by default but this causes difficulty in an environment where network traffic is controlled by a firewall, either host iptables or a physical appliance.

This patch adds an environment variable, PROXY_PORT, which allows the port to be pre-determined and made consistent.