### PR TITLE
fix: enable deleting missing machine deployment

### DIFF
--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -432,9 +432,7 @@ class TestDriver:
         assert self.node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS
         self.node_group.save.assert_called_once()
 
-    def test_delete_missing_nodegroup(
-        self, context, ubuntu_driver, requests_mock
-    ):
+    def test_delete_missing_nodegroup(self, context, ubuntu_driver, requests_mock):
         self.cluster.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
 
         with requests_mock as rsps:

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -19,6 +19,7 @@ import openstack
 import pykube
 import pytest
 import responses
+from heatclient import exc  # type: ignore
 from magnum.objects import fields  # type: ignore
 from magnum.tests.unit.objects import utils  # type: ignore
 from novaclient.v2 import flavors  # type: ignore
@@ -289,16 +290,17 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
-    def setup_node_group_tests(self, rsps, before, after):
+    def setup_node_group_tests(self, rsps, before, after=None):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),
         )
-        rsps.add(
-            self._response_for_cluster_with_machine_deployments(
-                *after,
-                method=responses.PATCH,
+        if after:
+            rsps.add(
+                self._response_for_cluster_with_machine_deployments(
+                    *after,
+                    method=responses.PATCH,
+                )
             )
-        )
 
     def test_create_nodegroup(self, context, ubuntu_driver, requests_mock):
         self.cluster.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
@@ -429,3 +431,25 @@ class TestDriver:
 
         assert self.node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS
         self.node_group.save.assert_called_once()
+
+    def test_delete_missing_nodegroup(
+        self, context, ubuntu_driver, requests_mock
+    ):
+        self.cluster.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
+
+        with requests_mock as rsps:
+            self.setup_node_group_tests(
+                rsps,
+                before=[
+                    {
+                        "name": "unrelated-machine-deployment",
+                        "replicas": 1,
+                        "metadata": {
+                            "annotations": {},
+                        },
+                    }
+                ],
+            )
+
+            with pytest.raises(exc.HTTPNotFound):
+                ubuntu_driver.delete_nodegroup(context, self.cluster, self.node_group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "semver>=2.0.0",
   "sherlock>=0.4.1",
   "shortuuid",
-  "python-heatclient>=3.5.0",
+  "python-heatclient",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "semver>=2.0.0",
   "sherlock>=0.4.1",
   "shortuuid",
+  "python-heatclient>=3.5.0",
 ]
 
 [dependency-groups]

--- a/src/addons/cloud_controller_manager.rs
+++ b/src/addons/cloud_controller_manager.rs
@@ -58,7 +58,7 @@ impl ClusterAddonValues for CloudControllerManagerValues {
                 format!(
                     "{}/{}",
                     registry.trim_end_matches('/'),
-                    image.name.split('/').last().unwrap()
+                    image.name.split('/').next_back().unwrap()
                 )
             }
             None => image.to_string(),

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "magnum-cluster-api"
-version = "0.28.0"
+version = "0.29.3"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
@@ -1114,6 +1114,8 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pykube-ng" },
     { name = "pyroute2" },
+    { name = "python-heatclient", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "python-heatclient", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "python-manilaclient", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "python-manilaclient", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
@@ -1150,6 +1152,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=2.4.0" },
     { name = "pykube-ng" },
     { name = "pyroute2", specifier = ">=0.3.4" },
+    { name = "python-heatclient", specifier = ">=3.5.0" },
     { name = "python-manilaclient", specifier = ">=3.3.2" },
     { name = "requests", specifier = ">=2.27.1" },
     { name = "semver", specifier = ">=2.0.0" },


### PR DESCRIPTION
If a MachineDeployment is missing, we end up not being able
to get rid of it with any way.  This patch changes the
exception to reraise the HTTPNotFound which will make Magnum
destroy the database object.

Closes: #639
