### PR TITLE
Use calico images from quay.io for workload clusters

### DIFF
--- a/magnum_cluster_api/cmd/image_loader.py
+++ b/magnum_cluster_api/cmd/image_loader.py
@@ -177,9 +177,9 @@ def _get_kubeadm_images(version: str):
 
 def _get_calico_images(tag="v3.24.2"):
     return [
-        f"docker.io/calico/cni:{tag}",
-        f"docker.io/calico/kube-controllers:{tag}",
-        f"docker.io/calico/node:{tag}",
+        f"quay.io/calico/cni:{tag}",
+        f"quay.io/calico/kube-controllers:{tag}",
+        f"quay.io/calico/node:{tag}",
     ]
 
 

--- a/magnum_cluster_api/image_utils.py
+++ b/magnum_cluster_api/image_utils.py
@@ -57,6 +57,8 @@ def get_image(name: str, repository: str = None):
         return name
 
     new_image_name = name
+    if name.startswith("quay.io/calico"):
+        new_image_name = name.replace("quay.io/calico/", f"{repository}/calico/")
     if name.startswith("docker.io/calico"):
         new_image_name = name.replace("docker.io/calico/", f"{repository}/calico/")
     if name.startswith("quay.io/cilium"):

--- a/magnum_cluster_api/manifests/calico/v3.24.2.yaml
+++ b/magnum_cluster_api/manifests/calico/v3.24.2.yaml
@@ -4390,7 +4390,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.24.2
+          image: quay.io/calico/cni:v3.24.2
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4418,7 +4418,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.24.2
+          image: quay.io/calico/cni:v3.24.2
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4461,7 +4461,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.24.2
+          image: quay.io/calico/node:v3.24.2
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4487,7 +4487,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.24.2
+          image: quay.io/calico/node:v3.24.2
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4704,7 +4704,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.24.2
+          image: quay.io/calico/kube-controllers:v3.24.2
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/magnum_cluster_api/manifests/calico/v3.25.2.yaml
+++ b/magnum_cluster_api/manifests/calico/v3.25.2.yaml
@@ -4440,7 +4440,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.25.2
+          image: quay.io/calico/cni:v3.25.2
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4468,7 +4468,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.25.2
+          image: quay.io/calico/cni:v3.25.2
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4511,7 +4511,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.25.2
+          image: quay.io/calico/node:v3.25.2
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4537,7 +4537,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.25.2
+          image: quay.io/calico/node:v3.25.2
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4754,7 +4754,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.25.2
+          image: quay.io/calico/kube-controllers:v3.25.2
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/magnum_cluster_api/manifests/calico/v3.26.5.yaml
+++ b/magnum_cluster_api/manifests/calico/v3.26.5.yaml
@@ -4639,7 +4639,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.5
+          image: quay.io/calico/cni:v3.26.5
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4667,7 +4667,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.5
+          image: quay.io/calico/cni:v3.26.5
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4710,7 +4710,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.5
+          image: quay.io/calico/node:v3.26.5
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4736,7 +4736,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.5
+          image: quay.io/calico/node:v3.26.5
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4953,7 +4953,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.5
+          image: quay.io/calico/kube-controllers:v3.26.5
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/magnum_cluster_api/manifests/calico/v3.27.4.yaml
+++ b/magnum_cluster_api/manifests/calico/v3.27.4.yaml
@@ -4777,7 +4777,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.27.4
+          image: quay.io/calico/cni:v3.27.4
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4805,7 +4805,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.27.4
+          image: quay.io/calico/cni:v3.27.4
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4848,7 +4848,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.27.4
+          image: quay.io/calico/node:v3.27.4
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4874,7 +4874,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.27.4
+          image: quay.io/calico/node:v3.27.4
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -5094,7 +5094,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.27.4
+          image: quay.io/calico/kube-controllers:v3.27.4
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/magnum_cluster_api/manifests/calico/v3.28.2.yaml
+++ b/magnum_cluster_api/manifests/calico/v3.28.2.yaml
@@ -4796,7 +4796,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.28.2
+          image: quay.io/calico/cni:v3.28.2
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4824,7 +4824,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.28.2
+          image: quay.io/calico/cni:v3.28.2
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4867,7 +4867,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.28.2
+          image: quay.io/calico/node:v3.28.2
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4893,7 +4893,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.28.2
+          image: quay.io/calico/node:v3.28.2
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -5113,7 +5113,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.28.2
+          image: quay.io/calico/kube-controllers:v3.28.2
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/magnum_cluster_api/manifests/calico/v3.29.0.yaml
+++ b/magnum_cluster_api/manifests/calico/v3.29.0.yaml
@@ -6107,7 +6107,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.29.0
+          image: quay.io/calico/cni:v3.29.0
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -6135,7 +6135,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.29.0
+          image: quay.io/calico/cni:v3.29.0
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -6178,7 +6178,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.29.0
+          image: quay.io/calico/node:v3.29.0
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -6204,7 +6204,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.29.0
+          image: quay.io/calico/node:v3.29.0
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -6427,7 +6427,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.29.0
+          image: quay.io/calico/kube-controllers:v3.29.0
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/tools/sync-calico
+++ b/tools/sync-calico
@@ -24,3 +24,7 @@ declare -a VERSIONS=(
 for i in "${VERSIONS[@]}"; do
   curl -q https://raw.githubusercontent.com/projectcalico/calico/${i}/manifests/calico.yaml > magnum_cluster_api/manifests/calico/${i}.yaml
 done
+
+for i in magnum_cluster_api/manifests/calico/* ; do
+    sed -i '' -e 's/docker\.io/quay\.io/g' "${i}"
+done


### PR DESCRIPTION
Instead of getting these from docker.io and running into rate limits use images from quay.io