### PR TITLE
keystone_auth: fix errors providing CA cert as string

### DIFF
--- a/magnum_cluster_api/charts/k8s-keystone-auth/templates/secret-ca.yaml
+++ b/magnum_cluster_api/charts/k8s-keystone-auth/templates/secret-ca.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     {{- include "k8s-keystone-auth.labels" . | nindent 4 }}
 stringData:
-  cloud_ca.crt: {{ .Values.conf.ca_cert }}
-{{- end -}}
+  cloud_ca.crt: |
+{{ .Values.conf.ca_cert | indent 4 }}
+{{- end }}

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -413,7 +413,7 @@ class ClusterResourcesConfigMap(ClusterBase):
                             "conf": {
                                 "auth_url": auth_url
                                 + ("" if auth_url.endswith("/v3") else "/v3"),
-                                "ca_file": utils.get_cloud_ca_cert(),
+                                "ca_cert": utils.get_cloud_ca_cert(),
                                 "policy": utils.get_keystone_auth_default_policy(
                                     self.cluster
                                 ),


### PR DESCRIPTION
Fixes #434 

This is a simpler version of #435 which fixes the original intent of the keystone_auth CA cert handling.