### PR TITLE
chore: Use endpoint_type rather than interface to work around lib bug

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -514,7 +514,7 @@ class CloudConfigSecret(ClusterBase):
                             "clouds": {
                                 "default": {
                                     "region_name": self.region_name,
-                                    "interface": CONF.capi_client.endpoint_type.replace(
+                                    "endpoint_type": CONF.capi_client.endpoint_type.replace(
                                         "URL", ""
                                     ),
                                     "identity_api_version": 3,


### PR DESCRIPTION
Our testing against internal API endpoints has found that the use of 'interface' key in the clouds.yaml format doesn't appear to be working, but replacing this with 'endpoint_type' does. Whilst this is likely to be a bug in an underlying component, these appear to suggest that 'endpoint_type' is preferred, so there doesn't seem to be any harm in working around the issue here.

When looking into the underlying bug, we found https://github.com/gophercloud/utils/blob/master/openstack/clientconfig/requests.go#L327, but it isn't clear whether the underlying issue is here or elsewhere.