### PR TITLE
fix: preserve disableAPIServerFloatingIP on upgraded clusters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Cluster API driver for Magnum
+
+## Checklist for work
+
+When completing any work, make sure that the following is completed:
+
+- All potential regressions are accounted for
+- "pre-commit" has been ran on the codebase.
+
+## Regressions
+
+### Immutable-field preservation
+
+- `src/immutable_fields.rs` has a resolver that reads the existing
+  `OpenStackCluster` spec and overrides topology variables to preserve fields
+  that CAPO's admission webhook considers immutable. Adding a new
+  `FieldMapping` is only half the fix.
+- The Python `Cluster.get_object` builder in `magnum_cluster_api/resources.py`
+  **must** source every resolver-owned key from the `variables` dict returned
+  by `self.rust_driver.resolve_immutable_fields(...)`, the way
+  `apiServerLoadBalancer` does at `resources.py:1048`. Recomputing the value
+  from labels or `utils.*` helpers silently discards the resolver output.
+- This applies to companion/gating flags too (e.g.
+  `disableAPIServerFloatingIPManaged`), not just the primary field.
+- The `mock_rust_driver` fixture in `magnum_cluster_api/tests/unit/conftest.py`
+  stubs `rust_driver.resolve_immutable_fields` as an identity function, so
+  any Python unit test that uses it will not fail when builder wiring is
+  missing. Cover the wiring with a Rust-side test, or a Python test that
+  does not rely on that fixture.

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1151,8 +1151,9 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "disableAPIServerFloatingIP",
-                            "value": utils.get_cluster_floating_ip_disabled(
-                                self.cluster
+                            "value": variables.get(
+                                "disableAPIServerFloatingIP",
+                                utils.get_cluster_floating_ip_disabled(self.cluster),
                             ),
                         },
                         {
@@ -1166,14 +1167,17 @@ class Cluster(ClusterBase):
                             #
                             # On upgrades of clusters created by pre-v0.25.x
                             # versions of magnum-cluster-api, the Rust
-                            # `resolve_immutable_fields` driver will flip this
-                            # to True whenever the existing OpenStackCluster
+                            # `resolve_immutable_fields` driver flips this to
+                            # True whenever the existing OpenStackCluster
                             # spec already has `disableAPIServerFloatingIP`
                             # set — so CAPI keeps emitting the field and CAPO's
                             # immutability webhook does not reject the update.
+                            # We therefore always prefer the resolved value
+                            # over the label-derived default.
                             "name": "disableAPIServerFloatingIPManaged",
-                            "value": utils.get_cluster_floating_ip_disabled(
-                                self.cluster
+                            "value": variables.get(
+                                "disableAPIServerFloatingIPManaged",
+                                utils.get_cluster_floating_ip_disabled(self.cluster),
                             ),
                         },
                         {

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1156,6 +1156,27 @@ class Cluster(ClusterBase):
                             ),
                         },
                         {
+                            # Companion flag for `disableAPIServerFloatingIP`
+                            # that gates whether the ClusterClass patch fires.
+                            #
+                            # For fresh clusters we mirror the user's intent
+                            # (derived from the `master_lb_floating_ip_enabled`
+                            # label) so the patch only fires when the field is
+                            # actually supposed to be set.
+                            #
+                            # On upgrades of clusters created by pre-v0.25.x
+                            # versions of magnum-cluster-api, the Rust
+                            # `resolve_immutable_fields` driver will flip this
+                            # to True whenever the existing OpenStackCluster
+                            # spec already has `disableAPIServerFloatingIP`
+                            # set — so CAPI keeps emitting the field and CAPO's
+                            # immutability webhook does not reject the update.
+                            "name": "disableAPIServerFloatingIPManaged",
+                            "value": utils.get_cluster_floating_ip_disabled(
+                                self.cluster
+                            ),
+                        },
+                        {
                             "name": "dnsNameservers",
                             "value": self.cluster.cluster_template.dns_nameserver.split(
                                 ","

--- a/magnum_cluster_api/tests/unit/test_go_template.py
+++ b/magnum_cluster_api/tests/unit/test_go_template.py
@@ -196,20 +196,20 @@ from magnum_cluster_api.tests.unit.go_template import render
         ),
         # disable_api_server_floating_ip
         pytest.param(
-            "{{ if .disableAPIServerFloatingIP }}true{{end}}",
+            "{{ if .disableAPIServerFloatingIPManaged }}true{{end}}",
             {},
             "",
             id="disable_api_floating_ip_missing",
         ),
         pytest.param(
-            "{{ if .disableAPIServerFloatingIP }}true{{end}}",
-            {"disableAPIServerFloatingIP": False},
+            "{{ if .disableAPIServerFloatingIPManaged }}true{{end}}",
+            {"disableAPIServerFloatingIPManaged": False},
             "",
             id="disable_api_floating_ip_false",
         ),
         pytest.param(
-            "{{ if .disableAPIServerFloatingIP }}true{{end}}",
-            {"disableAPIServerFloatingIP": True},
+            "{{ if .disableAPIServerFloatingIPManaged }}true{{end}}",
+            {"disableAPIServerFloatingIPManaged": True},
             "true",
             id="disable_api_floating_ip_true",
         ),

--- a/src/features/disable_api_server_floating_ip.rs
+++ b/src/features/disable_api_server_floating_ip.rs
@@ -24,6 +24,18 @@ use serde::{Deserialize, Serialize};
 pub struct FeatureValues {
     #[serde(rename = "disableAPIServerFloatingIP")]
     pub disable_api_server_floating_ip: bool,
+
+    /// Gates the `disableAPIServerFloatingIP` patch. Set to `true` when the
+    /// user has asked to disable the API server floating IP, or — by the
+    /// `immutable_fields` resolver — when the existing OpenStackCluster spec
+    /// already has this field set.
+    ///
+    /// This prevents CAPO's immutability webhook from rejecting topology
+    /// updates on clusters created by magnum-cluster-api versions prior to
+    /// the introduction of the `enabledIf` guard (see PR #486), which had
+    /// always patched this field on the spec.
+    #[serde(rename = "disableAPIServerFloatingIPManaged")]
+    pub disable_api_server_floating_ip_managed: bool,
 }
 
 pub struct Feature {}
@@ -32,7 +44,9 @@ impl ClusterFeaturePatches for Feature {
     fn patches(&self) -> Vec<ClusterClassPatches> {
         vec![ClusterClassPatches {
             name: "disableAPIServerFloatingIP".into(),
-            enabled_if: Some("{{ if .disableAPIServerFloatingIP }}true{{end}}".into()),
+            enabled_if: Some(
+                "{{ if .disableAPIServerFloatingIPManaged }}true{{end}}".into(),
+            ),
             definitions: Some(vec![ClusterClassPatchesDefinitions {
                 selector: ClusterClassPatchesDefinitionsSelector {
                     api_version: OpenStackClusterTemplate::api_resource().api_version,
@@ -74,6 +88,7 @@ mod tests {
 
         let mut values = default_values();
         values.disable_api_server_floating_ip = true;
+        values.disable_api_server_floating_ip_managed = true;
 
         let patches = feature.patches();
 
@@ -97,6 +112,7 @@ mod tests {
 
         let mut values = default_values();
         values.disable_api_server_floating_ip = false;
+        values.disable_api_server_floating_ip_managed = false;
 
         let patches = feature.patches();
 
@@ -111,6 +127,37 @@ mod tests {
                 .spec
                 .disable_api_server_floating_ip,
             None
+        );
+    }
+
+    /// Regression: upgrades of clusters created by old magnum-cluster-api
+    /// versions (pre-v0.25.x) that unconditionally patched
+    /// `disableAPIServerFloatingIP: false` onto the spec. The
+    /// `immutable_fields` resolver flips `disable_api_server_floating_ip_managed`
+    /// to `true` so the patch still fires with the preserved `false` value,
+    /// keeping the generated spec identical to the stored one and avoiding
+    /// CAPO's immutability webhook.
+    #[test]
+    fn test_patches_if_managed_even_when_value_is_false() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.disable_api_server_floating_ip = false;
+        values.disable_api_server_floating_ip_managed = true;
+
+        let patches = feature.patches();
+
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        assert_eq!(
+            resources
+                .openstack_cluster_template
+                .spec
+                .template
+                .spec
+                .disable_api_server_floating_ip,
+            Some(false)
         );
     }
 }

--- a/src/immutable_fields.rs
+++ b/src/immutable_fields.rs
@@ -48,6 +48,19 @@ struct FieldMapping {
     resource_path: &'static str,
     variable_path: &'static str,
     label: &'static str,
+    /// Optional companion variable that is set to `true` whenever
+    /// `resource_path` is present on the existing resource.
+    ///
+    /// This is required for fields whose ClusterClass patch is gated by an
+    /// `enabledIf` guard: simply propagating the existing value into
+    /// `variable_path` is not enough, because the patch will not fire when
+    /// the guard evaluates to falsy, leaving the generated spec without
+    /// the field. The CAPO webhook then blocks the update because it treats
+    /// a nil → <value> (or <value> → nil) transition as an immutability
+    /// violation (see
+    /// `pkg/webhooks/openstackcluster_webhook.go::ValidateUpdate` which
+    /// falls back to `reflect.DeepEqual`).
+    presence_variable_path: Option<&'static str>,
 }
 
 impl FieldMapping {
@@ -57,7 +70,20 @@ impl FieldMapping {
         labels: &HashMap<String, String>,
         mut variables: Value,
     ) -> Result<Value, Error> {
-        let value = if let Ok(v) = existing.resolve(parse_pointer(self.resource_path)?) {
+        let existing_value = existing.resolve(parse_pointer(self.resource_path)?).ok();
+
+        if let Some(presence_path) = self.presence_variable_path {
+            if existing_value.is_some() {
+                variables
+                    .assign(parse_pointer(presence_path)?, Value::Bool(true))
+                    .map_err(|e| Error::Assign {
+                        pointer: presence_path,
+                        source: e,
+                    })?;
+            }
+        }
+
+        let value = if let Some(v) = existing_value {
             v.clone()
         } else if let Some(label_val) = labels.get(self.label) {
             Value::String(label_val.clone())
@@ -137,16 +163,33 @@ pub const OPENSTACK_CLUSTER_FIELDS: ResourceFieldMappings<OpenStackCluster> =
                 resource_path: "/spec/apiServerLoadBalancer/provider",
                 variable_path: "/apiServerLoadBalancer/provider",
                 label: "octavia_provider",
+                presence_variable_path: None,
             },
             FieldMapping {
                 resource_path: "/spec/apiServerLoadBalancer/flavor",
                 variable_path: "/apiServerLoadBalancer/flavor",
                 label: "api_server_lb_flavor",
+                presence_variable_path: None,
             },
             FieldMapping {
                 resource_path: "/spec/apiServerLoadBalancer/availabilityZone",
                 variable_path: "/apiServerLoadBalancer/availabilityZone",
                 label: "api_server_lb_availability_zone",
+                presence_variable_path: None,
+            },
+            // Preserve `disableAPIServerFloatingIP` so that upgrades from old
+            // magnum-cluster-api versions (pre-v0.25.x) which unconditionally
+            // patched this field do not hit CAPO's immutability webhook.
+            //
+            // `presence_variable_path` forces the ClusterClass patch to fire
+            // whenever the existing OpenStackCluster already has this field
+            // set, even if the user's label-derived intent would otherwise
+            // skip the patch.
+            FieldMapping {
+                resource_path: "/spec/disableAPIServerFloatingIP",
+                variable_path: "/disableAPIServerFloatingIP",
+                label: "",
+                presence_variable_path: Some("/disableAPIServerFloatingIPManaged"),
             },
         ],
         _resource: PhantomData,
@@ -183,6 +226,7 @@ mod tests {
             resource_path: "/spec/apiServerLoadBalancer/provider",
             variable_path: "/apiServerLoadBalancer/provider",
             label: "octavia_provider",
+            presence_variable_path: None,
         };
 
         #[test]
@@ -440,6 +484,121 @@ mod tests {
                         "flavor": "lb-tiny",
                         "availabilityZone": "az2"
                     }
+                })
+            );
+        }
+    }
+
+    mod disable_api_server_floating_ip_preservation {
+        //! Regression tests for upgrades from pre-v0.25.x clusters which
+        //! always patched `disableAPIServerFloatingIP` on the OpenStackCluster.
+        //!
+        //! The CAPO webhook treats a change of `disableAPIServerFloatingIP`
+        //! (including nil ↔ value) as an immutability violation. When the
+        //! existing spec has the field set, we must ensure the ClusterClass
+        //! patch fires (via the `disableAPIServerFloatingIPManaged` companion
+        //! variable) and carries the pre-existing value through, so the
+        //! generated spec is identical to the stored spec.
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn preserves_false_value_and_sets_managed_flag() {
+            let existing = json!({"spec": {"disableAPIServerFloatingIP": false}});
+
+            let result = OPENSTACK_CLUSTER_FIELDS
+                .apply(&existing, &HashMap::new(), json!({}))
+                .expect("apply failed");
+
+            assert_eq!(
+                result,
+                json!({
+                    "disableAPIServerFloatingIP": false,
+                    "disableAPIServerFloatingIPManaged": true,
+                })
+            );
+        }
+
+        #[test]
+        fn preserves_true_value_and_sets_managed_flag() {
+            let existing = json!({"spec": {"disableAPIServerFloatingIP": true}});
+
+            let result = OPENSTACK_CLUSTER_FIELDS
+                .apply(&existing, &HashMap::new(), json!({}))
+                .expect("apply failed");
+
+            assert_eq!(
+                result,
+                json!({
+                    "disableAPIServerFloatingIP": true,
+                    "disableAPIServerFloatingIPManaged": true,
+                })
+            );
+        }
+
+        #[test]
+        fn missing_field_leaves_managed_flag_unset() {
+            // Fresh-install clusters (post-v0.25.x with the default label)
+            // have no `disableAPIServerFloatingIP` on the OpenStackCluster
+            // spec. We must not flip the managed flag, otherwise the patch
+            // would fire and add the field — which CAPO would reject as an
+            // immutability violation on subsequent reconciliations.
+            let existing = json!({"spec": {}});
+
+            let result = OPENSTACK_CLUSTER_FIELDS
+                .apply(&existing, &HashMap::new(), json!({}))
+                .expect("apply failed");
+
+            assert_eq!(result, json!({}));
+        }
+
+        #[test]
+        fn overrides_caller_supplied_variable_when_field_present() {
+            // The caller seeds the variables with the label-derived intent
+            // (`disableAPIServerFloatingIP = true`). The existing spec says
+            // otherwise — existing value must win to keep the spec immutable.
+            let existing = json!({"spec": {"disableAPIServerFloatingIP": false}});
+
+            let result = OPENSTACK_CLUSTER_FIELDS
+                .apply(
+                    &existing,
+                    &HashMap::new(),
+                    json!({"disableAPIServerFloatingIP": true}),
+                )
+                .expect("apply failed");
+
+            assert_eq!(
+                result,
+                json!({
+                    "disableAPIServerFloatingIP": false,
+                    "disableAPIServerFloatingIPManaged": true,
+                })
+            );
+        }
+
+        #[test]
+        fn preserves_caller_supplied_managed_flag_when_field_absent() {
+            // Fresh clusters where the user has asked to disable the floating
+            // IP: the caller seeds `disableAPIServerFloatingIPManaged = true`
+            // so the patch fires on create. Preservation must not clobber it.
+            let existing = json!({"spec": {}});
+
+            let result = OPENSTACK_CLUSTER_FIELDS
+                .apply(
+                    &existing,
+                    &HashMap::new(),
+                    json!({
+                        "disableAPIServerFloatingIP": true,
+                        "disableAPIServerFloatingIPManaged": true,
+                    }),
+                )
+                .expect("apply failed");
+
+            assert_eq!(
+                result,
+                json!({
+                    "disableAPIServerFloatingIP": true,
+                    "disableAPIServerFloatingIPManaged": true,
                 })
             );
         }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -235,6 +235,7 @@ pub mod fixtures {
             )
             .control_plane_availability_zones(vec!["zone1".into(), "zone2".into()])
             .disable_api_server_floating_ip(true)
+            .disable_api_server_floating_ip_managed(true)
             .external_network_id("external-network-id".into())
             .control_plane_flavor("control-plane".into())
             .flavor("worker".into())
@@ -309,7 +310,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 38);
+        assert_eq!(variables.len(), 39);
 
         for var in &variables {
             match var.name.as_str() {
@@ -347,6 +348,12 @@ mod tests {
                     assert_eq!(
                         var.value,
                         json!(default_values().disable_api_server_floating_ip)
+                    );
+                }
+                "disableAPIServerFloatingIPManaged" => {
+                    assert_eq!(
+                        var.value,
+                        json!(default_values().disable_api_server_floating_ip_managed)
                     );
                 }
                 "externalNetworkId" => {

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,6 @@ wheels = [
 
 [[package]]
 name = "magnum-cluster-api"
-version = "0.36.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Clusters created by magnum-cluster-api versions **older than v0.25.x** had `disableAPIServerFloatingIP` unconditionally patched onto the `OpenStackCluster` spec. [PR #486](https://github.com/vexxhost/magnum-cluster-api/pull/486) (v0.25.0) later guarded that patch with an `enabledIf` so the field is only set when the user actually asks to disable the API-server floating IP.

When such an old cluster is reconciled by a newer magnum-cluster-api, the generated `OpenStackCluster` spec no longer contains the field, but the stored spec still does. CAPO's admission webhook treats any change to `DisableAPIServerFloatingIP` — including `nil ↔ value` — as an immutability violation (it falls back to `reflect.DeepEqual` after zeroing out the fields it explicitly allows to mutate; see [`pkg/webhooks/openstackcluster_webhook.go`](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/release-0.11/pkg/webhooks/openstackcluster_webhook.go)). The topology update is rejected and the upgrade gets stuck.

This is what was observed by @yaguangtang on a customer environment where a cluster cloned from `magnum-v0.31.2` has `disableAPIServerFloatingIP: false` in its spec but a fresh install of 0.31.2 does not.

## Is this environment-specific?

**No** — it affects *every* environment that has clusters originally created by any magnum-cluster-api version that predates PR #486 (v0.25.0). The field was persisted at create time and remains on the `OpenStackCluster` forever because CAPO refuses to let it be removed.

## The fix

The feature is split into two topology variables:

| variable | role |
| --- | --- |
| `disableAPIServerFloatingIP` | the value (unchanged) |
| `disableAPIServerFloatingIPManaged` | gates whether the ClusterClass patch fires |

The Python driver seeds both from the user's `master_lb_floating_ip_enabled` label. The Rust `resolve_immutable_fields` driver additionally flips `disableAPIServerFloatingIPManaged` to `true` — and overrides the value — whenever the existing `OpenStackCluster` spec already has the field set. The patch therefore fires with the preserved value, the generated spec matches the stored spec, and CAPO's webhook is satisfied.

Fresh clusters where the user wants the default (floating IP enabled) remain unaffected: both variables are `false`, the patch is skipped and the field stays absent — which is *also* critical, because adding the field on an `UPDATE` of an existing cluster that never had it would itself trip the same immutability check.

## Tests

* `immutable_fields::tests::disable_api_server_floating_ip_preservation` covers the full matrix (field present/absent, value preservation, managed-flag propagation, caller-supplied overrides).
* `features::disable_api_server_floating_ip::tests::test_patches_if_managed_even_when_value_is_false` asserts that the patch fires and carries `false` through when the resolver has flagged the field as managed.

All 142 Rust unit tests pass locally.