### PR TITLE
fix: pass availability zone to boot (root) volumes

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -24,6 +24,13 @@ specify the volume size and type using the following labels:
 :   The volume type of the boot volume.
     **Default value**: Default volume
 
+`boot_volume_az`
+
+:   The availability zone for the boot volume.  This is useful when the volume
+    type backend is tied to a specific availability zone that differs from the
+    compute availability zone.
+    **Default value**: Falls back to `availability_zone` label, then empty
+
 `etcd_volume_size`
 
 :   The size in gigabytes of the `etcd` volume.  If you set this value, it will

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1122,6 +1122,13 @@ class Cluster(ClusterBase):
                             },
                         },
                         {
+                            "name": "bootVolumeAvailabilityZone",
+                            "value": self.cluster.labels.get(
+                                "boot_volume_az",
+                                self.cluster.labels.get("availability_zone", ""),
+                            ),
+                        },
+                        {
                             "name": "clusterIdentityRefName",
                             "value": utils.get_cluster_api_cloud_config_secret_name(
                                 self.cluster

--- a/src/features/boot_volume.rs
+++ b/src/features/boot_volume.rs
@@ -34,6 +34,9 @@ pub struct BootVolumeConfig {
 pub struct FeatureValues {
     #[serde(rename = "bootVolume")]
     pub boot_volume: BootVolumeConfig,
+
+    #[serde(rename = "bootVolumeAvailabilityZone")]
+    pub boot_volume_availability_zone: String,
 }
 
 pub struct Feature {}
@@ -61,9 +64,18 @@ impl ClusterFeaturePatches for Feature {
                     op: "add".into(),
                     path: "/spec/template/spec/rootVolume".into(),
                     value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
-                        template: Some(indoc!("
-                            type: {{ .bootVolume.type }}
-                            sizeGiB: {{ .bootVolume.size }}").to_string(),
+                        template: Some(
+                            indoc!(
+                                r#"
+                                type: {{ .bootVolume.type }}
+                                sizeGiB: {{ .bootVolume.size }}
+                                {{- if .bootVolumeAvailabilityZone }}
+                                availabilityZone:
+                                  name: "{{ .bootVolumeAvailabilityZone }}"
+                                {{- end }}
+                                "#
+                            )
+                            .into(),
                         ),
                         ..Default::default()
                     }),
@@ -83,7 +95,10 @@ inventory::submit! {
 mod tests {
     use super::*;
     use crate::{
-        cluster_api::openstackmachinetemplates::OpenStackMachineTemplateTemplateSpecRootVolume,
+        cluster_api::openstackmachinetemplates::{
+            OpenStackMachineTemplateTemplateSpecRootVolume,
+            OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone,
+        },
         features::test::TestClusterResources, resources::fixtures::default_values,
     };
     use pretty_assertions::assert_eq;
@@ -97,6 +112,58 @@ mod tests {
             .r#type("ssd".into())
             .size(10)
             .build();
+        values.boot_volume_availability_zone = "az1".into();
+
+        let patches = feature.patches();
+
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        assert_eq!(
+            resources
+                .control_plane_openstack_machine_template
+                .spec
+                .template
+                .spec
+                .root_volume,
+            Some(OpenStackMachineTemplateTemplateSpecRootVolume {
+                r#type: Some(values.clone().boot_volume.r#type),
+                size_gi_b: values.clone().boot_volume.size,
+                availability_zone: Some(OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone {
+                    name: Some(values.clone().boot_volume_availability_zone),
+                    ..Default::default()
+                }),
+            })
+        );
+
+        assert_eq!(
+            resources
+                .worker_openstack_machine_template
+                .spec
+                .template
+                .spec
+                .root_volume,
+            Some(OpenStackMachineTemplateTemplateSpecRootVolume {
+                r#type: Some(values.clone().boot_volume.r#type),
+                size_gi_b: values.clone().boot_volume.size,
+                availability_zone: Some(OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone {
+                    name: Some(values.clone().boot_volume_availability_zone),
+                    ..Default::default()
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn test_enabled_without_availability_zone() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.boot_volume = BootVolumeConfig::builder()
+            .r#type("ssd".into())
+            .size(10)
+            .build();
+        values.boot_volume_availability_zone = "".into();
 
         let patches = feature.patches();
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -204,6 +204,7 @@ pub mod fixtures {
                     .build(),
             )
             .boot_volume(boot_volume::BootVolumeConfig::builder().r#type("nvme".into()).size(0).build())
+            .boot_volume_availability_zone("".into())
             .cluster_identity_ref_name("identity-ref-name".into())
             .containerd_config(
                 BASE64_STANDARD.encode(indoc! {r#"
@@ -309,7 +310,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 37);
+        assert_eq!(variables.len(), 38);
 
         for var in &variables {
             match var.name.as_str() {
@@ -324,6 +325,9 @@ mod tests {
                 }
                 "bootVolume" => {
                     assert_eq!(var.value, json!(default_values().boot_volume));
+                }
+                "bootVolumeAvailabilityZone" => {
+                    assert_eq!(var.value, json!(default_values().boot_volume_availability_zone));
                 }
                 "clusterIdentityRefName" => {
                     assert_eq!(var.value, json!(default_values().cluster_identity_ref_name));


### PR DESCRIPTION
When using boot_volume_type label, CAPO defaults the root volume AZ to the machine's failure domain instead of the cluster's availability_zone label. This causes volume creation failures when the volume type backend is tied to a specific AZ (e.g. nova) but the machine gets scheduled to a different AZ.

This adds a new boot_volume_az label that allows explicitly setting the AZ for boot volumes, separate from the compute AZ. It falls back to the availability_zone label if not set.