### PR TITLE
feat: Add environment variable to set proxy bind address

### DIFF
--- a/magnum_cluster_api/proxy/manager.py
+++ b/magnum_cluster_api/proxy/manager.py
@@ -46,6 +46,7 @@ class ProxyManager(periodic_task.PeriodicTasks):
         self.haproxy_port = utils.find_free_port(
             port_hint=int(os.getenv("PROXY_PORT", 0))
         )
+        self.haproxy_bind = os.getenv("PROXY_BIND", "*")
         self.haproxy_pid = None
 
     def periodic_tasks(self, context, raise_on_error=False):
@@ -56,6 +57,7 @@ class ProxyManager(periodic_task.PeriodicTasks):
         config = self.template.render(
             pid_file=utils.get_haproxy_pid_path(),
             port=self.haproxy_port,
+            bind=self.haproxy_bind,
             clusters=proxied_clusters,
         )
 

--- a/magnum_cluster_api/proxy/templates/haproxy.cfg.j2
+++ b/magnum_cluster_api/proxy/templates/haproxy.cfg.j2
@@ -11,7 +11,7 @@ defaults
   timeout server  10s
 
 frontend magnum
-  bind *:{{ port }}
+  bind {{ bind }}:{{ port }}
   tcp-request inspect-delay 5s
   tcp-request content accept if { req.ssl_hello_type 1 }
   use_backend %[req.ssl_sni,lower]


### PR DESCRIPTION
This patch adds the environment variable PROXY_BIND which can be optionally set to override the default that binds to "*".

Binding on all addresses may inadvertently expose the proxy service when run on a node that also has public interfaces such as a bare metal openstack infrastructure node, or a network node.