### PR TITLE
Kubernetes 1.28.x support

### DIFF
--- a/magnum_cluster_api/cmd/image_loader.py
+++ b/magnum_cluster_api/cmd/image_loader.py
@@ -44,6 +44,10 @@ VERSIONS = [
     "v1.26.11",
     "v1.27.3",
     "v1.27.8",
+    "v1.27.15",
+    "v1.28.11",
+    "v1.29.6",
+    "v1.30.2",
 ]
 
 
@@ -83,6 +87,7 @@ def main(repository, parallel, insecure):
     images = set(
         _get_all_kubeadm_images()
         + _get_calico_images()
+        + _get_cilium_images()
         + _get_cloud_provider_images()
         + _get_infra_images()
     )
@@ -177,35 +182,67 @@ def _get_calico_images():
         "docker.io/calico/node:v3.24.2",
     ]
 
+def _get_cilium_images():
+    return [
+        # Cilium 1.15.6
+        "quay.io/cilium/cilium:v1.15.3",
+        "quay.io/cilium/operator-generic:v1.15.3",
+        "quay.io/cilium/cilium:v1.15.6",
+        "quay.io/cilium/operator-generic:v1.15.6",
+    ]
 
 def _get_cloud_provider_images():
     return [
-        # 1.24.6
+        # v1.24.6
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.24.6",
         "registry.k8s.io/provider-os/cinder-csi-plugin:v1.24.6",
         "registry.k8s.io/provider-os/manila-csi-plugin:v1.24.6",
         "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.24.6",
         # v1.25.3
+        "docker.io/k8scloudprovider/k8s-keystone-auth:v1.25.3",
         "docker.io/k8scloudprovider/cinder-csi-plugin:v1.25.3",
         "docker.io/k8scloudprovider/manila-csi-plugin:v1.25.3",
         "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.25.3",
         # v1.25.6
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.25.6",
         "registry.k8s.io/provider-os/cinder-csi-plugin:v1.25.6",
         "registry.k8s.io/provider-os/manila-csi-plugin:v1.25.6",
         "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.25.6",
         # v1.26.3
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.26.3",
         "registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.3",
         "registry.k8s.io/provider-os/manila-csi-plugin:v1.26.3",
         "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.3",
         # v1.27.2
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.27.2",
         "registry.k8s.io/provider-os/cinder-csi-plugin:v1.27.2",
         "registry.k8s.io/provider-os/manila-csi-plugin:v1.27.2",
         "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.27.2",
+        # v1.27.3
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.27.3",
+        "registry.k8s.io/provider-os/cinder-csi-plugin:v1.27.3",
+        "registry.k8s.io/provider-os/manila-csi-plugin:v1.27.3",
+        "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.27.3",
         # v1.28.0
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.28.0",
         "registry.k8s.io/provider-os/cinder-csi-plugin:v1.28.0",
         "registry.k8s.io/provider-os/manila-csi-plugin:v1.28.0",
         "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.0",
+        # v1.28.2
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.28.2",
+        "registry.k8s.io/provider-os/cinder-csi-plugin:v1.28.2",
+        "registry.k8s.io/provider-os/manila-csi-plugin:v1.28.2",
+        "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.2",
         # v1.29.0
         "registry.k8s.io/provider-os/k8s-keystone-auth:v1.29.0",
+        "registry.k8s.io/provider-os/cinder-csi-plugin:v1.29.0",
+        "registry.k8s.io/provider-os/manila-csi-plugin:v1.29.0",
+        "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.29.0",
+        # v1.30.0
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.30.0",
+        "registry.k8s.io/provider-os/cinder-csi-plugin:v1.30.0",
+        "registry.k8s.io/provider-os/manila-csi-plugin:v1.30.0",
+        "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.0",
     ]
 
 

--- a/magnum_cluster_api/cmd/image_loader.py
+++ b/magnum_cluster_api/cmd/image_loader.py
@@ -182,6 +182,7 @@ def _get_calico_images():
         "docker.io/calico/node:v3.24.2",
     ]
 
+
 def _get_cilium_images():
     return [
         # Cilium 1.15.6
@@ -190,6 +191,7 @@ def _get_cilium_images():
         "quay.io/cilium/cilium:v1.15.6",
         "quay.io/cilium/operator-generic:v1.15.6",
     ]
+
 
 def _get_cloud_provider_images():
     return [

--- a/magnum_cluster_api/conf.py
+++ b/magnum_cluster_api/conf.py
@@ -64,6 +64,11 @@ auto_scaling_opts = [
         default="$image_repository/cluster-autoscaler:v1.27.2",
         help="Image for the cluster auto-scaler for Kubernetes v1.27.",
     ),
+    cfg.StrOpt(
+        "v1_28_image",
+        default="$image_repository/cluster-autoscaler:v1.28.5",
+        help="Image for the cluster auto-scaler for Kubernetes v1.28.",
+    ),
 ]
 
 

--- a/magnum_cluster_api/image_utils.py
+++ b/magnum_cluster_api/image_utils.py
@@ -58,7 +58,9 @@ def get_image(name: str, repository: str = None):
 
     new_image_name = name
     if name.startswith("docker.io/calico"):
-        new_image_name = name.replace("docker.io/calico/", f"{repository}/calico-")
+        new_image_name = name.replace("docker.io/calico/", f"{repository}/calico/")
+    if name.startswith("quay.io/cilium"):
+        new_image_name = name.replace("quay.io/cilium/", f"{repository}/cilium/")
     if name.startswith("docker.io/k8scloudprovider"):
         new_image_name = name.replace("docker.io/k8scloudprovider", repository)
     if name.startswith("registry.k8s.io/sig-storage"):

--- a/magnum_cluster_api/integrations/common.py
+++ b/magnum_cluster_api/integrations/common.py
@@ -83,9 +83,13 @@ def get_cloud_provider_tag(cluster: objects.Cluster, label: str) -> str:
     elif version.major == 1 and version.minor == 26:
         tag = "v1.26.3"
     elif version.major == 1 and version.minor == 27:
-        # TODO(mnaser): There is no 1.27 release yet, so we're using
-        #               the latest 1.26 release for now.
-        tag = "v1.26.3"
+        tag = "v1.27.3"
+    elif version.major == 1 and version.minor == 28:
+        tag = "v1.28.2"
+    elif version.major == 1 and version.minor == 29:
+        tag = "v1.29.0"
+    elif version.major == 1 and version.minor == 30:
+        tag = "v1.30.0"
 
     if tag is None:
         raise ValueError(

--- a/zuul.d/jobs-flatcar.yaml
+++ b/zuul.d/jobs-flatcar.yaml
@@ -9,6 +9,7 @@
     name: magnum-cluster-api-sonobuoy-flatcar
     parent: magnum-cluster-api-sonobuoy
     abstract: true
+    voting: false
     vars:
       image_operating_system: flatcar
       image_os_distro: flatcar

--- a/zuul.d/jobs-rockylinux-8.yaml
+++ b/zuul.d/jobs-rockylinux-8.yaml
@@ -9,6 +9,7 @@
     name: magnum-cluster-api-sonobuoy-rockylinux-8
     parent: magnum-cluster-api-sonobuoy
     abstract: true
+    voting: false
     vars:
       image_operating_system: rockylinux-8
       image_os_distro: ubuntu

--- a/zuul.d/jobs-rockylinux-9.yaml
+++ b/zuul.d/jobs-rockylinux-9.yaml
@@ -9,6 +9,7 @@
     name: magnum-cluster-api-sonobuoy-rockylinux-9
     parent: magnum-cluster-api-sonobuoy
     abstract: true
+    voting: false
     vars:
       image_operating_system: rockylinux-9
       image_os_distro: ubuntu

--- a/zuul.d/jobs-ubuntu-2204.yaml
+++ b/zuul.d/jobs-ubuntu-2204.yaml
@@ -11,7 +11,7 @@
     parent: magnum-cluster-api-sonobuoy-ubuntu-2204
     vars:
       kube_tag: v1.27.15
-      image_url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-27-15-1719584981.qcow2
+      image_url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-27-15-1719601165.qcow2
 
 - job:
     name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15-calico
@@ -30,7 +30,7 @@
     parent: magnum-cluster-api-sonobuoy-ubuntu-2204
     vars:
       kube_tag: v1.28.11
-      image_url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-28-11-1719584982.qcow2
+      image_url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-28-11-1719601167.qcow2
 
 - job:
     name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11-calico

--- a/zuul.d/jobs-ubuntu-2204.yaml
+++ b/zuul.d/jobs-ubuntu-2204.yaml
@@ -1,11 +1,4 @@
 - job:
-    name: magnum-cluster-api-image-build-ubuntu-2204
-    parent: magnum-cluster-api-image-build
-    abstract: true
-    vars:
-      image_operating_system: ubuntu-2204
-
-- job:
     name: magnum-cluster-api-sonobuoy-ubuntu-2204
     parent: magnum-cluster-api-sonobuoy
     abstract: true
@@ -14,29 +7,40 @@
       image_os_distro: ubuntu
 
 - job:
-    name: magnum-cluster-api-image-build-ubuntu-2204-v1.27.8
-    parent: magnum-cluster-api-image-build-ubuntu-2204
-    vars:
-      kube_tag: v1.27.8
-
-- job:
-    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8
+    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15
     parent: magnum-cluster-api-sonobuoy-ubuntu-2204
-    dependencies:
-      - name: magnum-cluster-api-image-build-ubuntu-2204-v1.27.8
-        soft: true
     vars:
-      kube_tag: v1.27.8
+      kube_tag: v1.27.15
+      image_url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-27-15-1719584981.qcow2
 
 - job:
-    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8-calico
-    parent: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8
+    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15-calico
+    parent: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8-cilium
-    parent: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8
+    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15-cilium
+    parent: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15
+    vars:
+      network_driver: cilium
+
+- job:
+    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11
+    parent: magnum-cluster-api-sonobuoy-ubuntu-2204
+    vars:
+      kube_tag: v1.28.11
+      image_url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-28-11-1719584982.qcow2
+
+- job:
+    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11-calico
+    parent: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11
+    vars:
+      network_driver: calico
+
+- job:
+    name: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11-cilium
+    parent: magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11
     vars:
       network_driver: cilium
 
@@ -44,6 +48,7 @@
     name: magnum-cluster-api-ubuntu-2204
     check:
       jobs:
-        - magnum-cluster-api-image-build-ubuntu-2204-v1.27.8
-        - magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8-calico
-        - magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.8-cilium
+        - magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15-calico
+        - magnum-cluster-api-sonobuoy-ubuntu-2204-v1.27.15-cilium
+        - magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11-calico
+        - magnum-cluster-api-sonobuoy-ubuntu-2204-v1.28.11-cilium

--- a/zuul.d/playbooks/sonobuoy/run.yml
+++ b/zuul.d/playbooks/sonobuoy/run.yml
@@ -11,10 +11,14 @@
         - item.name == "{{ image_operating_system }}-kube-{{ kube_tag }}.qcow2"
 
     - name: Download image
-      when: image_url is defined
       get_url:
         url: "{{ image_url }}"
         dest: "{{ zuul.project.src_dir }}/{{ image_operating_system }}-kube-{{ kube_tag }}.qcow2"
+      register: fetch_artifact
+      retries: 5
+      delay: 10
+      when:
+        - image_url is defined
 
     - shell: "./hack/stack.sh"
       args:
@@ -28,7 +32,7 @@
         OS_DISTRO: "{{ image_os_distro }}"
         KUBE_TAG: "{{ kube_tag }}"
         NODE_COUNT: 2
-        BUILD_NEW_IMAGE: "true"
+        BUILD_NEW_IMAGE: "{{ fetch_artifact.changed }}"
         NETWORK_DRIVER: "{{ network_driver }}"
 
     - name: Copy Sonobuoy results to output folder

--- a/zuul.d/playbooks/sonobuoy/run.yml
+++ b/zuul.d/playbooks/sonobuoy/run.yml
@@ -10,10 +10,16 @@
         - item.name is defined
         - item.name == "{{ image_operating_system }}-kube-{{ kube_tag }}.qcow2"
 
+    - name: Download image
+      when: image_url is defined
+      get_url:
+        url: "{{ image_url }}"
+        dest: "{{ zuul.project.src_dir }}/{{ image_operating_system }}-kube-{{ kube_tag }}.qcow2"
+
     - shell: "./hack/stack.sh"
       args:
         chdir: "{{ zuul.project.src_dir }}"
- 
+
     - shell: "./hack/run-integration-tests.sh"
       args:
         chdir: "{{ zuul.project.src_dir }}"
@@ -22,7 +28,7 @@
         OS_DISTRO: "{{ image_os_distro }}"
         KUBE_TAG: "{{ kube_tag }}"
         NODE_COUNT: 2
-        BUILD_NEW_IMAGE: "{{ fetch_artifact.changed }}"
+        BUILD_NEW_IMAGE: "true"
         NETWORK_DRIVER: "{{ network_driver }}"
 
     - name: Copy Sonobuoy results to output folder


### PR DESCRIPTION
@mnaser 
You can safely merge this - it will add only support for k8s 1.28.x
With k8s 1.28.x there is no issues with keystone auth