### PR TITLE
fix: allow skipping node groups that are master or delete complete

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -426,7 +426,7 @@ class BaseDriver(driver.Driver):
             #               state and skip work if it's a master node group.
             if (
                 node_group.role == "master"
-                and node_group.status == fields.ClusterStatus.DELETE_COMPLETE
+                or node_group.status == fields.ClusterStatus.DELETE_COMPLETE
             ):
                 continue
 


### PR DESCRIPTION
Modified the condition to use OR instead of AND for skipping node groups. Now, node groups with a role of "master" or a status of "DELETE_COMPLETE" are skipped.

related to https://github.com/vexxhost/magnum-cluster-api/commit/0e904b6e256f6cfb5ddf32816707368ea6738ac2