### PR TITLE
fix(#790): enable kube http-proxy feature for Rust driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1741,7 +1742,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1824,6 +1827,12 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ inventory = "0.3.19"
 json-patch = "4.0.0"
 jsonptr = "0.7"
 k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_31"] }
-kube = { version = "3.0.0", features = ["runtime", "derive"] }
+kube = { version = "3.0.0", features = ["runtime", "derive", "http-proxy"] }
 log = "0.4.27"
 env_logger = { version = "0.11.6", default-features = false, features = ["auto-color", "humantime"] }
 maplit = "1.0.2"


### PR DESCRIPTION
## Why

When `magnum-api` is started with `HTTP_PROXY` / `HTTPS_PROXY` in its environment, instantiating the Rust driver crashes immediately:

```
RuntimeError: configured proxy http://10.33.124.130:3128/ requires the
disabled feature "kube/http-proxy"
```

The `kube` crate refuses to honour proxy env vars unless the `http-proxy` cargo feature is enabled. Today we ship without that feature, so any deployment that exports `HTTP(S)_PROXY` for the Magnum service is broken at startup. This was reported in #790 along with the one-line fix.

## Change

```toml
-kube = { version = "3.0.0", features = ["runtime", "derive"] }
+kube = { version = "3.0.0", features = ["runtime", "derive", "http-proxy"] }
```

Verified locally with `cargo build --release` (kube/kube-client/kube-runtime recompile cleanly).

## Note: PR #897

PR #897 ("skiPR #897 ("skiPR #897 ("skiPR #897 (\configured") was referenced as fixing this issue but it actually addresses workload-cluster cloud-init proxy confPR #897 ("skiPR #897 ("skiPR #897 ("skiPR #897 (\configured") was referenced as fixing this issue but it actually addresses workload-ream (httpsPR #897 ("skiPR #897 ("skiPR #897 ("skiPR #897 (\configured") wasY\PR #897 ("skiPR #897 ("skiPR #897ter should keep `HTTP(S)_PROXY` unset for `magnum-api` until that's resolved upstream. This PR is a strict superset of today's behaviour: without `HTTP(S)_PROXY` set, nothing changes.

Closes-Bug: #790