### PR TITLE
use v1beta1 CRD for capo resources

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -480,7 +480,7 @@ class BaseDriver(driver.Driver):
             }
             image_id_match = all(
                 [
-                    machine.obj["spec"]["imageUUID"] == md_variables["imageUUID"]
+                    machine.obj["spec"]["image"]["id"] == md_variables["imageUUID"]
                     for machine in machines
                 ]
             )

--- a/magnum_cluster_api/objects.py
+++ b/magnum_cluster_api/objects.py
@@ -76,7 +76,7 @@ class ClusterResourceSet(NamespacedAPIObject):
 
 
 class OpenStackMachineTemplate(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
+    version = "infrastructure.cluster.x-k8s.io/v1beta1"
     endpoint = "openstackmachinetemplates"
     kind = "OpenStackMachineTemplate"
 
@@ -157,13 +157,13 @@ class Machine(NamespacedAPIObject):
 
 
 class OpenStackClusterTemplate(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
+    version = "infrastructure.cluster.x-k8s.io/v1beta1"
     endpoint = "openstackclustertemplates"
     kind = "OpenStackClusterTemplate"
 
 
 class OpenStackCluster(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
+    version = "infrastructure.cluster.x-k8s.io/v1beta1"
     endpoint = "openstackclusters"
     kind = "OpenStackCluster"
 
@@ -295,7 +295,7 @@ class Cluster(NamespacedAPIObject):
 
 
 class OpenStackMachine(NamespacedAPIObject):
-    version = "infrastructure.cluster.x-k8s.io/v1alpha7"
+    version = "infrastructure.cluster.x-k8s.io/v1beta1"
     endpoint = "openstackmachines"
     kind = "OpenStackMachine"
 

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -52,6 +52,7 @@ CLUSTER_CLASS_NAME = f"magnum-v{CLUSTER_CLASS_VERSION}"
 CLUSTER_CLASS_NODE_VOLUME_DETACH_TIMEOUT = "300s"  # seconds
 
 PLACEHOLDER = "PLACEHOLDER"
+PLACEHOLDER_UUID = "00000000-0000-0000-0000-000000000000"
 
 AUTOSCALE_ANNOTATION_MIN = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
 AUTOSCALE_ANNOTATION_MAX = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
@@ -803,7 +804,11 @@ class OpenStackMachineTemplate(Base):
                 "spec": {
                     "template": {
                         "spec": {
+                            "image": {
+                                "id": PLACEHOLDER_UUID,
+                            },
                             "identityRef": {
+                                "name": PLACEHOLDER,
                                 "cloudName": "default",
                             },
                             "flavor": PLACEHOLDER,
@@ -829,6 +834,7 @@ class OpenStackClusterTemplate(Base):
                     "template": {
                         "spec": {
                             "identityRef": {
+                                "name": PLACEHOLDER,
                                 "cloudName": "default",
                             },
                             "managedSecurityGroups": {
@@ -1733,7 +1739,7 @@ class ClusterClass(Base):
                                     },
                                     "jsonPatches": [
                                         {
-                                            "op": "add",
+                                            "op": "replace",
                                             "path": "/spec/template/spec/identityRef/name",
                                             "valueFrom": {
                                                 "variable": "clusterIdentityRefName"
@@ -1745,7 +1751,7 @@ class ClusterClass(Base):
                                             "valueFrom": {"variable": "sshKeyName"},
                                         },
                                         {
-                                            "op": "add",
+                                            "op": "replace",
                                             "path": "/spec/template/spec/image/id",
                                             "valueFrom": {"variable": "imageUUID"},
                                         },
@@ -1794,9 +1800,13 @@ class ClusterClass(Base):
                                         },
                                         {
                                             "op": "add",
-                                            "path": "/spec/template/spec/externalNetwork/id",
+                                            "path": "/spec/template/spec/externalNetwork",
                                             "valueFrom": {
-                                                "variable": "externalNetworkId"
+                                                "template": textwrap.dedent(
+                                                    """\
+                                                    id: {{ .externalNetworkId }}
+                                                    """
+                                                ),
                                             },
                                         },
                                     ],


### PR DESCRIPTION
Since capo 0.11, v1alpha7 is deprecated.
This PR includes CRD changes from v1alpha7 to v1beta1.

Closes: https://github.com/vexxhost/magnum-cluster-api/issues/401