### PR TITLE
feat: add support for Cilium HubbleUI

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -150,6 +150,16 @@ is often accomplished by deploying a driver on each node.
    Default value: `v3.24.2`
    Supported values: `v3.24.2`, `v3.25.2`, `v3.26.5`, `v3.27.4`, `v3.28.2`, `v3.29.0`
 
+### Cilium
+
+* `cilium_hubble_ui_enabled`
+
+   Enable the Cilium Hubble UI for network observability. When enabled, both
+   the Hubble Relay and Hubble UI components are deployed, allowing users to
+   visualize network flows and service dependencies in their clusters.
+
+   Default value: `false`
+
 ## Container Storage Interface (CSI)
 
 ### Cinder

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -36,6 +36,12 @@ pub struct ClusterLabels {
     #[pyo3(default="10.100.0.0/16".to_owned())]
     pub cilium_ipv4pool: String,
 
+    /// Enable the Cilium Hubble UI for network observability.
+    /// Note: OpenStack labels are always strings, so this accepts "true"/"false".
+    #[builder(default="false".to_owned())]
+    #[pyo3(default="false".to_owned())]
+    pub cilium_hubble_ui_enabled: String,
+
     /// Enable the use of the Cinder CSI driver for the cluster.
     #[builder(default = true)]
     #[pyo3(default = true)]
@@ -106,6 +112,12 @@ pub struct ClusterLabels {
 
 impl ClusterLabels {
     const DEFAULT_CLOUD_PROVIDER_TAG: &'static str = "v1.34.1";
+
+    /// Returns true if Cilium Hubble UI is enabled.
+    /// Parses the string label value "true"/"false" to a boolean.
+    pub fn is_cilium_hubble_ui_enabled(&self) -> bool {
+        self.cilium_hubble_ui_enabled.eq_ignore_ascii_case("true")
+    }
 
     pub fn get_cloud_provider_tag(&self) -> String {
         if let Some(tag) = &self.cloud_provider_tag {


### PR DESCRIPTION
Add cilium_hubble_ui_enabled cluster label to enable Cilium's Hubble UI for network observability. When enabled, both the Hubble Relay and Hubble UI components are deployed, allowing users to visualize network flows and service dependencies in their clusters.

Closes: MCAPI-9