### PR TITLE
feat: add tolerations for csi controllerPlugin manifests

### DIFF
--- a/magnum_cluster_api/manifests/cinder-csi/cinder-csi-controllerplugin-rbac.yaml
+++ b/magnum_cluster_api/manifests/cinder-csi/cinder-csi-controllerplugin-rbac.yaml
@@ -81,6 +81,7 @@ rules:
   - watch
   - create
   - delete
+  - patch
 - apiGroups:
   - ''
   resources:

--- a/magnum_cluster_api/manifests/cinder-csi/cinder-csi-controllerplugin.yaml
+++ b/magnum_cluster_api/manifests/cinder-csi/cinder-csi-controllerplugin.yaml
@@ -27,7 +27,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
         imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
@@ -43,7 +43,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.1
+        image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
@@ -57,7 +57,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
         imagePullPolicy: Always
         name: csi-snapshotter
         volumeMounts:
@@ -71,7 +71,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
         imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
@@ -82,7 +82,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
         name: liveness-probe
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -92,6 +92,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
         - --cluster=$(CLUSTER_NAME)
+        - --pvc-annotations
         - --v=1
         env:
         - name: CSI_ENDPOINT
@@ -100,7 +101,7 @@ spec:
           value: /etc/config/cloud.conf
         - name: CLUSTER_NAME
           value: kubernetes
-        image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.28.0
+        image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.32.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -127,6 +128,11 @@ spec:
       securityContext:
         runAsUser: 0
       serviceAccount: csi-cinder-controller-sa
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - emptyDir: null
         name: socket-dir

--- a/magnum_cluster_api/manifests/cinder-csi/cinder-csi-nodeplugin.yaml
+++ b/magnum_cluster_api/manifests/cinder-csi/cinder-csi-nodeplugin.yaml
@@ -25,7 +25,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         volumeMounts:
@@ -35,7 +35,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -43,6 +43,7 @@ spec:
       - args:
         - /bin/cinder-csi-plugin
         - --endpoint=$(CSI_ENDPOINT)
+        - --provide-controller-service=false
         - --cloud-config=$(CLOUD_CONFIG)
         - --v=1
         env:
@@ -50,7 +51,7 @@ spec:
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG
           value: /etc/config/cloud.conf
-        image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.28.0
+        image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.32.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5

--- a/magnum_cluster_api/manifests/manila-csi/csi-controllerplugin.yaml
+++ b/magnum_cluster_api/manifests/manila-csi/csi-controllerplugin.yaml
@@ -38,10 +38,11 @@ spec:
       containers:
       - args:
         - --csi-address=$(ADDRESS)
+        - --extra-create-metadata
         env:
         - name: ADDRESS
           value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi-controllerplugin.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
         imagePullPolicy: IfNotPresent
         name: provisioner
         volumeMounts:
@@ -52,7 +53,7 @@ spec:
         env:
         - name: ADDRESS
           value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi-controllerplugin.sock
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
         imagePullPolicy: IfNotPresent
         name: snapshotter
         volumeMounts:
@@ -64,7 +65,7 @@ spec:
         env:
         - name: ADDRESS
           value: unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi-controllerplugin.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
         imagePullPolicy: IfNotPresent
         name: resizer
         volumeMounts:
@@ -73,8 +74,9 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - /bin/manila-csi-plugin --nodeid=$(NODE_ID) --endpoint=$(CSI_ENDPOINT) --drivername=$(DRIVER_NAME)
+        - /bin/manila-csi-plugin --endpoint=$(CSI_ENDPOINT) --drivername=$(DRIVER_NAME)
           --share-protocol-selector=$(MANILA_SHARE_PROTO) --fwdendpoint=$(FWD_CSI_ENDPOINT)
+          --pvc-annotations
         env:
         - name: DRIVER_NAME
           value: manila.csi.openstack.org
@@ -109,6 +111,11 @@ spec:
           name: cloud-ca-cert-volume
           readOnly: true
       serviceAccountName: openstack-manila-csi-controllerplugin
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - hostPath:
           path: /var/lib/kubelet/plugins/manila.csi.openstack.org

--- a/magnum_cluster_api/manifests/manila-csi/csi-nodeplugin.yaml
+++ b/magnum_cluster_api/manifests/manila-csi/csi-nodeplugin.yaml
@@ -26,7 +26,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -44,7 +44,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - /bin/manila-csi-plugin --nodeid=$(NODE_ID) --endpoint=$(CSI_ENDPOINT) --drivername=$(DRIVER_NAME)
+        - /bin/manila-csi-plugin --endpoint=$(CSI_ENDPOINT) --drivername=$(DRIVER_NAME)
           --share-protocol-selector=$(MANILA_SHARE_PROTO) --fwdendpoint=$(FWD_CSI_ENDPOINT)
         env:
         - name: DRIVER_NAME

--- a/tools/sync-cinder-csi-manifests
+++ b/tools/sync-cinder-csi-manifests
@@ -69,6 +69,16 @@ for manifest in MANIFESTS:
                     },
                 }
             )
+            doc["spec"]["template"]["spec"]["tolerations"] = [
+                {
+                    "effect": "NoSchedule",
+                    "key": "node-role.kubernetes.io/master",
+                },
+                {
+                    "effect": "NoSchedule",
+                    "key": "node-role.kubernetes.io/control-plane",
+                }
+            ]
 
             # NOTE(mnaser): We need to run as root in order to read the `cloud.conf`
             #               file from the host.

--- a/tools/sync-manila-csi-manifests
+++ b/tools/sync-manila-csi-manifests
@@ -91,6 +91,17 @@ for manifest in MANIFESTS:
                 }
             )
 
+            doc["spec"]["template"]["spec"]["tolerations"] = [
+                {
+                    "effect": "NoSchedule",
+                    "key": "node-role.kubernetes.io/master",
+                },
+                {
+                    "effect": "NoSchedule",
+                    "key": "node-role.kubernetes.io/control-plane",
+                }
+            ]
+
         if doc["kind"] == "DaemonSet":
             doc["spec"]["template"]["spec"]["containers"][1]["env"][3][
                 "value"


### PR DESCRIPTION
Although zero-worker node cluster with autoscaling has been implemented, clusters keep at least one worker node because of these components scheduled on worker nodes.