### PR TITLE
fix(#821): require kube_tag label and fail fast with actionable error

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -71,9 +71,9 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
-        self.rust_driver.create_cluster(cluster)
-
         utils.validate_cluster(context, cluster)
+
+        self.rust_driver.create_cluster(cluster)
 
         return self._create_cluster(context, cluster)
 
@@ -441,7 +441,11 @@ class BaseDriver(driver.Driver):
         #               https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/990
         utils.delete_loadbalancers(context, cluster)
 
-        self.rust_driver.delete_cluster(cluster)
+        # NOTE(okozachenko): If kube_tag is missing, the cluster never passed
+        #                     validation during create, so the Rust-managed
+        #                     ClusterResourceSets were never created.
+        if cluster.labels.get("kube_tag"):
+            self.rust_driver.delete_cluster(cluster)
         resources.Cluster(
             context,
             self.kube_client,

--- a/magnum_cluster_api/exceptions.py
+++ b/magnum_cluster_api/exceptions.py
@@ -71,3 +71,11 @@ class MachineDeploymentNotFound(exception.ObjectNotFound):
 
 class InvalidOctaviaLoadBalancerAlgorithm(exception.Invalid):
     message = _("Invalid value for octavia_lb_algorithm: %(octavia_lb_algorithm)s.")
+
+
+class MissingClusterLabel(exception.Invalid):
+    message = _(
+        "Cluster label %(label)s is required and must match the Kubernetes "
+        "version of the cluster image. Set it on the cluster template or the "
+        "cluster (e.g. --labels %(label)s=v1.30.5)."
+    )

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -566,3 +566,35 @@ def test_wait_for_sdk_loadbalancers_deleted_times_out(mocker):
         utils._wait_for_sdk_loadbalancers_deleted(octavia_client, {"lb-id"})
 
     sleep.assert_called_once_with(1)
+
+
+class TestGetKubeTag:
+    def test_returns_label_when_set(self, context):
+        cluster = magnum_test_utils.get_test_cluster(
+            context, labels={"kube_tag": "v1.30.5"}
+        )
+        assert utils.get_kube_tag(cluster) == "v1.30.5"
+
+    def test_raises_when_missing(self, context):
+        cluster = magnum_test_utils.get_test_cluster(context, labels={})
+        with pytest.raises(exceptions.MissingClusterLabel):
+            utils.get_kube_tag(cluster)
+
+    def test_raises_when_empty(self, context):
+        cluster = magnum_test_utils.get_test_cluster(
+            context, labels={"kube_tag": ""}
+        )
+        with pytest.raises(exceptions.MissingClusterLabel):
+            utils.get_kube_tag(cluster)
+
+
+class TestValidateClusterRequiresKubeTag:
+    def test_validate_cluster_raises_when_kube_tag_missing(self, context):
+        cluster = magnum_test_utils.get_test_cluster(
+            context, labels={}, master_count=1, fixed_network=None, fixed_subnet=None
+        )
+        cluster.cluster_template = magnum_test_utils.get_test_cluster_template(
+            context, network_driver="calico"
+        )
+        with pytest.raises(exceptions.MissingClusterLabel):
+            utils.validate_cluster(mock.Mock(), cluster)

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -581,9 +581,7 @@ class TestGetKubeTag:
             utils.get_kube_tag(cluster)
 
     def test_raises_when_empty(self, context):
-        cluster = magnum_test_utils.get_test_cluster(
-            context, labels={"kube_tag": ""}
-        )
+        cluster = magnum_test_utils.get_test_cluster(context, labels={"kube_tag": ""})
         with pytest.raises(exceptions.MissingClusterLabel):
             utils.get_kube_tag(cluster)
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -191,7 +191,10 @@ def generate_manila_csi_cloud_config(
 
 
 def get_kube_tag(cluster: magnum_objects.Cluster) -> str:
-    return cluster.labels.get("kube_tag", "v1.25.3")
+    tag = cluster.labels.get("kube_tag")
+    if not tag:
+        raise mcapi_exceptions.MissingClusterLabel(label="kube_tag")
+    return tag
 
 
 def get_auto_scaling_enabled(cluster: magnum_objects.Cluster) -> bool:
@@ -459,6 +462,12 @@ def lookup_image(cli: clients.OpenStackClients, image_ref: str) -> dict:
 
 
 def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluster):
+    # The kube_tag label drives kubelet/kubeadm bootstrap and *must* match the
+    # Kubernetes version baked into the cluster image. We refuse to fall back to
+    # a hard-coded default because no default can be correct for an arbitrary
+    # image (see issue #821).
+    get_kube_tag(cluster)
+
     # Check network driver
     if cluster.cluster_template.network_driver not in ["cilium", "calico"]:
         raise mcapi_exceptions.UnsupportedCNI


### PR DESCRIPTION
## Why

The `kube_tag` label drives kubelet/kubeadm bootstrap and **must** match the Kubernetes version baked into the cluster image. Today `get_kube_tag()` silently falls back to a hard-coded `v1.25.3` when the label is missing, which has two failure modes:

1. The default cannot possibly be correct for an arbitrary cluster image, so it produces clusters that fail to bootstrap with no clear hint as to why.
2. When the label is omitted entirely, downstream code paths (including the Rust driver during cluster delete) raise a bare `KeyError: 'kube_tag'` that is opaque to operators. See #821 for the original traceback.

## What

* New `MissingClusterLabel(magnum.common.exception.Invalid)` exception with an actionable message that names the missing label and shows how to set it.
* `get_kube_tag()` now raises `MissingClusterLabel` instead of returning a misleading default.
* `validate_cluster()` calls `get_kube_tag()` first so cluster create is rejected up-front with a clear 400-class error rather than failing partway through bootstrap.
* Unit tests for both `get_kube_tag()` and `validate_cluster()`.

## Alternative to #867

#867 keeps the silent-default behaviour but moves the literal `v1.25.3` into a Rust constant exported as `magnum_cluster_api.DEFAULT_KUBE_TAG`.

This PR takes the opposite approach: refuse to guess. The label is required and the operator gets a clear error explaining what to sThis PR takes the opposite approach: refuse to guess. The label is required and the operator gets a clear error explaining what to sThis PR takes the opposite approach: refuse to guess. The label is required and t exThisng manual workaround (set `kube_tag` in the DB and re-run delete) still applies for legacy clusters. A follow-up could make the Rust delete path tolerant of a missing label.

Closes-Bug: #821