### PR TITLE
keystone_auth: always use public endpoint from tenant cluster

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -395,7 +395,7 @@ class ClusterResourcesConfigMap(ClusterBase):
         if utils.get_cluster_label_as_bool(self.cluster, "keystone_auth_enabled", True):
             auth_url = osc.url_for(
                 service_type="identity",
-                interface=CONF.capi_client.endpoint_type.replace("URL", ""),
+                interface="public",
             )
             data = {
                 **data,


### PR DESCRIPTION
I may be misunderstanding, but as far as I can tell the keystone auth component lives entirely in a tenant's cluster, and so must always use the public endpoint to access Keystone.

As we change the capi_client endpoint_type to internal in our deployment, this appears to be contributing to a failure of the keystone auth components in tenant clusters.

If there was a way to get this component to use `/etc/kubernetes/cloud.conf` like other similar components I guess that would be preferable to having this separate definition.