### PR TITLE
fix: continue, dont return in sync_kubeconfigs

### DIFF
--- a/magnum_cluster_api/proxy/manager.py
+++ b/magnum_cluster_api/proxy/manager.py
@@ -291,7 +291,7 @@ class ProxyManager(periodic_task.PeriodicTasks):
                     "Kubeconfig secret %s does not exist",
                     cluster.kubeconfig_secret_name,
                 )
-                return
+                continue
 
             # Get the kubeconfig from the secret
             kubeconfig = base64.b64decode(secret.obj["data"]["value"]).decode("utf-8")


### PR DESCRIPTION
When syncing kubeconfigs, we return if we aren't able to find a
secret which isn't right, since that can block the whole loop
of execution.
