### PR TITLE
Support Kubernetes 1.31.x

### DIFF
--- a/magnum_cluster_api/cmd/image_loader.py
+++ b/magnum_cluster_api/cmd/image_loader.py
@@ -48,6 +48,7 @@ VERSIONS = [
     "v1.28.11",
     "v1.29.6",
     "v1.30.2",
+    "v1.31.1",
 ]
 
 
@@ -245,6 +246,11 @@ def _get_cloud_provider_images():
         "registry.k8s.io/provider-os/cinder-csi-plugin:v1.30.0",
         "registry.k8s.io/provider-os/manila-csi-plugin:v1.30.0",
         "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.0",
+        # v1.31.1
+        "registry.k8s.io/provider-os/k8s-keystone-auth:v1.31.1",
+        "registry.k8s.io/provider-os/cinder-csi-plugin:v1.31.1",
+        "registry.k8s.io/provider-os/manila-csi-plugin:v1.31.1",
+        "registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.31.1",
     ]
 
 

--- a/magnum_cluster_api/conf.py
+++ b/magnum_cluster_api/conf.py
@@ -79,6 +79,11 @@ auto_scaling_opts = [
         default="$image_repository/cluster-autoscaler:v1.30.1",
         help="Image for the cluster auto-scaler for Kubernetes v1.30.",
     ),
+    cfg.StrOpt(
+        "v1_31_image",
+        default="$image_repository/cluster-autoscaler:v1.31.0",
+        help="Image for the cluster auto-scaler for Kubernetes v1.31.",
+    ),
 ]
 
 

--- a/magnum_cluster_api/integrations/common.py
+++ b/magnum_cluster_api/integrations/common.py
@@ -90,6 +90,8 @@ def get_cloud_provider_tag(cluster: objects.Cluster, label: str) -> str:
         tag = "v1.29.0"
     elif version.major == 1 and version.minor == 30:
         tag = "v1.30.0"
+    elif version.major == 1 and version.minor == 31:
+        tag = "v1.31.1"
 
     if tag is None:
         raise ValueError(

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -2039,7 +2039,7 @@ class ClusterClass(Base):
                                         {
                                             "op": "add",
                                             "path": "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-",
-                                            "value": "mkdir /etc/kubernetes/keystone-kustomization",
+                                            "value": "mkdir -p /etc/kubernetes/keystone-kustomization",
                                         },
                                         {
                                             "op": "add",


### PR DESCRIPTION
This  PR adds support for Kubernetes 1.31.x

I have successfully booted a new Kubernetes cluster 1.31.1 
Also, I have tested Kubernetes cluster upgrade from 1.30.2 -> 1.31.1

```
+--------------------------------------+-----------+---------+------------+--------------+-----------------+---------------+
| uuid                                 | name      | keypair | node_count | master_count | status          | health_status |
+--------------------------------------+-----------+---------+------------+--------------+-----------------+---------------+
| e475fe8d-394a-4eb3-af0f-68634f4927ab | cluster_1 | ace     |          2 |            3 | UPDATE_COMPLETE | HEALTHY       |
+--------------------------------------+-----------+---------+------------+--------------+-----------------+---------------+
```

Configuration:
- RockyLinux 9
- Cilium
- OVN

CAPI versions:
```
NAME                       NAMESPACE                           TYPE                     CURRENT VERSION   NEXT VERSION
bootstrap-kubeadm          capi-kubeadm-bootstrap-system       BootstrapProvider        v1.8.4            Already up to date
control-plane-kubeadm      capi-kubeadm-control-plane-system   ControlPlaneProvider     v1.8.4            Already up to date
cluster-api                capi-system                         CoreProvider             v1.8.4            Already up to date
infrastructure-openstack   capo-system                         InfrastructureProvider   v0.10.5           Already up to date
```
Template:
```
os coe cluster template show k8s-v1.31.1-cilium-ovn
+-----------------------+-------------------------------------------------------------------------------------------------------------------------------------+
| Field                 | Value                                                                                                                               |
+-----------------------+-------------------------------------------------------------------------------------------------------------------------------------+
| insecure_registry     | -                                                                                                                                   |
| labels                | {'kube_tag': 'v1.31.1', 'container_infra_prefix': 'gitea.geekhome.org/public', 'fixed_subnet_cidr': '192.168.0.0/24',               |
|                       | 'octavia_provider': 'ovn'}                                                                                                          |
| updated_at            | -                                                                                                                                   |
| floating_ip_enabled   | False                                                                                                                               |
| fixed_subnet          | -                                                                                                                                   |
| master_flavor_id      | 2cpu4ram20hdd                                                                                                                       |
| uuid                  | c0dce5e1-c2d7-439f-a8a2-dc35d0eb0026                                                                                                |
| no_proxy              | -                                                                                                                                   |
| https_proxy           | -                                                                                                                                   |
| tls_disabled          | False                                                                                                                               |
| keypair_id            | -                                                                                                                                   |
| public                | False                                                                                                                               |
| http_proxy            | -                                                                                                                                   |
| docker_volume_size    | -                                                                                                                                   |
| server_type           | vm                                                                                                                                  |
| external_network_id   | vlan77                                                                                                                              |
| cluster_distro        | rockylinux                                                                                                                          |
| image_id              | rockylinux-9-kube-v1.31.1                                                                                                           |
| volume_driver         | -                                                                                                                                   |
| registry_enabled      | False                                                                                                                               |
| docker_storage_driver | overlay2                                                                                                                            |
| apiserver_port        | -                                                                                                                                   |
| name                  | k8s-v1.31.1-cilium-ovn                                                                                                              |
| created_at            | 2024-10-10T18:51:54+00:00                                                                                                           |
| network_driver        | cilium                                                                                                                              |
| fixed_network         | -                                                                                                                                   |
| coe                   | kubernetes                                                                                                                          |
| flavor_id             | 2cpu2ram20hdd                                                                                                                       |
| master_lb_enabled     | True                                                                                                                                |
| dns_nameserver        | 8.8.8.8,8.8.4.4                                                                                                                     |
| project_id            | aaed759d65f54702a6c319f89a7b2ce7                                                                                                    |
| hidden                | False                                                                                                                               |
| tags                  | -                                                                                                                                   |
+-----------------------+-------------------------------------------------------------------------------------------------------------------------------------+
```
Cluster nodes:
```
kubectl get nodes 
NAME                                          STATUS   ROLES                  AGE     VERSION
kube-n3t15-default-worker-j5xbh-n49x4-hwf4r   Ready    worker                 66m     v1.31.1
kube-n3t15-default-worker-j5xbh-n49x4-szrvq   Ready    worker                 2m49s   v1.31.1
kube-n3t15-jn27j-62vxv                        Ready    control-plane,master   84m     v1.31.1
kube-n3t15-jn27j-7jgpx                        Ready    control-plane,master   74m     v1.31.1
kube-n3t15-jn27j-gfbwv                        Ready    control-plane,master   65m     v1.31.1
```
Cluster pods status:
```
kubectl get nodes 
NAME                                          STATUS   ROLES                  AGE     VERSION
kube-n3t15-default-worker-j5xbh-n49x4-hwf4r   Ready    worker                 66m     v1.31.1
kube-n3t15-default-worker-j5xbh-n49x4-szrvq   Ready    worker                 2m49s   v1.31.1
kube-n3t15-jn27j-62vxv                        Ready    control-plane,master   84m     v1.31.1
kube-n3t15-jn27j-7jgpx                        Ready    control-plane,master   74m     v1.31.1
kube-n3t15-jn27j-gfbwv                        Ready    control-plane,master   65m     v1.31.1
```


Also I have to fix directory creation for keystone-kustomization - with -p flag there will be no error, if dir already exists