### PR TITLE
Allow min_node_count to be zero

### DIFF
--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -269,7 +269,7 @@ def get_node_group_min_node_count(
     node_group: magnum_objects.NodeGroup,
     default=1,
 ) -> int:
-    if node_group.min_node_count == 0:
+    if node_group.min_node_count is None:
         return default
     return node_group.min_node_count
 


### PR DESCRIPTION
The current behavior sets min_node_count to 1 if the user specifies it should be zero. Zero is supported by both Magnum and the Cluster Autoscaler.

This sets it to the default value 1 (same as Magnum when min_node_count is not specified) only when it was not specified.

Related:
* Magnum: https://review.opendev.org/c/openstack/magnum/+/737580
* Autoscaler: https://github.com/kubernetes/autoscaler/pull/3995