### PR TITLE
feat: add auto_upgrade_cni label support for automatic CNI version upgrade

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -399,12 +399,45 @@ class BaseDriver(driver.Driver):
         #              we ignore the `nodegroup` parameter and upgrade the entire cluster
         #              at once.
         cluster.cluster_template_id = cluster_template.uuid
-        cluster.labels["kube_tag"] = cluster_template.labels["kube_tag"]
+
+        # NOTE: oslo.versionedobjects only detects field changes via __setattr__,
+        # not via in-place dict mutation (dict["k"] = v bypasses dirty tracking).
+        # We must build a new dict and reassign cluster.labels / ng.labels so that
+        # the ORM marks the field dirty and persists it on the subsequent save().
+        _cluster_labels = dict(cluster.labels)
+        _cluster_labels["kube_tag"] = cluster_template.labels["kube_tag"]
+
+        # Option C: Opt-in CNI upgrades.
+        #
+        # When `auto_upgrade_cni=true` is set on the cluster or the new
+        # template, copy the CNI version labels (calico_tag / cilium_tag)
+        # from the new template into the cluster labels so the Rust driver
+        # can create a Reconcile-strategy ClusterResourceSet that forces CAPI
+        # to re-apply the updated CNI manifests on the workload cluster.
+        #
+        # See: https://github.com/vexxhost/magnum-cluster-api/issues/919
+        _auto_upgrade_cni = utils.get_cluster_label_as_bool(
+            cluster, "auto_upgrade_cni", False
+        ) or utils.get_cluster_label_as_bool(
+            cluster_template, "auto_upgrade_cni", False
+        )
+        if _auto_upgrade_cni:
+            for _cni_label in ("calico_tag", "cilium_tag"):
+                if _cni_label in cluster_template.labels:
+                    _cluster_labels[_cni_label] = cluster_template.labels[_cni_label]
+
+        cluster.labels = _cluster_labels
 
         for ng in cluster.nodegroups:
             ng.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
             ng.image_id = cluster_template.image_id
-            ng.labels["kube_tag"] = cluster_template.labels["kube_tag"]
+            _ng_labels = dict(ng.labels)
+            _ng_labels["kube_tag"] = cluster_template.labels["kube_tag"]
+            if _auto_upgrade_cni:
+                for _cni_label in ("calico_tag", "cilium_tag"):
+                    if _cni_label in cluster_template.labels:
+                        _ng_labels[_cni_label] = cluster_template.labels[_cni_label]
+            ng.labels = _ng_labels
             ng.save()
 
         # NOTE(mnaser): We run a full apply on the cluster regardless of the changes, since

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -569,3 +569,103 @@ class TestDriver:
                     self.node_group.destroy.assert_called_once()
                 else:
                     self.node_group.destroy.assert_not_called()
+
+
+class TestUpgradeClusterCniLabels:
+    """Unit tests for the auto_upgrade_cni label-copying logic in upgrade_cluster."""
+
+    def _make_nodegroup(self, labels=None):
+        ng = mock.MagicMock()
+        ng.labels = dict(labels or {})
+        ng.save = mock.MagicMock()
+        return ng
+
+    def test_auto_upgrade_cni_on_cluster_copies_calico_tag(
+        self, context, ubuntu_driver
+    ):
+        ng = self._make_nodegroup({"kube_tag": "v1.29.0"})
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.29.0", "auto_upgrade_cni": "true"}
+        cluster.nodegroups = [ng]
+
+        new_template = mock.MagicMock()
+        new_template.labels = {"kube_tag": "v1.30.0", "calico_tag": "v3.29.0"}
+
+        ubuntu_driver.upgrade_cluster(
+            context, cluster, new_template, 1, mock.MagicMock()
+        )
+
+        assert cluster.labels["calico_tag"] == "v3.29.0"
+        assert ng.labels["calico_tag"] == "v3.29.0"
+
+    def test_auto_upgrade_cni_on_template_copies_calico_tag(
+        self, context, ubuntu_driver
+    ):
+        ng = self._make_nodegroup({"kube_tag": "v1.29.0"})
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.29.0"}
+        cluster.nodegroups = [ng]
+
+        new_template = mock.MagicMock()
+        new_template.labels = {
+            "kube_tag": "v1.30.0",
+            "auto_upgrade_cni": "true",
+            "calico_tag": "v3.29.0",
+        }
+
+        ubuntu_driver.upgrade_cluster(
+            context, cluster, new_template, 1, mock.MagicMock()
+        )
+
+        assert cluster.labels["calico_tag"] == "v3.29.0"
+        assert ng.labels["calico_tag"] == "v3.29.0"
+
+    def test_no_auto_upgrade_cni_does_not_copy_cni_labels(self, context, ubuntu_driver):
+        ng = self._make_nodegroup({"kube_tag": "v1.29.0"})
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.29.0"}
+        cluster.nodegroups = [ng]
+
+        new_template = mock.MagicMock()
+        new_template.labels = {"kube_tag": "v1.30.0", "calico_tag": "v3.29.0"}
+
+        ubuntu_driver.upgrade_cluster(
+            context, cluster, new_template, 1, mock.MagicMock()
+        )
+
+        assert "calico_tag" not in cluster.labels
+        assert "calico_tag" not in ng.labels
+
+    def test_auto_upgrade_cni_skips_absent_cni_labels_in_template(
+        self, context, ubuntu_driver
+    ):
+        ng = self._make_nodegroup({"kube_tag": "v1.29.0"})
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.29.0", "auto_upgrade_cni": "true"}
+        cluster.nodegroups = [ng]
+
+        new_template = mock.MagicMock()
+        new_template.labels = {"kube_tag": "v1.30.0"}
+
+        ubuntu_driver.upgrade_cluster(
+            context, cluster, new_template, 1, mock.MagicMock()
+        )
+
+        assert "calico_tag" not in cluster.labels
+        assert "cilium_tag" not in cluster.labels
+
+    def test_auto_upgrade_cni_copies_cilium_tag(self, context, ubuntu_driver):
+        ng = self._make_nodegroup({"kube_tag": "v1.29.0"})
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.29.0", "auto_upgrade_cni": "true"}
+        cluster.nodegroups = [ng]
+
+        new_template = mock.MagicMock()
+        new_template.labels = {"kube_tag": "v1.30.0", "cilium_tag": "v1.16.0"}
+
+        ubuntu_driver.upgrade_cluster(
+            context, cluster, new_template, 1, mock.MagicMock()
+        )
+
+        assert cluster.labels["cilium_tag"] == "v1.16.0"
+        assert ng.labels["cilium_tag"] == "v1.16.0"

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -368,3 +368,28 @@ class TestUtils(base.BaseTestCase):
             context,
             fixed_network,
         )
+
+
+class TestGetKubeTag:
+    def test_returns_cluster_label_kube_tag(self):
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.30.0"}
+        assert utils.get_kube_tag(cluster) == "v1.30.0"
+
+    def test_falls_back_to_template_label(self):
+        cluster = mock.MagicMock()
+        cluster.labels = {}
+        cluster.cluster_template.labels = {"kube_tag": "v1.34.5"}
+        assert utils.get_kube_tag(cluster) == "v1.34.5"
+
+    def test_cluster_label_overrides_template(self):
+        cluster = mock.MagicMock()
+        cluster.labels = {"kube_tag": "v1.30.0"}
+        cluster.cluster_template.labels = {"kube_tag": "v1.34.5"}
+        assert utils.get_kube_tag(cluster) == "v1.30.0"
+
+    def test_returns_default_when_neither_has_kube_tag(self):
+        cluster = mock.MagicMock()
+        cluster.labels = {}
+        cluster.cluster_template.labels = {}
+        assert utils.get_kube_tag(cluster) == "v1.25.3"

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -188,7 +188,16 @@ def generate_manila_csi_cloud_config(
 
 
 def get_kube_tag(cluster: magnum_objects.Cluster) -> str:
-    return cluster.labels.get("kube_tag", "v1.25.3")
+    # Check cluster's own labels first, then fall back to template labels
+    kube_tag = cluster.labels.get("kube_tag")
+    if kube_tag:
+        return kube_tag
+    ct = cluster.cluster_template
+    if ct and ct.labels:
+        kube_tag = ct.labels.get("kube_tag")
+        if kube_tag:
+            return kube_tag
+    return "v1.25.3"
 
 
 def get_auto_scaling_enabled(cluster: magnum_objects.Cluster) -> bool:

--- a/src/addons/calico.rs
+++ b/src/addons/calico.rs
@@ -1,0 +1,255 @@
+// Copyright (c) 2024 VEXXHOST, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! Calico CNI addon for Magnum Cluster API.
+//!
+//! Calico is deployed via vendored static YAML manifests (one per version),
+//! stored in `magnum_cluster_api/manifests/calico/`.  When `auto_upgrade_cni`
+//! is enabled on the cluster, the Calico addon creates a dedicated
+//! ClusterResourceSet with `strategy: Reconcile` and updates the associated
+//! Secret with the manifest for the requested `calico_tag`.  This allows CAPI
+//! to re-apply Calico on the workload cluster, effectively upgrading it.
+//!
+//! See: <https://github.com/vexxhost/magnum-cluster-api/issues/919>
+
+use crate::{
+    addons::ClusterAddon,
+    magnum::{self, ClusterError},
+};
+use include_dir::{include_dir, Dir};
+use maplit::btreemap;
+use std::collections::BTreeMap;
+
+/// All vendored Calico manifests, embedded at compile time.
+///
+/// Each file is named `<version>.yaml`, e.g. `v3.27.4.yaml`.
+static CALICO_MANIFESTS: Dir<'_> =
+    include_dir!("$CARGO_MANIFEST_DIR/magnum_cluster_api/manifests/calico");
+
+pub struct Addon {
+    cluster: magnum::Cluster,
+}
+
+impl Addon {
+    /// Apply `container_infra_prefix` image mirroring to a Calico manifest.
+    ///
+    /// Calico manifests reference images under `quay.io/calico/`.  When a
+    /// custom registry prefix is configured, those references are rewritten to
+    /// `{registry}/calico/` so that air-gapped or mirrored deployments work.
+    fn apply_image_prefix(content: String, registry: &Option<String>) -> String {
+        match registry {
+            Some(registry) => content.replace(
+                "quay.io/calico/",
+                &format!("{}/calico/", registry.trim_end_matches('/')),
+            ),
+            None => content,
+        }
+    }
+}
+
+impl ClusterAddon for Addon {
+    fn new(cluster: magnum::Cluster) -> Self {
+        Self { cluster }
+    }
+
+    fn enabled(&self) -> bool {
+        self.cluster.cluster_template.network_driver == "calico"
+    }
+
+    fn secret_name(&self) -> Result<String, ClusterError> {
+        Ok(format!("{}-calico", self.cluster.stack_id()?))
+    }
+
+    fn manifests(&self) -> Result<BTreeMap<String, String>, helm::HelmTemplateError> {
+        let calico_tag = &self.cluster.labels.calico_tag;
+        let filename = format!("{}.yaml", calico_tag);
+
+        let raw = CALICO_MANIFESTS
+            .get_file(&filename)
+            .and_then(|f| f.contents_utf8())
+            .ok_or_else(|| {
+                helm::HelmTemplateError::HelmCommand(format!(
+                    "Calico manifest not found for version: {} (expected file: {})",
+                    calico_tag, filename
+                ))
+            })?
+            .to_owned();
+
+        let content =
+            Self::apply_image_prefix(raw, &self.cluster.labels.container_infra_prefix);
+
+        Ok(btreemap! {
+            "calico.yaml".to_owned() => content,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    fn make_cluster(network_driver: &str, calico_tag: &str) -> magnum::Cluster {
+        magnum::Cluster {
+            uuid: "sample-uuid".to_string(),
+            labels: magnum::ClusterLabels::builder()
+                .calico_tag(calico_tag.to_owned())
+                .build(),
+            stack_id: Some("kube-abcde".to_string()),
+            cluster_template: magnum::ClusterTemplate {
+                network_driver: network_driver.to_string(),
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_calico_addon_enabled() {
+        let cluster = make_cluster("calico", "v3.27.4");
+        let addon = Addon::new(cluster);
+        assert!(addon.enabled());
+    }
+
+    #[test]
+    fn test_calico_addon_disabled_for_cilium() {
+        let cluster = make_cluster("cilium", "v3.27.4");
+        let addon = Addon::new(cluster);
+        assert!(!addon.enabled());
+    }
+
+    #[test]
+    fn test_calico_addon_secret_name() {
+        let cluster = make_cluster("calico", "v3.27.4");
+        let addon = Addon::new(cluster);
+        assert_eq!(addon.secret_name().unwrap(), "kube-abcde-calico");
+    }
+
+    #[test]
+    fn test_calico_addon_manifests_known_version() {
+        let cluster = make_cluster("calico", "v3.27.4");
+        let addon = Addon::new(cluster);
+        let manifests = addon.manifests().expect("should return manifests");
+        assert!(
+            manifests.contains_key("calico.yaml"),
+            "expected 'calico.yaml' key in manifests"
+        );
+        let content = &manifests["calico.yaml"];
+        assert!(!content.is_empty(), "manifest content should not be empty");
+    }
+
+    #[test]
+    fn test_calico_addon_manifests_unknown_version() {
+        let cluster = make_cluster("calico", "v9.99.99");
+        let addon = Addon::new(cluster);
+        let result = addon.manifests();
+        assert!(result.is_err(), "should fail for unknown version");
+        match result.unwrap_err() {
+            helm::HelmTemplateError::HelmCommand(msg) => {
+                assert!(msg.contains("v9.99.99"), "error should mention the version");
+            }
+            _ => panic!("expected HelmCommand error"),
+        }
+    }
+
+    #[test]
+    fn test_calico_addon_manifests_image_prefix() {
+        let cluster = magnum::Cluster {
+            uuid: "sample-uuid".to_string(),
+            labels: magnum::ClusterLabels::builder()
+                .calico_tag("v3.27.4".to_owned())
+                .container_infra_prefix(Some("registry.example.com".to_owned()))
+                .build(),
+            stack_id: Some("kube-abcde".to_string()),
+            cluster_template: magnum::ClusterTemplate {
+                network_driver: "calico".to_string(),
+            },
+            ..Default::default()
+        };
+        let addon = Addon::new(cluster);
+        let manifests = addon.manifests().expect("should return manifests");
+        let content = &manifests["calico.yaml"];
+        assert!(
+            !content.contains("quay.io/calico/"),
+            "quay.io/calico/ should have been replaced"
+        );
+        assert!(
+            content.contains("registry.example.com/calico/"),
+            "registry.example.com/calico/ should appear in manifest"
+        );
+    }
+
+    #[test]
+    fn test_calico_addon_manifests_image_prefix_trailing_slash() {
+        // Registry with a trailing slash should not produce double slashes
+        let cluster = magnum::Cluster {
+            uuid: "sample-uuid".to_string(),
+            labels: magnum::ClusterLabels::builder()
+                .calico_tag("v3.27.4".to_owned())
+                .container_infra_prefix(Some("registry.example.com/".to_owned()))
+                .build(),
+            stack_id: Some("kube-abcde".to_string()),
+            cluster_template: magnum::ClusterTemplate {
+                network_driver: "calico".to_string(),
+            },
+            ..Default::default()
+        };
+        let addon = Addon::new(cluster);
+        let manifests = addon.manifests().expect("should return manifests");
+        let content = &manifests["calico.yaml"];
+        assert!(
+            !content.contains("quay.io/calico/"),
+            "quay.io/calico/ should have been replaced"
+        );
+        assert!(
+            !content.contains("registry.example.com//calico/"),
+            "double slashes must not appear in image refs"
+        );
+        assert!(
+            content.contains("registry.example.com/calico/"),
+            "registry.example.com/calico/ should appear in manifest"
+        );
+    }
+
+    #[rstest]
+    #[case("v3.24.2")]
+    #[case("v3.25.2")]
+    #[case("v3.26.5")]
+    #[case("v3.27.4")]
+    #[case("v3.28.2")]
+    #[case("v3.29.0")]
+    #[case("v3.29.2")]
+    #[case("v3.29.3")]
+    #[case("v3.30.0")]
+    #[case("v3.30.1")]
+    #[case("v3.30.2")]
+    #[case("v3.31.3")]
+    fn test_calico_addon_manifests_all_known_versions(#[case] calico_tag: &str) {
+        let cluster = make_cluster("calico", calico_tag);
+        let addon = Addon::new(cluster);
+        let manifests = addon
+            .manifests()
+            .expect("all bundled calico versions should render manifests");
+        assert!(
+            manifests.contains_key("calico.yaml"),
+            "expected calico.yaml key for version {}",
+            calico_tag
+        );
+        assert!(
+            !manifests["calico.yaml"].is_empty(),
+            "manifest content must not be empty for version {}",
+            calico_tag
+        );
+    }
+}

--- a/src/addons/mod.rs
+++ b/src/addons/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use thiserror::Error;
 
+pub mod calico;
 pub mod cilium;
 pub mod cinder_csi;
 pub mod cloud_controller_manager;

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -315,6 +315,14 @@ impl Driver {
         self.apply_cluster_class(py)?;
         self.apply_cloud_provider_cluster_resource_set(py, &cluster, true)?;
 
+        // When auto_upgrade_cni is enabled, apply a Reconcile-strategy
+        // ClusterResourceSet for CNI so that the updated calico_tag/cilium_tag
+        // labels (already copied from the new template by driver.py) are
+        // reflected in the workload cluster.  This is Option C from issue #919.
+        if cluster.labels.is_auto_upgrade_cni_enabled() {
+            self.apply_cni_cluster_resource_set(py, &cluster)?;
+        }
+
         Ok(())
     }
 
@@ -354,6 +362,65 @@ impl Driver {
 
         let result = pythonize::pythonize(py, &json_variables)?;
         Ok(result.unbind())
+    }
+}
+
+impl Driver {
+    /// Apply the CNI addon ClusterResourceSet (and its backing Secret) for the
+    /// given cluster using `strategy: Reconcile`.
+    ///
+    /// This creates a dedicated ClusterResourceSet for the cluster's CNI
+    /// plugin (Calico or Cilium) that is separate from the legacy
+    /// ApplyOnce CRS.  Using Reconcile strategy ensures that CAPI re-applies
+    /// the CNI manifests whenever the Secret content changes, which is
+    /// required to actually perform a CNI version upgrade.
+    ///
+    /// Called from `upgrade_cluster()` when `auto_upgrade_cni` is enabled.
+    fn apply_cni_cluster_resource_set(
+        &self,
+        py: Python<'_>,
+        cluster: &magnum::Cluster,
+    ) -> PyResult<()> {
+        if addons::cilium::Addon::new(cluster.clone()).enabled() {
+            let addon = addons::cilium::Addon::new(cluster.clone());
+            Python::detach(py, || {
+                get_runtime().block_on(async {
+                    self.client
+                        .create_or_update_namespaced_resource(
+                            &self.namespace,
+                            cluster.cluster_addon_secret(&addon)?,
+                        )
+                        .await?;
+                    self.client
+                        .create_or_update_namespaced_resource(
+                            &self.namespace,
+                            cluster.cluster_addon_cluster_resource_set(&addon)?,
+                        )
+                        .await?;
+                    Ok::<(), PyErr>(())
+                })
+            })?;
+        } else if addons::calico::Addon::new(cluster.clone()).enabled() {
+            let addon = addons::calico::Addon::new(cluster.clone());
+            Python::detach(py, || {
+                get_runtime().block_on(async {
+                    self.client
+                        .create_or_update_namespaced_resource(
+                            &self.namespace,
+                            cluster.cluster_addon_secret(&addon)?,
+                        )
+                        .await?;
+                    self.client
+                        .create_or_update_namespaced_resource(
+                            &self.namespace,
+                            cluster.cluster_addon_cluster_resource_set(&addon)?,
+                        )
+                        .await?;
+                    Ok::<(), PyErr>(())
+                })
+            })?;
+        }
+        Ok(())
     }
 }
 

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -23,91 +23,89 @@ pub struct ClusterTemplate {
     pub network_driver: String,
 }
 
-#[derive(Clone, Default, Deserialize, FromPyObject, TypedBuilder)]
-#[pyo3(from_item_all)]
+#[derive(Clone, Default, Deserialize, TypedBuilder)]
 pub struct ClusterLabels {
     /// The tag of the Cilium container image to use for the cluster.
     #[builder(default="v1.15.3".to_owned())]
-    #[pyo3(default="v1.15.3".to_owned())]
     pub cilium_tag: String,
 
     /// The IP address range to use for the Cilium IPAM pool.
     #[builder(default="10.100.0.0/16".to_owned())]
-    #[pyo3(default="10.100.0.0/16".to_owned())]
     pub cilium_ipv4pool: String,
 
     /// Enable the Cilium Hubble UI for network observability.
     /// Note: OpenStack labels are always strings, so this accepts "true"/"false".
     #[builder(default="false".to_owned())]
-    #[pyo3(default="false".to_owned())]
     pub cilium_hubble_ui_enabled: String,
 
     /// Enable the use of the Cinder CSI driver for the cluster.
     #[builder(default = true)]
-    #[pyo3(default = true)]
     pub cinder_csi_enabled: bool,
 
     /// The tag of the Cinder CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
-    #[pyo3(default="v1.32.0".to_owned())]
     pub cinder_csi_plugin_tag: String,
 
     /// Enable the use of the Manila CSI driver for the cluster.
     #[builder(default = true)]
-    #[pyo3(default = true)]
     pub manila_csi_enabled: bool,
 
     /// The tag of the Manila CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
-    #[pyo3(default="v1.32.0".to_owned())]
     pub manila_csi_plugin_tag: String,
 
     /// The tag to use for the OpenStack cloud controller provider
     /// when bootstrapping the cluster. If not specified, it will be
     /// automatically selected based on the Kubernetes version.
     #[builder(default)]
-    #[pyo3(default)]
     pub cloud_provider_tag: Option<String>,
 
     /// The prefix of the container images to use for the cluster, which
     /// defaults to the upstream images if not set.
     #[builder(default)]
-    #[pyo3(default)]
     pub container_infra_prefix: Option<String>,
 
     /// CSI attacher tag to use for the cluster.
     #[builder(default="v4.7.0".to_owned())]
-    #[pyo3(default="v4.7.0".to_owned())]
     pub csi_attacher_tag: String,
 
     /// CSI liveness probe tag to use for the cluster.
     #[builder(default="v2.14.0".to_owned())]
-    #[pyo3(default="v2.14.0".to_owned())]
     pub csi_liveness_probe_tag: String,
 
     /// CSI Node Driver Registrar tag to use for the cluster.
     #[builder(default="v2.12.0".to_owned())]
-    #[pyo3(default="v2.12.0".to_owned())]
     pub csi_node_driver_registrar_tag: String,
 
     // CSI Provisioner tag to use for the cluster.
     #[builder(default="v5.1.0".to_owned())]
-    #[pyo3(default="v5.1.0".to_owned())]
     pub csi_provisioner_tag: String,
 
     /// CSI Resizer tag to use for the cluster.
     #[builder(default="v1.12.0".to_owned())]
-    #[pyo3(default="v1.12.0".to_owned())]
     pub csi_resizer_tag: String,
 
     /// CSI Snapshotter tag to use for the cluster.
     #[builder(default="v8.1.0".to_owned())]
-    #[pyo3(default="v8.1.0".to_owned())]
     pub csi_snapshotter_tag: String,
+
+    /// The tag of the Calico container image to use for the cluster.
+    /// This is only used when the cluster's network_driver is "calico".
+    #[builder(default="v3.31.3".to_owned())]
+    pub calico_tag: String,
 
     /// The Kubernetes version to use for the cluster.
     #[builder(default="v1.30.0".to_owned())]
     pub kube_tag: String,
+
+    /// Enable automatic CNI (Calico/Cilium) upgrades during cluster upgrade.
+    /// When set to "true", the CNI version labels are copied from the new
+    /// cluster template during upgrade and the CNI addon ClusterResourceSet
+    /// is re-applied using Reconcile strategy.
+    /// Default: "false" (opt-in — CNI upgrade remains admin responsibility).
+    /// See: https://github.com/vexxhost/magnum-cluster-api/issues/919
+    #[builder(default="false".to_owned())]
+    pub auto_upgrade_cni: String,
 }
 
 impl ClusterLabels {
@@ -117,6 +115,14 @@ impl ClusterLabels {
     /// Parses the string label value "true"/"false" to a boolean.
     pub fn is_cilium_hubble_ui_enabled(&self) -> bool {
         self.cilium_hubble_ui_enabled.eq_ignore_ascii_case("true")
+    }
+
+    /// Returns true if automatic CNI upgrades are enabled.
+    /// When true, calico_tag/cilium_tag are copied from the new template
+    /// during cluster upgrade and the CNI addon ClusterResourceSet is
+    /// re-applied with Reconcile strategy.
+    pub fn is_auto_upgrade_cni_enabled(&self) -> bool {
+        self.auto_upgrade_cni.eq_ignore_ascii_case("true")
     }
 
     pub fn get_cloud_provider_tag(&self) -> String {
@@ -147,6 +153,56 @@ impl ClusterLabels {
             (1, 35) => "v1.35.0".to_owned(),
             _ => Self::DEFAULT_CLOUD_PROVIDER_TAG.to_owned(),
         }
+    }
+}
+
+impl<'a, 'py> pyo3::FromPyObject<'a, 'py> for ClusterLabels {
+    type Error = pyo3::PyErr;
+    fn extract(obj: pyo3::Borrowed<'a, 'py, pyo3::PyAny>) -> pyo3::PyResult<Self> {
+        let dict_borrowed = obj.cast::<pyo3::types::PyDict>()?;
+        let dict: &pyo3::Bound<pyo3::types::PyDict> = &dict_borrowed;
+        use pyo3::types::PyDictMethods;
+        fn gs(d: &pyo3::Bound<pyo3::types::PyDict>, k: &str, def: &str) -> pyo3::PyResult<String> {
+            match d.get_item(k)? {
+                Some(v) => v.extract::<String>(),
+                None => Ok(def.to_owned()),
+            }
+        }
+        fn gb(d: &pyo3::Bound<pyo3::types::PyDict>, k: &str, def: bool) -> pyo3::PyResult<bool> {
+            match d.get_item(k)? {
+                Some(v) => {
+                    if let Ok(b) = v.extract::<bool>() { return Ok(b); }
+                    Ok(v.extract::<String>()?.eq_ignore_ascii_case("true"))
+                }
+                None => Ok(def),
+            }
+        }
+        fn go(d: &pyo3::Bound<pyo3::types::PyDict>, k: &str) -> pyo3::PyResult<Option<String>> {
+            match d.get_item(k)? {
+                Some(v) => Ok(Some(v.extract::<String>()?)),
+                None => Ok(None),
+            }
+        }
+        Ok(ClusterLabels {
+            cilium_tag: gs(dict, "cilium_tag", "v1.15.3")?,
+            cilium_ipv4pool: gs(dict, "cilium_ipv4pool", "10.100.0.0/16")?,
+            cilium_hubble_ui_enabled: gs(dict, "cilium_hubble_ui_enabled", "false")?,
+            cinder_csi_enabled: gb(dict, "cinder_csi_enabled", true)?,
+            cinder_csi_plugin_tag: gs(dict, "cinder_csi_plugin_tag", "v1.32.0")?,
+            manila_csi_enabled: gb(dict, "manila_csi_enabled", true)?,
+            manila_csi_plugin_tag: gs(dict, "manila_csi_plugin_tag", "v1.32.0")?,
+            cloud_provider_tag: go(dict, "cloud_provider_tag")?,
+            container_infra_prefix: go(dict, "container_infra_prefix")?,
+            csi_attacher_tag: gs(dict, "csi_attacher_tag", "v4.7.0")?,
+            csi_liveness_probe_tag: gs(dict, "csi_liveness_probe_tag", "v2.14.0")?,
+            csi_node_driver_registrar_tag: gs(dict, "csi_node_driver_registrar_tag", "v2.12.0")?,
+            csi_provisioner_tag: gs(dict, "csi_provisioner_tag", "v5.1.0")?,
+            csi_resizer_tag: gs(dict, "csi_resizer_tag", "v1.12.0")?,
+            csi_snapshotter_tag: gs(dict, "csi_snapshotter_tag", "v8.1.0")?,
+            calico_tag: gs(dict, "calico_tag", "v3.31.3")?,
+            kube_tag: gs(dict, "kube_tag", "v1.30.0")?,
+            auto_upgrade_cni: gs(dict, "auto_upgrade_cni", "false")?,
+        })
     }
 }
 
@@ -409,6 +465,93 @@ mod tests {
             let result: Result<ClusterStatus, _> = py_status.extract();
             assert!(result.is_err());
         });
+    }
+
+    #[test]
+    fn test_cluster_labels_from_py_empty_dict_uses_defaults() {
+        // When a cluster has no labels (empty dict), FromPyObject should
+        // use defaults for all fields.  This was the root cause of issue #919
+        // where `KeyError: 'kube_tag'` occurred.
+        let _ = Python::initialize();
+        Python::attach(|py| {
+            use pyo3::types::{PyDict, PyDictMethods};
+            let dict = PyDict::new(py);
+            let labels: ClusterLabels = dict
+                .extract()
+                .expect("empty dict should produce default ClusterLabels");
+            assert_eq!(labels.kube_tag, "v1.30.0");
+            assert_eq!(labels.calico_tag, "v3.31.3");
+            assert_eq!(labels.auto_upgrade_cni, "false");
+            assert!(labels.cinder_csi_enabled);
+            assert!(labels.manila_csi_enabled);
+            assert!(labels.cloud_provider_tag.is_none());
+            assert!(labels.container_infra_prefix.is_none());
+        });
+    }
+
+    #[test]
+    fn test_cluster_labels_from_py_partial_labels_uses_defaults_for_missing() {
+        // Cluster with only auto_upgrade_cni; all other fields should default.
+        let _ = Python::initialize();
+        Python::attach(|py| {
+            use pyo3::types::{PyDict, PyDictMethods};
+            let dict = PyDict::new(py);
+            dict.set_item("auto_upgrade_cni", "true")
+                .expect("set_item failed");
+            let labels: ClusterLabels = dict
+                .extract()
+                .expect("partial dict should produce ClusterLabels");
+            assert_eq!(labels.auto_upgrade_cni, "true");
+            assert_eq!(labels.kube_tag, "v1.30.0", "kube_tag should default");
+            assert_eq!(labels.calico_tag, "v3.31.3", "calico_tag should default");
+        });
+    }
+
+    #[test]
+    fn test_cluster_labels_from_py_bool_fields_from_string() {
+        // cinder_csi_enabled and manila_csi_enabled accept string "true"/"false"
+        let _ = Python::initialize();
+        Python::attach(|py| {
+            use pyo3::types::{PyDict, PyDictMethods};
+            let dict = PyDict::new(py);
+            dict.set_item("cinder_csi_enabled", "false")
+                .expect("set_item failed");
+            dict.set_item("manila_csi_enabled", "true")
+                .expect("set_item failed");
+            let labels: ClusterLabels = dict.extract().expect("should parse");
+            assert!(!labels.cinder_csi_enabled);
+            assert!(labels.manila_csi_enabled);
+        });
+    }
+
+    #[test]
+    fn test_is_auto_upgrade_cni_enabled_default() {
+        let labels = ClusterLabels::default();
+        assert!(!labels.is_auto_upgrade_cni_enabled());
+    }
+
+    #[test]
+    fn test_is_auto_upgrade_cni_enabled_true() {
+        let labels = ClusterLabels::builder()
+            .auto_upgrade_cni("true".to_owned())
+            .build();
+        assert!(labels.is_auto_upgrade_cni_enabled());
+    }
+
+    #[test]
+    fn test_is_auto_upgrade_cni_enabled_uppercase_true() {
+        let labels = ClusterLabels::builder()
+            .auto_upgrade_cni("TRUE".to_owned())
+            .build();
+        assert!(labels.is_auto_upgrade_cni_enabled());
+    }
+
+    #[test]
+    fn test_is_auto_upgrade_cni_enabled_false() {
+        let labels = ClusterLabels::builder()
+            .auto_upgrade_cni("false".to_owned())
+            .build();
+        assert!(!labels.is_auto_upgrade_cni_enabled());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements Issue #919 Option C: automatic CNI version upgrade during cluster upgrades.

When a cluster has the `auto_upgrade_cni=true` label and is upgraded to a new cluster template, the CNI version tags (`calico_tag`/`cilium_tag`) are automatically copied from the new template to the cluster and its nodegroups.

## How it works

1. Operator sets `auto_upgrade_cni=true` on the cluster template
2. When `openstack coe cluster upgrade <cluster> <new-template>` is called, the driver detects this label
3. If the new template has a different `calico_tag` or `cilium_tag`, those are copied to the cluster labels
4. The Cluster API ClusterResourceSet (CRS) for the CNI is then updated with the new version, triggering the CNI upgrade

## Changes

### Python (Magnum driver)
- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `per- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`: Copy \- `driver.py`:upgrade scenarios
- `test_utils.py`: Tests for `get_label` helper

### Rust (CAPI driver)
- `src/magnum.rs`: Add `auto_upgrade_cni` field and CNI tag propagation
- `src/driver.rs`: Wire `auto_upgrade_cni` into upgrade path
- `src/addons/calico.rs`: New Calico addon implementation
- `src/cluster_api/openstackclusters.rs`: OpenStackCluster resource support
- `src/immutable_fields.rs`: Immutable field validatio- `src/immutable_fields.rs`: Immutable field validatio- `src/immutable_fields.rs`: Immutable field valide_cn- `src/immutable_fields.rs`: Immutable field validatio- `src/immutable_fields.rs`: Immutable field validatio- `srcy.i- `src/icil- `src/immutable_fiel with master loadbalancer enabled (Octavia)