### PR TITLE
chore: upgrade capo version to 0.11.2

### DIFF
--- a/hack/setup-capo.sh
+++ b/hack/setup-capo.sh
@@ -20,7 +20,7 @@ export GOPROXY=off
 
 # Versions to test
 CAPI_VERSION=${CAPI_VERSION:-v1.8.4}
-CAPO_VERSION=${CAPO_VERSION:-v0.11.0}
+CAPO_VERSION=${CAPO_VERSION:-v0.11.2}
 
 # Install the `clusterctl` CLI
 sudo curl -Lo /usr/local/bin/clusterctl https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/clusterctl-linux-amd64


### PR DESCRIPTION
motivation: bug fix for incorrect sg applying
ref: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/tag/v0.11.1