### PR TITLE
fix dns server list issue when specified with more than one

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -2048,7 +2048,10 @@ class ClusterClass(Base):
                                             "template": textwrap.dedent(
                                                 """\
                                                     - cidr: {{ .nodeCidr }}
-                                                      dnsNameservers: {{ .dnsNameservers }}
+                                                      dnsNameservers:
+                                                     {{- range .dnsNameservers }}
+                                                        - {{ . }}
+                                                     {{- end }}
                                                     """
                                             ),
                                         },

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -189,7 +189,7 @@ def cluster_template(context, image, kube_tag):
         image_id=image["id"],
         master_lb_enabled=True,
         external_network_id=uuidutils.generate_uuid(),
-        dns_nameserver="8.8.8.8",
+        dns_nameserver="8.8.8.8,1.1.1.1",
         master_flavor_id=uuidutils.generate_uuid(),
         flavor_id=uuidutils.generate_uuid(),
         cluster_distro="ubuntu",


### PR DESCRIPTION
In magnum template when specify more than one dns servers,the cluster using that template fail to create due to dns list being regard as string
https://github.com/gophercloud/gophercloud/blob/main/openstack/networking/v2/subnets/requests.go#L125C1-L125C60