### PR TITLE
fix: stop unexpected rollouts

### DIFF
--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -1,0 +1,12 @@
+# Cluster Topology
+
+The Cluster API driver for Magnum makes use of the Cluster topology feature of the Cluster API project.  This allows it to delegate all of the work around building resources such as the `OpenStackCluster`, `MachineDeployments` and everything else managed entire by the Cluster API instead of the driver creating all of these resources.
+
+In order to do this, the driver creates a [`ClusterClass`](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/write-clusterclass) resource which is called `magnum-v{VERSION}` where `{VERSION}` is the current version of the driver because of the following reasons:
+
+- This allows us to have multiple different versions of the `ClusterClass` because it is an immutable resource.
+- This prevents causing a rollout of existing clusters should a change happen to the underlying `ClusterClass`.
+
+It's important to note that there are only _one_ scenarios where the `spec.topology.class` for a given `Cluster` will be modified and this will be when a cluster upgrade is done.  This is because there is an expectation by the user that a rolling restart operation will occur if a cluster upgrade is requested.  No other action should be allowed to change the `spec.topology.class` of a `Cluster`.
+
+For users, it's important to keep in mind that if they want to use a newer `ClusterClass` in order to make sure of a new feature available in a newer `ClusterClass`, they can simply do an upgrade within Magnum to the same cluster template and it will actually force an update of the `spec.topology.class`, which might then naturally cause a full rollout to occur.

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,11 @@
         {
           devShell = pkgs.mkShell
             {
-              # LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+              LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
 
               buildInputs = with pkgs; [
+                bashInteractive
+                glibcLocales
                 poetry
               ];
             };

--- a/magnum_cluster_api/tests/unit/conftest.py
+++ b/magnum_cluster_api/tests/unit/conftest.py
@@ -15,6 +15,8 @@
 import pytest
 from magnum.common import context as magnum_context
 
+from magnum_cluster_api import driver
+
 
 @pytest.fixture
 def context():
@@ -26,3 +28,26 @@ def context():
         user_id="fake_user",
         is_admin=False,
     )
+
+
+@pytest.fixture(scope="session")
+def mock_pykube(session_mocker):
+    session_mocker.patch("pykube.KubeConfig")
+    session_mocker.patch("pykube.HTTPClient")
+
+
+@pytest.fixture(scope="session")
+def mock_cluster_lock(session_mocker):
+    session_mocker.patch("kubernetes.config.load_config")
+    session_mocker.patch("magnum_cluster_api.sync.ClusterLock.acquire")
+    session_mocker.patch("magnum_cluster_api.sync.ClusterLock.release")
+
+
+@pytest.fixture(scope="session")
+def mock_validate_nodegroup(session_mocker):
+    session_mocker.patch("magnum_cluster_api.utils.validate_nodegroup")
+
+
+@pytest.fixture()
+def ubuntu_driver(mock_cluster_lock, mock_pykube):
+    yield driver.UbuntuDriver()

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from magnum.objects import fields
+from magnum.tests.unit.objects import utils
+
+
+class TestDriver:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker, context, mock_pykube, mock_validate_nodegroup):
+        self.cluster = utils.get_test_cluster(context, labels={})
+        self.cluster.save = mocker.MagicMock()
+
+        self.node_group = utils.get_test_nodegroup(context)
+        self.node_group.save = mocker.MagicMock()
+
+        self.mock_cluster_resource = mocker.MagicMock()
+        self.mock_cluster_objects = mocker.patch(
+            "magnum_cluster_api.objects.Cluster.objects"
+        )
+        self.mock_cluster_objects.return_value.get.return_value = (
+            self.mock_cluster_resource
+        )
+
+        self.mock_wait_capi_cluster_reconciliation_start = mocker.patch(
+            "magnum_cluster_api.driver.BaseDriver.wait_capi_cluster_reconciliation_start"
+        )
+
+    def _assert_node_group_crud_calls(self):
+        self.mock_cluster_objects.return_value.get.assert_called_once_with(
+            name=self.cluster.stack_id
+        )
+        self.mock_cluster_resource.update.assert_called_once()
+        self.mock_wait_capi_cluster_reconciliation_start.assert_called_once()
+
+    def _assert_node_group_status(self, expected_status):
+        assert self.node_group.status == expected_status
+        self.node_group.save.assert_called_once()
+
+        assert self.cluster.status == fields.ClusterStatus.UPDATE_IN_PROGRESS
+        self.cluster.save.assert_called_once()
+
+    def test_create_nodegroup(self, mocker, context, ubuntu_driver):
+        self.mock_cluster_resource.obj = {
+            "spec": {
+                "topology": {
+                    "workers": {
+                        "machineDeployments": [],
+                    }
+                }
+            },
+        }
+
+        mock_mutate_machine_deployment = mocker.patch(
+            "magnum_cluster_api.resources.mutate_machine_deployment"
+        )
+
+        ubuntu_driver.create_nodegroup(context, self.cluster, self.node_group)
+
+        mock_mutate_machine_deployment.assert_called_once_with(
+            context, self.cluster, self.node_group
+        )
+
+        assert self.mock_cluster_resource.obj["spec"]["topology"]["workers"][
+            "machineDeployments"
+        ] == [mock_mutate_machine_deployment.return_value]
+
+        self._assert_node_group_crud_calls()
+        self._assert_node_group_status(fields.ClusterStatus.CREATE_IN_PROGRESS)
+
+    def test_update_nodegroup(self, mocker, context, ubuntu_driver):
+        self.mock_cluster_resource.obj = {
+            "spec": {
+                "topology": {
+                    "workers": {
+                        "machineDeployments": [
+                            {
+                                "name": self.node_group.name,
+                            }
+                        ],
+                    }
+                }
+            },
+        }
+
+        mock_mutate_machine_deployment = mocker.patch(
+            "magnum_cluster_api.resources.mutate_machine_deployment"
+        )
+
+        ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
+
+        mock_mutate_machine_deployment.assert_called_once_with(
+            context,
+            self.cluster,
+            self.node_group,
+            {
+                "name": self.node_group.name,
+            },
+        )
+
+        assert self.mock_cluster_resource.obj["spec"]["topology"]["workers"][
+            "machineDeployments"
+        ] == [mock_mutate_machine_deployment.return_value]
+
+        self._assert_node_group_crud_calls()
+        self._assert_node_group_status(fields.ClusterStatus.UPDATE_IN_PROGRESS)
+
+    def test_update_nodegroup_with_multiple_node_groups(
+        self, mocker, context, ubuntu_driver
+    ):
+        mock_machine_deployment = mocker.MagicMock()
+
+        self.mock_cluster_resource.obj = {
+            "spec": {
+                "topology": {
+                    "workers": {
+                        "machineDeployments": [
+                            mock_machine_deployment,
+                            {
+                                "name": self.node_group.name,
+                            },
+                        ],
+                    }
+                }
+            },
+        }
+
+        mock_mutate_machine_deployment = mocker.patch(
+            "magnum_cluster_api.resources.mutate_machine_deployment"
+        )
+
+        ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
+
+        assert not mock_machine_deployment.called
+
+        mock_mutate_machine_deployment.assert_called_once_with(
+            context,
+            self.cluster,
+            self.node_group,
+            {
+                "name": self.node_group.name,
+            },
+        )
+
+        assert self.mock_cluster_resource.obj["spec"]["topology"]["workers"][
+            "machineDeployments"
+        ] == [
+            mock_machine_deployment,
+            mock_mutate_machine_deployment.return_value,
+        ]
+
+        self._assert_node_group_crud_calls()
+        self._assert_node_group_status(fields.ClusterStatus.UPDATE_IN_PROGRESS)
+
+    def test_delete_nodegroup_with_multiple_node_groups(
+        self, mocker, context, ubuntu_driver
+    ):
+        mock_machine_deployment = mocker.MagicMock()
+
+        self.mock_cluster_resource.obj = {
+            "spec": {
+                "topology": {
+                    "workers": {
+                        "machineDeployments": [
+                            mock_machine_deployment,
+                            {
+                                "name": self.node_group.name,
+                            },
+                        ],
+                    }
+                }
+            },
+        }
+
+        ubuntu_driver.delete_nodegroup(context, self.cluster, self.node_group)
+
+        assert not mock_machine_deployment.called
+
+        assert self.mock_cluster_resource.obj["spec"]["topology"]["workers"][
+            "machineDeployments"
+        ] == [
+            mock_machine_deployment,
+        ]
+
+        self._assert_node_group_crud_calls()
+        self._assert_node_group_status(fields.ClusterStatus.DELETE_IN_PROGRESS)


### PR DESCRIPTION
When making any node group changes, we were previously
making an entire change of all the cluster resources.  With
this change, we're instead simply making the small changes
in the node group which should avoid unexpected full rollouts
of node groups when changing min/max for autoscaling or
resizing a cluster.
