### PR TITLE
[MCAPI-1] feat: upgrade capi & capo version

### DIFF
--- a/hack/setup-capo.sh
+++ b/hack/setup-capo.sh
@@ -19,8 +19,8 @@
 export GOPROXY=off
 
 # Versions to test
-CAPI_VERSION=${CAPI_VERSION:-v1.6.0}
-CAPO_VERSION=${CAPO_VERSION:-v0.9.0}
+CAPI_VERSION=${CAPI_VERSION:-vv1.8.1}
+CAPO_VERSION=${CAPO_VERSION:-v0.10.4}
 
 # Install the `clusterctl` CLI
 sudo curl -Lo /usr/local/bin/clusterctl https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/clusterctl-linux-amd64

--- a/hack/setup-capo.sh
+++ b/hack/setup-capo.sh
@@ -19,8 +19,8 @@
 export GOPROXY=off
 
 # Versions to test
-CAPI_VERSION=${CAPI_VERSION:-vv1.8.1}
-CAPO_VERSION=${CAPO_VERSION:-v0.10.4}
+CAPI_VERSION=${CAPI_VERSION:-v1.8.4}
+CAPO_VERSION=${CAPO_VERSION:-v0.10.5}
 
 # Install the `clusterctl` CLI
 sudo curl -Lo /usr/local/bin/clusterctl https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/clusterctl-linux-amd64

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -827,9 +827,8 @@ class OpenStackClusterTemplate(Base):
                     "template": {
                         "spec": {
                             "cloudName": "default",
-                            "managedSecurityGroups": {
-                                "allowAllInClusterTraffic": True,
-                            },
+                            "managedSecurityGroups": True,
+                            "allowAllInClusterTraffic": True,
                         },
                     },
                 },

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -827,8 +827,9 @@ class OpenStackClusterTemplate(Base):
                     "template": {
                         "spec": {
                             "cloudName": "default",
-                            "managedSecurityGroups": True,
-                            "allowAllInClusterTraffic": True,
+                            "managedSecurityGroups": {
+                                "allowAllInClusterTraffic": True,
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
capi 1.6 -> 1.8.4
capo 0.9 -> v0.10.5

To support workload cluster 1.31, need to upgrade capi to 1.8.x To support workload cluster 1.30, need to upgrade capi to 1.7.x