### PR TITLE
Add a label to control load-balancer monitor creation

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -129,6 +129,13 @@ is often accomplished by deploying a driver on each node.
    Default value (`amphora` provider): `ROUND_ROBIN`
    Default value (`ovn` provider): `SOURCE_IP_PORT`
 
+* `octavia_lb_healthcheck`
+
+   The Octavia Load Balancer members can be monitored with health monitor.
+   This must be enabled when externalTrafficPolicy is set to `Local`.
+
+   Default value: `True`
+
 ## Container Networking Interface (CNI)
 
 ### Calcio

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -107,6 +107,7 @@ class TestGenerateCloudControllerManagerConfig:
             [LoadBalancer]
             lb-provider=amphora
             lb-method=ROUND_ROBIN
+            create-monitor=True
             """
         )
 
@@ -132,6 +133,33 @@ class TestGenerateCloudControllerManagerConfig:
             [LoadBalancer]
             lb-provider=amphora
             lb-method=ROUND_ROBIN
+            create-monitor=True
+            """
+        )
+
+    def test_generate_cloud_controller_manager_config_for_amphora_without_monitor(self, requests_mock):
+        self.cluster.labels = {"octavia_provider": "ovn", "octavia_lb_healthcheck": "False"}
+
+        with requests_mock as rsps:
+            rsps.add(self._response_for_cloud_config_secret())
+
+            config = utils.generate_cloud_controller_manager_config(
+                self.context, self.pykube_api, self.cluster
+            )
+
+        assert config == textwrap.dedent(
+            """\
+            [Global]
+            auth-url=http://localhost/v3
+            region=RegionOne
+            application-credential-id=fake_application_credential_id
+            application-credential-secret=fake_application_credential_secret
+            tls-insecure=false
+
+            [LoadBalancer]
+            lb-provider=ovn
+            lb-method=SOURCE_IP_PORT
+            create-monitor=False
             """
         )
 
@@ -157,6 +185,7 @@ class TestGenerateCloudControllerManagerConfig:
             [LoadBalancer]
             lb-provider=ovn
             lb-method=SOURCE_IP_PORT
+            create-monitor=True
             """
         )
 
@@ -187,6 +216,7 @@ class TestGenerateCloudControllerManagerConfig:
             [LoadBalancer]
             lb-provider=ovn
             lb-method=SOURCE_IP_PORT
+            create-monitor=True
             """
         )
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -115,6 +115,7 @@ def generate_cloud_controller_manager_config(
 
     octavia_provider = cluster.labels.get("octavia_provider", "amphora")
     octavia_lb_algorithm = cluster.labels.get("octavia_lb_algorithm")
+    octavia_lb_healthcheck = cluster.labels.get("octavia_lb_healthcheck", True)
 
     if octavia_provider == "amphora" and octavia_lb_algorithm is None:
         octavia_lb_algorithm = "ROUND_ROBIN"
@@ -137,6 +138,7 @@ def generate_cloud_controller_manager_config(
         [LoadBalancer]
         lb-provider={octavia_provider}
         lb-method={octavia_lb_algorithm}
+        create-monitor={octavia_lb_healthcheck}
         """
     )
 


### PR DESCRIPTION
There are usecases when creation of load balancer monitors are required.
Let's add a corresponsive label to control behaviour of monitors
creation.
Default value is set in accordance with CCM.

[1] https://github.com/kubernetes/cloud-provider-openstack/blob/5ed0a04dc732d0e9bf70ddd3beaccdabd3841957/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md?plain=1#L231-L232