### PR TITLE
set failureDomain as none instead of empty string

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -782,7 +782,7 @@ def mutate_machine_deployment(
         {
             "class": "default-worker",
             "name": node_group.name,
-            "failureDomain": node_group.labels.get("availability_zone", ""),
+            "failureDomain": node_group.labels.get("availability_zone"),
             "machineHealthCheck": {"enable": utils.get_auto_healing_enabled(cluster)},
             "variables": {
                 "overrides": [


### PR DESCRIPTION
https://github.com/kubernetes-sigs/cluster-api/issues/12661

this is a pre-req change to upgrade CAPI to v1.10