### PR TITLE
Fix csi manila upgrade case

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -338,7 +338,7 @@ class CloudProviderClusterResourcesSecret(ClusterBase):
                                 "allowVolumeExpansion": True,
                                 "kind": objects.StorageClass.kind,
                                 "metadata": {
-                                    "name": "share-%s"
+                                    "name": "share-nfs-%s"
                                     % utils.convert_to_rfc1123(st.name),
                                 },
                                 "provisioner": "nfs.manila.csi.openstack.org",

--- a/src/addons/cinder_csi.rs
+++ b/src/addons/cinder_csi.rs
@@ -200,8 +200,8 @@ impl ClusterAddon for Addon {
         Self { cluster }
     }
 
-    fn enabled(&self) -> bool {
-        self.cluster.labels.cinder_csi_enabled
+    fn enabled(&self) ->  bool {
+        self.cluster.labels.cinder_csi_enabled.parse::<bool>().expect("failed to fetch cluster label")
     }
 
     fn secret_name(&self) -> Result<String, ClusterError> {

--- a/src/addons/manila_csi.rs
+++ b/src/addons/manila_csi.rs
@@ -128,8 +128,8 @@ impl ClusterAddon for Addon {
         Self { cluster }
     }
 
-    fn enabled(&self) -> bool {
-        self.cluster.labels.manila_csi_enabled
+    fn enabled(&self) ->  bool {
+        self.cluster.labels.manila_csi_enabled.parse::<bool>().expect("failed to fetch cluster label")
     }
 
     fn secret_name(&self) -> Result<String, ClusterError> {

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -37,9 +37,9 @@ pub struct ClusterLabels {
     pub cilium_ipv4pool: String,
 
     /// Enable the use of the Cinder CSI driver for the cluster.
-    #[builder(default = true)]
-    #[pyo3(default = true)]
-    pub cinder_csi_enabled: bool,
+    #[builder(default = "true".to_owned())]
+    #[pyo3(default = "true".to_owned())]
+    pub cinder_csi_enabled: String,
 
     /// The tag of the Cinder CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
@@ -47,9 +47,9 @@ pub struct ClusterLabels {
     pub cinder_csi_plugin_tag: String,
 
     /// Enable the use of the Manila CSI driver for the cluster.
-    #[builder(default = true)]
-    #[pyo3(default = true)]
-    pub manila_csi_enabled: bool,
+    #[builder(default = "true".to_owned())]
+    #[pyo3(default = "true".to_owned())]
+    pub manila_csi_enabled: String,
 
     /// The tag of the Manila CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]


### PR DESCRIPTION
Fix manila storageclass upgrade
`provisioner` is immutable. for PV. PV in cluster that is built with storageclass that changes `provisioner` will not be able to upgrade to new storageclass. As we use same storageclass name, old cluster is forcing to upgrade to new storageclass and fail as it ask for `provisioner` change in PV.

Fix cinder_csi_enabled and manila_csi_enabled type
These two type are passing as string in cluster.labels not bool.

Relate to https://github.com/vexxhost/magnum-cluster-api/issues/740