### PR TITLE
Do not convert volume_type name for StorageClass

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -298,7 +298,7 @@ class ClusterResourcesConfigMap(ClusterBase):
                             },
                             "provisioner": "cinder.csi.openstack.org",
                             "parameters": {
-                                "type": utils.convert_to_rfc1123(vt.name),
+                                "type": vt.name,
                             },
                             "reclaimPolicy": "Delete",
                             "volumeBindingMode": "Immediate",


### PR DESCRIPTION
Previous fix [1] has brought a regression to the configuration, where
resulting YAML reffers to non-existent volume type on volume creation.

For instance, given that volume type is set to `default_encrypted`
resulting file will look like this:

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: block-default-encrypted
  uid: 70646c1f-369b-4e5c-b8be-66524120f721
  resourceVersion: '430'
  creationTimestamp: '2024-10-18T09:37:44Z'
  annotations:
    storageclass.kubernetes.io/is-default-class: 'true'
provisioner: cinder.csi.openstack.org
parameters:
  type: default-encrypted
reclaimPolicy: Delete
allowVolumeExpansion: true
volumeBindingMode: Immediate
```

And then volume creation will fail with:
```
failed to provision volume with StorageClass "block-default-encrypted": rpc error: code = Internal desc = CreateVolume failed with error Resource not found: [POST https://cloud.io/volume/v3/92c1a58255c2454fb72ebc66354b66f7/volumes], error message: {"itemNotFound": {"code": 404, "message": "Volume type with name default-encrypted could not be found."}}
```

[1] https://github.com/vexxhost/magnum-cluster-api/commit/7d0f316c85189f69ebe0787e3d24edb2b733501d