### PR TITLE
Add AZ, Flavor, and Floating IP labels for apiServerLoadBalancer

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1068,12 +1068,27 @@ class ClusterClass(Base):
                                     "provider": {
                                         "type": "string",
                                     },
+                                    "availabilityZone": {
+                                        "type": "string",
+                                    },
+                                    "flavor": {
+                                        "type": "string",
+                                    },                                    
                                 },
                             },
                         },
                     },
                     {
                         "name": "apiServerTLSCipherSuites",
+                        "required": True,
+                        "schema": {
+                            "openAPIV3Schema": {
+                                "type": "string",
+                            },
+                        },
+                    },
+                    {
+                        "name": "apiServerFloatingIP",
                         "required": True,
                         "schema": {
                             "openAPIV3Schema": {
@@ -2029,6 +2044,30 @@ class ClusterClass(Base):
                         ],
                     },
                     {
+                        "name": "apiServerFloatingIP",
+                        "enabledIf": '{{ if ne .apiServerFloatingIP "" }}true{{end}}',
+                        "definitions": [
+                            {
+                                "selector": {
+                                    "apiVersion": objects.OpenStackClusterTemplate.version,
+                                    "kind": objects.OpenStackClusterTemplate.kind,
+                                    "matchResources": {
+                                        "infrastructureCluster": True,
+                                    },
+                                },
+                                "jsonPatches": [
+                                    {
+                                        "op": "add",
+                                        "path": "/spec/template/spec/apiServerFloatingIP",
+                                        "valueFrom": {
+                                            "variable": "apiServerFloatingIP"
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
                         "name": "newNetworkConfig",
                         "enabledIf": '{{ if eq .fixedNetworkId "" }}true{{end}}',
                         "definitions": [
@@ -2754,6 +2793,12 @@ class Cluster(ClusterBase):
                                 "provider": self.cluster.labels.get(
                                     "octavia_provider", "amphora"
                                 ),
+                                "availabilityZone": self.cluster.labels.get(
+                                    "api_lb_availability_zone", ""
+                                ),			
+                                "flavor": self.cluster.labels.get(
+                                    "api_lb_flavor", ""
+                                ),	
                             },
                         },
                         {
@@ -2763,6 +2808,12 @@ class Cluster(ClusterBase):
                                 "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",  # noqa: E501
                             ),
                         },
+                        {
+                            "name": "apiServerFloatingIP",
+                            "value": self.cluster.labels.get(
+                                "api_server_floating_ip", ""
+                            ),
+                        },     
                         {
                             "name": "openidConnect",
                             "value": {


### PR DESCRIPTION
Users can choose AZ, Flavor and specify a Floating IP for their apiServerLoadBalancer. This is useful for multi-AZ systems.