### PR TITLE
ci: drop pkg_resources and enable Zuul unit test job

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -14,11 +14,11 @@
 
 import abc
 import glob
-import importlib.resources
 import math
 import os
 import types
 import typing
+from importlib import resources as importlib_resources
 
 import certifi
 import pykube  # type: ignore
@@ -61,43 +61,44 @@ class ClusterAutoscalerHelmRelease:
     def __init__(self, api, cluster) -> None:
         self.cluster = cluster
 
-    @property
     def apply(self):
         image = images.get_cluster_autoscaler_image(
             utils.get_kube_tag(self.cluster),
         )
         image_repo, image_tag = image.split(":", 1)
 
-        return helm.UpgradeReleaseCommand(
-            namespace="magnum-system",
-            release_name=self.cluster.stack_id,
-            chart_ref=os.path.join(
-                str(importlib.resources.files("magnum_cluster_api").joinpath("charts")),
-                "cluster-autoscaler/",
-            ),
-            values={
-                "fullnameOverride": f"{self.cluster.stack_id}-autoscaler",
-                "cloudProvider": "clusterapi",
-                "clusterAPIMode": "kubeconfig-incluster",
-                "clusterAPIKubeconfigSecret": f"{self.cluster.stack_id}-kubeconfig",
-                "autoDiscovery": {
-                    "clusterName": self.cluster.stack_id,
+        with importlib_resources.as_file(
+            importlib_resources.files("magnum_cluster_api")
+            / "charts"
+            / "cluster-autoscaler"
+        ) as chart_path:
+            return helm.UpgradeReleaseCommand(
+                namespace="magnum-system",
+                release_name=self.cluster.stack_id,
+                chart_ref=os.path.join(str(chart_path), ""),
+                values={
+                    "fullnameOverride": f"{self.cluster.stack_id}-autoscaler",
+                    "cloudProvider": "clusterapi",
+                    "clusterAPIMode": "kubeconfig-incluster",
+                    "clusterAPIKubeconfigSecret": f"{self.cluster.stack_id}-kubeconfig",
+                    "autoDiscovery": {
+                        "clusterName": self.cluster.stack_id,
+                    },
+                    "image": {
+                        "repository": image_repo,
+                        "tag": image_tag,
+                    },
+                    "nodeSelector": {
+                        "openstack-control-plane": "enabled",
+                    },
+                    "extraArgs": {
+                        "logtostderr": True,
+                        "stderrthreshold": "info",
+                        "v": 4,
+                        "enforce-node-group-min-size": True,
+                    },
                 },
-                "image": {
-                    "repository": image_repo,
-                    "tag": image_tag,
-                },
-                "nodeSelector": {
-                    "openstack-control-plane": "enabled",
-                },
-                "extraArgs": {
-                    "logtostderr": True,
-                    "stderrthreshold": "info",
-                    "v": 4,
-                    "enforce-node-group-min-size": True,
-                },
-            },
-        )
+            )()
 
     @property
     def delete(self):
@@ -401,9 +402,6 @@ class LegacyClusterResourcesSecret(ClusterBase):
 
     def get_object(self) -> dict:
         repository = utils.get_cluster_container_infra_prefix(self.cluster)
-        manifests_path = str(
-            importlib.resources.files("magnum_cluster_api").joinpath("manifests")
-        )
 
         data = magnum_cluster_api.Driver.get_legacy_cluster_resource_secret_data(
             self.cluster
@@ -433,33 +431,39 @@ class LegacyClusterResourcesSecret(ClusterBase):
             },
         }
 
-        if self.cluster.cluster_template.network_driver == "calico":
-            calico_version = self.cluster.labels.get("calico_tag", CALICO_TAG)
-            data = {
-                **data,
-                **{
-                    "calico.yml": image_utils.update_manifest_images(
-                        self.cluster.uuid,
-                        os.path.join(manifests_path, f"calico/{calico_version}.yaml"),
-                        repository=repository,
-                    )
-                },
-            }
+        with importlib_resources.as_file(
+            importlib_resources.files("magnum_cluster_api") / "manifests"
+        ) as manifests_path:
+            if self.cluster.cluster_template.network_driver == "calico":
+                calico_version = self.cluster.labels.get("calico_tag", CALICO_TAG)
+                data = {
+                    **data,
+                    **{
+                        "calico.yml": image_utils.update_manifest_images(
+                            self.cluster.uuid,
+                            os.path.join(
+                                str(manifests_path),
+                                f"calico/{calico_version}.yaml",
+                            ),
+                            repository=repository,
+                        )
+                    },
+                }
 
-        if manila.is_enabled(self.cluster):
-            data = {
-                **data,
-                **{
-                    os.path.basename(manifest): image_utils.update_manifest_images(
-                        self.cluster.uuid,
-                        manifest,
-                        repository=repository,
-                    )
-                    for manifest in glob.glob(
-                        os.path.join(manifests_path, "nfs-csi/*.yaml")
-                    )
-                },
-            }
+            if manila.is_enabled(self.cluster):
+                data = {
+                    **data,
+                    **{
+                        os.path.basename(manifest): image_utils.update_manifest_images(
+                            self.cluster.uuid,
+                            manifest,
+                            repository=repository,
+                        )
+                        for manifest in glob.glob(
+                            os.path.join(str(manifests_path), "nfs-csi/*.yaml")
+                        )
+                    },
+                }
 
         osc = clients.get_openstack_api(self.context)
         if utils.get_cluster_label_as_bool(self.cluster, "keystone_auth_enabled", True):
@@ -467,33 +471,31 @@ class LegacyClusterResourcesSecret(ClusterBase):
                 service_type="identity",
                 interface="public",
             )
-            data = {
-                **data,
-                **{
-                    "keystone-auth.yaml": helm.TemplateReleaseCommand(
-                        namespace="kube-system",
-                        release_name="k8s-keystone-auth",
-                        chart_ref=os.path.join(
-                            str(
-                                importlib.resources.files(
-                                    "magnum_cluster_api"
-                                ).joinpath("charts")
-                            ),
-                            "k8s-keystone-auth/",
-                        ),
-                        values={
-                            "conf": {
-                                "auth_url": auth_url
-                                + ("" if auth_url.endswith("/v3") else "/v3"),
-                                "ca_cert": magnum_utils.get_openstack_ca(),
-                                "policy": utils.get_keystone_auth_default_policy(
-                                    self.cluster
-                                ),
+            with importlib_resources.as_file(
+                importlib_resources.files("magnum_cluster_api")
+                / "charts"
+                / "k8s-keystone-auth"
+            ) as chart_path:
+                data = {
+                    **data,
+                    **{
+                        "keystone-auth.yaml": helm.TemplateReleaseCommand(
+                            namespace="kube-system",
+                            release_name="k8s-keystone-auth",
+                            chart_ref=os.path.join(str(chart_path), ""),
+                            values={
+                                "conf": {
+                                    "auth_url": auth_url
+                                    + ("" if auth_url.endswith("/v3") else "/v3"),
+                                    "ca_cert": magnum_utils.get_openstack_ca(),
+                                    "policy": utils.get_keystone_auth_default_policy(
+                                        self.cluster
+                                    ),
+                                },
                             },
-                        },
-                    )(repository=repository)
-                },
-            }
+                        )(repository=repository)
+                    },
+                }
 
         return {
             "type": "addons.cluster.x-k8s.io/resource-set",

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -14,13 +14,13 @@
 
 import abc
 import glob
+import importlib.resources
 import math
 import os
 import types
 import typing
 
 import certifi
-import pkg_resources
 import pykube  # type: ignore
 import yaml
 from magnum import objects as magnum_objects  # type: ignore
@@ -72,7 +72,7 @@ class ClusterAutoscalerHelmRelease:
             namespace="magnum-system",
             release_name=self.cluster.stack_id,
             chart_ref=os.path.join(
-                pkg_resources.resource_filename("magnum_cluster_api", "charts"),
+                str(importlib.resources.files("magnum_cluster_api").joinpath("charts")),
                 "cluster-autoscaler/",
             ),
             values={
@@ -401,8 +401,8 @@ class LegacyClusterResourcesSecret(ClusterBase):
 
     def get_object(self) -> dict:
         repository = utils.get_cluster_container_infra_prefix(self.cluster)
-        manifests_path = pkg_resources.resource_filename(
-            "magnum_cluster_api", "manifests"
+        manifests_path = str(
+            importlib.resources.files("magnum_cluster_api").joinpath("manifests")
         )
 
         data = magnum_cluster_api.Driver.get_legacy_cluster_resource_secret_data(
@@ -474,8 +474,10 @@ class LegacyClusterResourcesSecret(ClusterBase):
                         namespace="kube-system",
                         release_name="k8s-keystone-auth",
                         chart_ref=os.path.join(
-                            pkg_resources.resource_filename(
-                                "magnum_cluster_api", "charts"
+                            str(
+                                importlib.resources.files(
+                                    "magnum_cluster_api"
+                                ).joinpath("charts")
                             ),
                             "k8s-keystone-auth/",
                         ),

--- a/magnum_cluster_api/tests/unit/cmd/test_image_loader.py
+++ b/magnum_cluster_api/tests/unit/cmd/test_image_loader.py
@@ -12,9 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import importlib.resources
 import itertools
 import os
+from importlib import resources as importlib_resources
 
 import yaml
 
@@ -52,9 +52,7 @@ def test__get_calico_images():
     default_version = first_image.split(":")[1]  # e.g., "v3.24.2"
 
     # Get manifest path
-    manifests_path = str(
-        importlib.resources.files("magnum_cluster_api").joinpath("manifests")
-    )
+    manifests_path = str(importlib_resources.files("magnum_cluster_api") / "manifests")
     calico_path = os.path.join(manifests_path, "calico")
     manifest_file = os.path.join(calico_path, f"{default_version}.yaml")
 
@@ -72,9 +70,7 @@ def test__get_calico_images():
 
 
 def test__get_infra_images():
-    manifests_path = str(
-        importlib.resources.files("magnum_cluster_api").joinpath("manifests")
-    )
+    manifests_path = str(importlib_resources.files("magnum_cluster_api") / "manifests")
 
     for csi in ["nfs"]:
         folder = os.path.join(manifests_path, f"{csi}-csi")

--- a/magnum_cluster_api/tests/unit/cmd/test_image_loader.py
+++ b/magnum_cluster_api/tests/unit/cmd/test_image_loader.py
@@ -12,10 +12,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import importlib.resources
 import itertools
 import os
 
-import pkg_resources
 import yaml
 
 from magnum_cluster_api.cmd import image_loader
@@ -52,7 +52,9 @@ def test__get_calico_images():
     default_version = first_image.split(":")[1]  # e.g., "v3.24.2"
 
     # Get manifest path
-    manifests_path = pkg_resources.resource_filename("magnum_cluster_api", "manifests")
+    manifests_path = str(
+        importlib.resources.files("magnum_cluster_api").joinpath("manifests")
+    )
     calico_path = os.path.join(manifests_path, "calico")
     manifest_file = os.path.join(calico_path, f"{default_version}.yaml")
 
@@ -70,7 +72,9 @@ def test__get_calico_images():
 
 
 def test__get_infra_images():
-    manifests_path = pkg_resources.resource_filename("magnum_cluster_api", "manifests")
+    manifests_path = str(
+        importlib.resources.files("magnum_cluster_api").joinpath("manifests")
+    )
 
     for csi in ["nfs"]:
         folder = os.path.join(manifests_path, f"{csi}-csi")

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -166,6 +166,29 @@ class TestDriver:
             json=json,
         )
 
+    def _response_for_machine_sets(self, node_group_name, machine_sets=None):
+        """Helper method to create a mock response for MachineSet.for_node_group."""
+        items = list(machine_sets) if machine_sets else []
+
+        return responses.Response(
+            responses.GET,
+            "http://localhost/apis/%s/namespaces/%s/%s"
+            % (
+                objects.MachineSet.version,
+                "magnum-system",
+                objects.MachineSet.endpoint,
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "labelSelector": "cluster.x-k8s.io/cluster-name=%s,topology.cluster.x-k8s.io/deployment-name=%s"
+                        % (self.cluster.stack_id, node_group_name)
+                    }
+                ),
+            ],
+            json={"items": items},
+        )
+
     def _response_for_openstack_machines(self, deployment_name, machine_specs=None):
         """Helper method to create a mock response for OpenStackMachine API calls."""
         json = {"items": []}
@@ -331,10 +354,16 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
-    def setup_node_group_tests(self, rsps, before, after=None):
+    def setup_node_group_tests(self, rsps, before, after=None, migrate_node_group=None):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),
         )
+        if migrate_node_group is not None:
+            # _update_nodegroup() invokes resources.migrate_machineset_failure_domain()
+            # which performs MachineSet.for_node_group() → GET on /machinesets.
+            # Register an empty list so no PATCH is issued (no empty-string
+            # failureDomain values to migrate in test fixtures).
+            rsps.add(self._response_for_machine_sets(migrate_node_group))
         if after:
             rsps.add(
                 self._response_for_cluster_with_machine_deployments(
@@ -381,6 +410,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                migrate_node_group=self.node_group.name,
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
@@ -426,6 +456,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                migrate_node_group=self.node_group.name,
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)

--- a/magnum_cluster_api/tests/unit/test_image_utils.py
+++ b/magnum_cluster_api/tests/unit/test_image_utils.py
@@ -13,9 +13,9 @@
 # under the License.
 
 import glob
-import importlib.resources
 import os
 import uuid
+from importlib import resources as importlib_resources
 
 import pytest
 import yaml
@@ -31,9 +31,7 @@ from magnum_cluster_api import image_utils
     ],
 )
 def test_update_manifest_images(glob_path):
-    manifests_path = str(
-        importlib.resources.files("magnum_cluster_api").joinpath("manifests")
-    )
+    manifests_path = str(importlib_resources.files("magnum_cluster_api") / "manifests")
     repository = "quay.io/test"
 
     cluster_uuid = str(uuid.uuid4())

--- a/magnum_cluster_api/tests/unit/test_image_utils.py
+++ b/magnum_cluster_api/tests/unit/test_image_utils.py
@@ -13,10 +13,10 @@
 # under the License.
 
 import glob
+import importlib.resources
 import os
 import uuid
 
-import pkg_resources
 import pytest
 import yaml
 
@@ -31,7 +31,9 @@ from magnum_cluster_api import image_utils
     ],
 )
 def test_update_manifest_images(glob_path):
-    manifests_path = pkg_resources.resource_filename("magnum_cluster_api", "manifests")
+    manifests_path = str(
+        importlib.resources.files("magnum_cluster_api").joinpath("manifests")
+    )
     repository = "quay.io/test"
 
     cluster_uuid = str(uuid.uuid4())

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -109,7 +109,7 @@ class TestGenerateCloudControllerManagerConfig:
             tls-insecure=false
 
             [LoadBalancer]
-            lb-provider=amphora
+            lb-provider=amphorav2
             lb-method=ROUND_ROBIN
             create-monitor=True
             """

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py3
 [testenv]
 deps =
   fixtures
+  lark
   oslotest
   pytest
   pytest-mock

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,4 +1,17 @@
 - job:
+    name: magnum-cluster-api-tox
+    parent: tox
+    abstract: true
+    pre-run: zuul.d/playbooks/tox/pre.yml
+
+- job:
+    name: magnum-cluster-api-tox-unit
+    parent: magnum-cluster-api-tox
+    pre-run: zuul.d/playbooks/unit/pre.yml
+    vars:
+      tox_envlist: unit
+
+- job:
     name: magnum-cluster-api-devstack
     parent: devstack
     abstract: true

--- a/zuul.d/playbooks/tox/pre.yml
+++ b/zuul.d/playbooks/tox/pre.yml
@@ -4,6 +4,15 @@
     - ensure-uv
 
   tasks:
+    - name: Install build dependencies
+      ansible.builtin.apt:
+        name:
+          - build-essential
+          - pkg-config
+          - libssl-dev
+        state: present
+      become: true
+
     - name: Run no-op command to build module
       ansible.builtin.command: uv run python3 --version
       args:

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -1,6 +1,7 @@
 - project:
     check:
       jobs:
+        - magnum-cluster-api-tox-unit
         - magnum-cluster-api-hydrophone-v1.33.11-calico
         - magnum-cluster-api-hydrophone-v1.33.11-cilium
         - magnum-cluster-api-hydrophone-v1.34.7-calico
@@ -9,6 +10,7 @@
         - magnum-cluster-api-hydrophone-v1.35.4-cilium
     gate:
       jobs:
+        - magnum-cluster-api-tox-unit
         - magnum-cluster-api-hydrophone-v1.33.11-calico
         - magnum-cluster-api-hydrophone-v1.33.11-cilium
         - magnum-cluster-api-hydrophone-v1.34.7-calico


### PR DESCRIPTION
- [x] Drop `pkg_resources` and use `importlib.resources.files()`
- [x] Add `magnum-cluster-api-tox-unit` job definition to `zuul.d/jobs.yaml`
- [x] Add `magnum-cluster-api-tox-unit` to check and gate pipelines in `zuul.d/project.yaml`