### PR TITLE
Add support for oslo-config-generator

### DIFF
--- a/magnum_cluster_api/conf.py
+++ b/magnum_cluster_api/conf.py
@@ -141,14 +141,31 @@ common_security_opts = [
     ),
 ]
 
+ALL_GROUPS = [
+    auto_scaling_group,
+    capi_client_group,
+    manila_client_group,
+    proxy_group,
+]
+
+ALL_OPTS = [
+    (auto_scaling_group, auto_scaling_opts),
+    (capi_client_group, capi_client_opts),
+    (capi_client_group, common_security_opts),
+    (manila_client_group, manila_client_opts),
+    (manila_client_group, common_security_opts),
+    (proxy_group, proxy_opts),
+]
+
+
 CONF = cfg.CONF
-CONF.register_group(auto_scaling_group)
-CONF.register_group(capi_client_group)
-CONF.register_group(manila_client_group)
-CONF.register_group(proxy_group)
-CONF.register_opts(auto_scaling_opts, group=auto_scaling_group)
-CONF.register_opts(capi_client_opts, group=capi_client_group)
-CONF.register_opts(common_security_opts, group=capi_client_group)
-CONF.register_opts(manila_client_opts, group=manila_client_group)
-CONF.register_opts(common_security_opts, group=manila_client_group)
-CONF.register_opts(proxy_opts, group=proxy_group)
+
+for group in ALL_GROUPS:
+    CONF.register_group(group)
+
+for group, opts in ALL_OPTS:
+    CONF.register_opts(opts, group=group)
+
+
+def list_opts():
+    return ALL_OPTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,8 @@ magnum-cluster-api-proxy = "magnum_cluster_api.cmd.proxy:main"
 "k8s_cluster_api_flatcar" = "magnum_cluster_api.driver:FlatcarDriver"
 "k8s_cluster_api_rockylinux" = "magnum_cluster_api.driver:RockyLinuxDriver"
 
+[tool.poetry.plugins."oslo.config.opts"]
+magnum_cluster_api = "magnum_cluster_api.conf:list_opts"
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Generate the default config with `oslo-config-generator --namespace magnum_cluster_api`

This patch refactors the config group and option registration to use a common data structure for runtime config and the config generator output.