### PR TITLE
fix tenacity.RetryError on cluster resize

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -21,8 +21,8 @@ from magnum.conductor import scale_manager
 from magnum.drivers.common import driver
 from magnum.objects import fields
 from tenacity import (
-    Retrying,
     RetryError,
+    Retrying,
     retry_if_exception,
     retry_if_not_result,
     retry_unless_exception_type,


### PR DESCRIPTION
Without this patch `openstack coe cluster resize` will fail with UPDATE_FAILED

This patch fix tenacity.RetryError: RetryError[<Future at 0xXXXXXXXX state=finished returned MachineDeployment>] when resizing nodegroup

