### PR TITLE
fix: fetch full history for release publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,8 @@ jobs:
           release-type: rust
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ steps.release.outputs.release_created }}
+        with:
+          fetch-depth: 0
       - name: Build package (x86_64)
         if: ${{ steps.release.outputs.release_created }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0


### PR DESCRIPTION
## Summary
- fetch the full git history in the release workflow checkout
- make release publish builds see the release tag for VERGEN_GIT_DESCRIBE

## Why
The 0.36.3 release workflow failed in maturin because the shallow checkout did not provide the tag history needed by vergen-gix.