### PR TITLE
feat: simplify and generalise get_image()

### DIFF
--- a/magnum_cluster_api/image_utils.py
+++ b/magnum_cluster_api/image_utils.py
@@ -56,31 +56,9 @@ def get_image(name: str, repository: str = None):
     if not repository:
         return name
 
-    new_image_name = name
     if name.startswith("docker.io/calico"):
-        new_image_name = name.replace("docker.io/calico/", f"{repository}/calico/")
-    if name.startswith("quay.io/cilium"):
-        new_image_name = name.replace("quay.io/cilium/", f"{repository}/cilium/")
-    if name.startswith("docker.io/k8scloudprovider"):
-        new_image_name = name.replace("docker.io/k8scloudprovider", repository)
-    if name.startswith("registry.k8s.io/sig-storage"):
-        new_image_name = name.replace("registry.k8s.io/sig-storage", repository)
-    if name.startswith("registry.k8s.io/provider-os"):
-        new_image_name = name.replace("registry.k8s.io/provider-os", repository)
-    if name.startswith("gcr.io/k8s-staging-sig-storage"):
-        new_image_name = name.replace("gcr.io/k8s-staging-sig-storage", repository)
-    if new_image_name.startswith(f"{repository}/livenessprobe"):
-        return new_image_name.replace("livenessprobe", "csi-livenessprobe")
-    if new_image_name.startswith("registry.k8s.io/coredns"):
-        return new_image_name.replace("registry.k8s.io/coredns", repository)
-    if new_image_name.startswith("registry.k8s.io/autoscaling"):
-        return new_image_name.replace("registry.k8s.io/autoscaling", repository)
-    if (
-        new_image_name.startswith("registry.k8s.io/etcd")
-        or new_image_name.startswith("registry.k8s.io/kube-")
-        or new_image_name.startswith("registry.k8s.io/pause")
-    ):
-        return new_image_name.replace("registry.k8s.io", repository)
+        return name.replace("docker.io/calico/", f"{repository}/calico-")
+    if name.startswith(f"{repository}/livenessprobe"):
+        return name.replace("livenessprobe", "csi-livenessprobe")
 
-    assert new_image_name.startswith(repository) is True
-    return new_image_name
+    return repository + "/" + name.split("/")[-1]


### PR DESCRIPTION
get_image function in image_utils.py had a hardcoded list of image names and code to modify these for use with a local target registry. It fails an assertion if an unexpected image name is passed in.

This commit simplifies the code and has default functionality for any image not explicitly handled, so that

   old_registry/path/image_name

is converted to

   new_registry/image_name

which will work in almost all cases.