### PR TITLE
Add proxy config for containerd and apt on ubuntu

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -677,7 +677,14 @@ class KubeadmConfigTemplate(Base):
                 "spec": {
                     "template": {
                         "spec": {
-                            "files": [],
+                            "files": [
+                                {
+                                    "path": "/etc/kubernetes/.placeholder",
+                                    "permissions": "0644",
+                                    "content": base64.encode_as_text(PLACEHOLDER),
+                                    "encoding": "base64",
+                                },
+                            ],
                             "joinConfiguration": {
                                 "nodeRegistration": {
                                     "name": "{{ local_hostname }}",
@@ -965,6 +972,24 @@ class ClusterClass(Base):
                         },
                         {
                             "name": "cloudControllerManagerConfig",
+                            "required": True,
+                            "schema": {
+                                "openAPIV3Schema": {
+                                    "type": "string",
+                                },
+                            },
+                        },
+                        {
+                            "name": "systemdProxyConfig",
+                            "required": True,
+                            "schema": {
+                                "openAPIV3Schema": {
+                                    "type": "string",
+                                },
+                            },
+                        },
+                        {
+                            "name": "aptProxyConfig",
                             "required": True,
                             "schema": {
                                 "openAPIV3Schema": {
@@ -1316,6 +1341,82 @@ class ClusterClass(Base):
                             ],
                         },
                         {
+                            "name": "ubuntu",
+                            "enabledIf": '{{ if eq .operatingSystem "ubuntu" }}true{{end}}',
+                            "definitions": [
+                                {
+                                    "selector": {
+                                        "apiVersion": objects.KubeadmControlPlaneTemplate.version,
+                                        "kind": objects.KubeadmControlPlaneTemplate.kind,
+                                        "matchResources": {
+                                            "controlPlane": True,
+                                        },
+                                    },
+                                    "jsonPatches": [
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/files/-",
+                                            "valueFrom": {
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    path: "/etc/apt/apt.conf.d/90proxy"
+                                                    owner: "root:root"
+                                                    permissions: "0644"
+                                                    content: "{{ .aptProxyConfig }}"
+                                                    encoding: "base64"
+                                                    """
+                                                ),
+                                            },
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
+                                            "value": [
+                                                "systemctl daemon-reload",
+                                                "systemctl restart containerd",
+                                            ],
+                                        },
+                                    ],
+                                },
+                                {
+                                    "selector": {
+                                        "apiVersion": objects.KubeadmConfigTemplate.version,
+                                        "kind": objects.KubeadmConfigTemplate.kind,
+                                        "matchResources": {
+                                            "machineDeploymentClass": {
+                                                "names": ["default-worker"],
+                                            }
+                                        },
+                                    },
+                                    "jsonPatches": [
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/files/-",
+                                            "valueFrom": {
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    path: "/etc/apt/apt.conf.d/90proxy"
+                                                    owner: "root:root"
+                                                    permissions: "0644"
+                                                    content: "{{ .aptProxyConfig }}"
+                                                    encoding: "base64"
+                                                    """
+                                                ),
+                                            },
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/preKubeadmCommands",
+                                            "value": [
+                                                "systemctl daemon-reload",
+                                                "systemctl restart containerd",
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        {
                             "name": "flatcar",
                             "enabledIf": '{{ if eq .operatingSystem "flatcar" }}true{{end}}',
                             "definitions": [
@@ -1334,6 +1435,7 @@ class ClusterClass(Base):
                                             "value": textwrap.dedent(
                                                 """\
                                             bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
+                                            bash -c "test -f /tmp/containerd-bootstrap || (touch /tmp/containerd-bootstrap && systemctl daemon-reload && systemctl restart containerd)"
                                             """  # noqa: E501
                                             ),
                                         },
@@ -1398,6 +1500,7 @@ class ClusterClass(Base):
                                                 textwrap.dedent(
                                                     """\
                                                 bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
+                                                bash -c "test -f /tmp/containerd-bootstrap || (touch /tmp/containerd-bootstrap && systemctl daemon-reload && systemctl restart containerd)"
                                                 """  # noqa: E501
                                                 )
                                             ],
@@ -1905,6 +2008,21 @@ class ClusterClass(Base):
                                                 )
                                             },
                                         },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/kubeadmConfigSpec/files/-",
+                                            "valueFrom": {
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    path: "/etc/systemd/system/containerd.service.d/proxy.conf"
+                                                    owner: "root:root"
+                                                    permissions: "0644"
+                                                    content: "{{ .systemdProxyConfig }}"
+                                                    encoding: "base64"
+                                                    """
+                                                )
+                                            },
+                                        },
                                     ],
                                 },
                                 {
@@ -1920,26 +2038,61 @@ class ClusterClass(Base):
                                     "jsonPatches": [
                                         {
                                             "op": "add",
-                                            "path": "/spec/template/spec/files",
+                                            "path": "/spec/template/spec/files/-",
                                             "valueFrom": {
                                                 "template": textwrap.dedent(
                                                     """\
-                                                    - path: "/etc/kubernetes/cloud.conf"
-                                                      owner: "root:root"
-                                                      permissions: "0600"
-                                                      content: "{{ .cloudControllerManagerConfig }}"
-                                                      encoding: "base64"
-                                                    - path: "/etc/kubernetes/cloud_ca.crt"
-                                                      owner: "root:root"
-                                                      permissions: "0600"
-                                                      content: "{{ .cloudCaCert }}"
-                                                      encoding: "base64"
-                                                    - path: "/etc/containerd/config.toml"
-                                                      owner: "root:root"
-                                                      permissions: "0644"
-                                                      content: "{{ .containerdConfig }}"
-                                                      encoding: "base64"
-                                                """
+                                                    path: "/etc/kubernetes/cloud.conf"
+                                                    owner: "root:root"
+                                                    permissions: "0600"
+                                                    content: "{{ .cloudControllerManagerConfig }}"
+                                                    encoding: "base64"
+                                                    """
+                                                ),
+                                            },
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/files/-",
+                                            "valueFrom": {
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    path: "/etc/kubernetes/cloud_ca.crt"
+                                                    owner: "root:root"
+                                                    permissions: "0600"
+                                                    content: "{{ .cloudCaCert }}"
+                                                    encoding: "base64"
+                                                    """
+                                                ),
+                                            },
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/files/-",
+                                            "valueFrom": {
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    path: "/etc/containerd/config.toml"
+                                                    owner: "root:root"
+                                                    permissions: "0644"
+                                                    content: "{{ .containerdConfig }}"
+                                                    encoding: "base64"
+                                                    """
+                                                ),
+                                            },
+                                        },
+                                        {
+                                            "op": "add",
+                                            "path": "/spec/template/spec/files/-",
+                                            "valueFrom": {
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    path: "/etc/systemd/system/containerd.service.d/proxy.conf"
+                                                    owner: "root:root"
+                                                    permissions: "0644"
+                                                    content: "{{ .systemdProxyConfig }}"
+                                                    encoding: "base64"
+                                                    """
                                                 ),
                                             },
                                         },
@@ -2264,6 +2417,18 @@ class Cluster(ClusterBase):
                                     utils.generate_cloud_controller_manager_config(
                                         self.context, self.api, self.cluster
                                     )
+                                ),
+                            },
+                            {
+                                "name": "systemdProxyConfig",
+                                "value": base64.encode_as_text(
+                                    utils.generate_systemd_proxy_config(self.cluster)
+                                ),
+                            },
+                            {
+                                "name": "aptProxyConfig",
+                                "value": base64.encode_as_text(
+                                    utils.generate_apt_proxy_config(self.cluster)
                                 ),
                             },
                             {

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -208,6 +208,48 @@ def generate_containerd_config(
     ).format(sandbox_image=sandbox_image)
 
 
+def generate_systemd_proxy_config(cluster: magnum_objects.Cluster):
+    if (
+        cluster.cluster_template.http_proxy is not None
+        or cluster.cluster_template.https_proxy is not None
+    ):
+        return textwrap.dedent(
+            """\
+            [Service]
+            Environment="http_proxy={http_proxy}"
+            Environment="HTTP_PROXY={http_proxy}"
+            Environment="https_proxy={https_proxy}"
+            Environment="HTTPS_PROXY={https_proxy}"
+            Environment="no_proxy={no_proxy}"
+            Environment="NO_PROXY={no_proxy}"
+            """
+        ).format(
+            http_proxy=cluster.cluster_template.http_proxy,
+            https_proxy=cluster.cluster_template.https_proxy,
+            no_proxy=cluster.cluster_template.no_proxy,
+        )
+    else:
+        return ""
+
+
+def generate_apt_proxy_config(cluster: magnum_objects.Cluster):
+    if (
+        cluster.cluster_template.http_proxy is not None
+        or cluster.cluster_template.https_proxy is not None
+    ):
+        return textwrap.dedent(
+            """\
+            Acquire::http::Proxy "{http_proxy}";
+            Acquire::https::Proxy "{https_proxy}";
+            """
+        ).format(
+            http_proxy=cluster.cluster_template.http_proxy,
+            https_proxy=cluster.cluster_template.https_proxy,
+        )
+    else:
+        return ""
+
+
 def get_node_group_label(
     context: context.RequestContext,
     node_group: magnum_objects.NodeGroup,


### PR DESCRIPTION
This PR adds support for HTTP proxy servers in user clusters, with config supplied via the existing Magnum proxy variables. Specifically, proxies are configured in containerd for image downloads, and in apt when running Ubuntu.

I've had to add a placeholder file to the KubeadmConfigTemplate as otherwise the JSON patch process fails when adding files to the empty array.