### PR TITLE
Use up-to-date provisioner name for Cinder CSI

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -230,7 +230,7 @@ class ClusterResourcesConfigMap(ClusterBase):
                                 else {},
                                 "name": "block-%s" % utils.convert_to_rfc1123(vt.name),
                             },
-                            "provisioner": "kubernetes.io/cinder",
+                            "provisioner": "cinder.csi.openstack.org",
                             "parameters": {
                                 "type": utils.convert_to_rfc1123(vt.name),
                             },


### PR DESCRIPTION
Change Cinder CSI Provisioner 

from

"provisioner": "kubernetes.io/cinder"

to

"provisioner": "cinder.csi.openstack.org",