### PR TITLE
Fix empty proxy configuration breaking CAPI validation

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1121,13 +1121,13 @@ class Cluster(ClusterBase):
                         {
                             "name": "systemdProxyConfig",
                             "value": base64.encode_as_text(
-                                utils.generate_systemd_proxy_config(self.cluster)
+                                utils.generate_systemd_proxy_config(self.cluster) or "#"
                             ),
                         },
                         {
                             "name": "aptProxyConfig",
                             "value": base64.encode_as_text(
-                                utils.generate_apt_proxy_config(self.cluster)
+                                utils.generate_apt_proxy_config(self.cluster) or "#"
                             ),
                         },
                         {


### PR DESCRIPTION
Fixes vexxhost/magnum-cluster-api#790

When HTTP/HTTPS proxy is not configured, empty strings returned by generate_systemd_proxy_config() and generate_apt_proxy_config() were being base64-encoded and causing YAML parsing errors in Cluster API.

The issue occurs because:
1. utils.generate_systemd_proxy_config() returns "" when no proxy is set
2. utils.generate_apt_proxy_config() returns "" when no proxy is set
3. These empty strings get base64-encoded in resources.py
4. When CAPI decodes them, empty values break cloud-init YAML parsing
5. Cluster creation fails with validation errors

The fix:
- Use "or '#'" fallback in resources.py when encoding proxy configs
- When proxy functions return "", the fallback "#" is used instead
- "#" is a comment character in both systemd and apt config files
- Base64-encoding "#" is safe and doesn't break YAML parsing
- Clusters with actual proxy configs continue to work normally

Changes:
- magnum_cluster_api/resources.py: Add "or '#'" fallback to proxy config encoding
- magnum_cluster_api/tests/unit/test_resources.py: Add comprehensive unit tests

Test coverage includes:
1. Clusters without proxy configuration (fallback to "#")
2. Clusters with proxy configuration (actual config encoded)
3. Critical test ensuring empty strings are never encoded

This is a minimal, safe fix that:
- Prevents cluster creation failures
- Has no impact on existing proxy-enabled clusters
- Uses a harmless comment character as fallback
- Is compatible with all configuration file formats

Related issue: https://github.com/vexxhost/magnum-cluster-api/issues/790