### PR TITLE
Fix nodegroup stuck in DELETE_IN_PROGRESS after deletion

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -522,15 +522,13 @@ class BaseDriver(driver.Driver):
             # NOTE(mnaser): If the cluster is in `DELETE_IN_PROGRESS` state, we need to
             #               wait for the `MachineDeployment` to be deleted before we can
             #               mark the node group as `DELETE_COMPLETE`.
-            if (
-                node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS
-                and md is None
-            ):
-                utils.delete_worker_server_group(
-                    ctx=context, cluster=cluster, node_group=node_group
-                )
-                node_group.status = fields.ClusterStatus.DELETE_COMPLETE
-                node_group.save()
+            if node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS:
+                if md is None:
+                    utils.delete_worker_server_group(
+                        ctx=context, cluster=cluster, node_group=node_group
+                    )
+                    node_group.status = fields.ClusterStatus.DELETE_COMPLETE
+                    node_group.save()
                 continue
 
             md_is_running = (

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -516,15 +516,13 @@ class BaseDriver(driver.Driver):
             # NOTE(mnaser): If the cluster is in `DELETE_IN_PROGRESS` state, we need to
             #               wait for the `MachineDeployment` to be deleted before we can
             #               mark the node group as `DELETE_COMPLETE`.
-            if (
-                node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS
-                and md is None
-            ):
-                utils.delete_worker_server_group(
-                    ctx=context, cluster=cluster, node_group=node_group
-                )
-                node_group.status = fields.ClusterStatus.DELETE_COMPLETE
-                node_group.save()
+            if node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS:
+                if md is None:
+                    utils.delete_worker_server_group(
+                        ctx=context, cluster=cluster, node_group=node_group
+                    )
+                    node_group.status = fields.ClusterStatus.DELETE_COMPLETE
+                    node_group.save()
                 continue
 
             md_is_running = (


### PR DESCRIPTION
When a nodegroup is deleted, delete_nodegroup() removes the MachineDeployment entry from the CAPI Cluster topology spec. While CAPI reconciles and deletes the actual MachineDeployment K8s object, update_nodegroups_status() falls through to get_machine_deployment_spec() which raises MachineDeploymentNotFound since the spec entry is already gone. This uncaught exception crashes the periodic update_cluster_status() task, preventing the nodegroup from ever transitioning to DELETE_COMPLETE.

Restructure the DELETE_IN_PROGRESS check so that the continue statement applies regardless of whether the MachineDeployment K8s object still exists, ensuring the code never falls through to get_machine_deployment_spec() for nodegroups being deleted.

Closes: #978 