### PR TITLE
Handle no default route in get_default_ip_address()

### DIFF
--- a/magnum_cluster_api/proxy/utils.py
+++ b/magnum_cluster_api/proxy/utils.py
@@ -29,15 +29,16 @@ def get_default_gateway_interface():
 
 def get_default_ip_address():
     interface = get_default_gateway_interface()
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    ip_address = socket.inet_ntoa(
-        fcntl.ioctl(
-            sock.fileno(),
-            0x8915,  # SIOCGIFADDR
-            struct.pack("256s", interface.encode("utf-8")[:15]),
-        )[20:24]
-    )
-    return ip_address
+    if interface:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        ip_address = socket.inet_ntoa(
+            fcntl.ioctl(
+                sock.fileno(),
+                0x8915,  # SIOCGIFADDR
+                struct.pack("256s", interface.encode("utf-8")[:15]),
+            )[20:24]
+        )
+        return ip_address
 
 
 def find_free_port():


### PR DESCRIPTION
A host is not required to have a default gateway, more specific routes may be present instead.

In this situation get_default_gateway_interface() returns None, which is reasonable. get_default_ip_address() then fails with a struct pack error.

This patch allows get_default_ip_address to fall through and also return None when there is no interface identified as the default gateway.