### PR TITLE
Allow provide multiple ports with fixed subnets

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -298,6 +298,15 @@ is often accomplished by deploying a driver on each node.
 
    Default value: `soft-anti-affinity`
 
+* `extra_fixed_subnets`
+
+    Extra fixed subnets. This allow us to provide extra subnets for machines in cluster.
+    For example `[{"id": "$extra_subnet_ID1"}, {"id": "$extra_subnet_ID2"}]`
+    This is not a override for the default fixed_subnet but a added-on list.
+    So we can have multiple subnets support (from same fixed network).
+
+   Default value: `None`
+
 ## TODO
 
 availability_zone

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -300,8 +300,8 @@ is often accomplished by deploying a driver on each node.
 
 * `extra_fixed_subnets`
 
-    Extra fixed subnets. This allow us to provide extra subnets for machines in cluster.
-    For example `[{"id": "$extra_subnet_ID1"}, {"id": "$extra_subnet_ID2"}]`
+    Extra fixed subnet names. This allow us to provide extra subnets for machines in cluster.
+    For example `'["$extra_subnet_name1", "$extra_subnet_name2"]'`.
     This is not a override for the default fixed_subnet but a added-on list.
     So we can have multiple subnets support (from same fixed network).
 

--- a/magnum_cluster_api/exceptions.py
+++ b/magnum_cluster_api/exceptions.py
@@ -57,6 +57,10 @@ class ClusterMasterCountEven(Exception):
     pass
 
 
+class ClusterInvalidLabel(exception.Invalid):
+    message = _("Invalid Cluster label %(label)s: %(reason)s.")
+
+
 class UnsupportedCNI(Exception):
     pass
 

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -14,6 +14,7 @@
 
 import abc
 import glob
+import json
 import math
 import os
 import types
@@ -702,7 +703,7 @@ class CloudConfigSecret(ClusterBase):
 
 def mutate_machine_deployment(
     context: context.RequestContext,
-    cluster: objects.Cluster,
+    cluster: magnum_objects.Cluster,
     node_group: magnum_objects.NodeGroup,
     machine_deployment: dict = None,
 ):
@@ -840,7 +841,7 @@ def mutate_machine_deployment(
 
 
 def generate_machine_deployments_for_cluster(
-    context: context.RequestContext, cluster: objects.Cluster
+    context: context.RequestContext, cluster: magnum_objects.Cluster
 ) -> list:
     machine_deployments = []
     for ng in cluster.nodegroups:
@@ -1086,6 +1087,20 @@ class Cluster(ClusterBase):
                                 self.context, self.cluster.fixed_subnet
                             )
                             or "",
+                        },
+                        {
+                            "name": "fixedSubnetIds",
+                            "value": [
+                                (
+                                    neutron.get_fixed_subnet_id(self.context, subnet)
+                                    or ""
+                                )
+                                for subnet in [self.cluster.fixed_subnet or ""]
+                                + json.loads(
+                                    self.cluster.labels.get("extra_fixed_subnets", "[]")
+                                )
+                            ]
+                            or [""],
                         },
                         {
                             "name": "flavor",

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -412,6 +412,14 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
         else:
             neutron.get_subnet(ctx, cluster.fixed_subnet, source="name", target="id")
 
+    if not cluster.fixed_subnet and json.loads(
+        cluster.labels.get("extra_fixed_subnets", "[]")
+    ):
+        raise mcapi_exceptions.ClusterInvalidLabel(
+            label="extra_fixed_subnets",
+            reason="Label `extra_fixed_subnets` requires cluster fixed subnet",
+        )
+
 
 def validate_nodegroup_name(nodegroup: magnum_objects.NodeGroup):
     # Machine requires a lowercase RFC 1123 subdomain name.

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -242,6 +242,7 @@ pub mod fixtures {
             .dns_nameservers(vec!["1.1.1.1".into()])
             .fixed_network_id("".into())
             .fixed_subnet_id("".into())
+            .fixed_subnet_ids(vec!["".into()])
             .openid_connect(
                 openid_connect::OpenIdConnectConfig::builder()
                     .issuer_url("https://example.com".to_string())
@@ -305,7 +306,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 35);
+        assert_eq!(variables.len(), 36);
 
         for var in &variables {
             match var.name.as_str() {
@@ -368,6 +369,9 @@ mod tests {
                 }
                 "fixedSubnetId" => {
                     assert_eq!(var.value, json!(default_values().fixed_subnet_id));
+                }
+                "fixedSubnetIds" => {
+                    assert_eq!(var.value, json!(default_values().fixed_subnet_ids));
                 }
                 "openidConnect" => {
                     assert_eq!(var.value, json!(default_values().openid_connect));


### PR DESCRIPTION
openstack machine ports will allow to set multiple networks to controller and workers by provide extra_fixed_subnets in label of a magnum cluster.
extra subnets for openstack machine ports needs to be set in cluster label.
For example

```
openstack coe cluster template create   --image $(openstack image show ubuntu-2204-kube-${version}s -c id -f value)   --external-network public   --dns-nameserver 8.8.8.8   --master-lb-enabled   --master-flavor m1.medium   --flavor m1.medium   --network-driver calico   --docker-storage-driver overlay2   --coe kubernetes   --fixed-network private   --fixed-subnet private-subnet   --label kube_tag=${version}   --label fixed_subnet_cidr=192.168.2.0/24  \
--label extra_fixed_subnets='[{"name": "private-test-subnet2"}]' --keypair key   k8s-${version}-ports
```