### PR TITLE
feat: add label kubelet_extra_args to enable pass args to the kubelet

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -231,6 +231,27 @@ is often accomplished by deploying a driver on each node.
 
    Default value: `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`
 
+* `kubelet_extra_args`
+
+   Pass extra command-line flags to the kubelet on every control-plane and
+   worker node in the cluster.  These are merged into the
+   `kubeletExtraArgs` map of the underlying `KubeadmControlPlaneTemplate`
+   and `KubeadmConfigTemplate`, in addition to the defaults that the
+   driver always sets (`cloud-provider=external` and `tls-cipher-suites`).
+
+   The label value is a **semicolon-separated** list of `key=value` pairs.
+   Semicolon (rather than comma) is used so that values which themselves
+   contain commas — such as kubelet's `--system-reserved` flag — pass
+   through unchanged.  Keys are kubelet flag names without the leading
+   `--`.  Whitespace around pairs is stripped, and entries without `=` or
+   with an empty key are silently ignored.
+
+   Example:
+
+       kubelet_extra_args=max-pods=150;system-reserved=cpu=100m,memory=128Mi;eviction-hard=memory.available<100Mi
+
+   Default value: `""` (no extra arguments)
+
 * `kube_tag`
 
    The version of Kubernetes to use.

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1229,6 +1229,10 @@ class Cluster(ClusterBase):
                             ),
                         },
                         {
+                            "name": "kubeletExtraArgs",
+                            "value": utils.get_kubelet_extra_args(self.cluster),
+                        },
+                        {
                             "name": "apiServerSANs",
                             "value": utils.generate_api_cert_san_list(self.cluster),
                         },

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -829,6 +829,12 @@ def mutate_machine_deployment(
                         "name": "hardwareDiskBus",
                         "value": image.get("hw_disk_bus", ""),
                     },
+                    {
+                        "name": "kubeletExtraArgs",
+                        "value": utils.get_node_group_kubelet_extra_args(
+                            cluster, node_group
+                        ),
+                    },
                     # NOTE(oleks): Override using MachineDeployment-level variables for node groups
                     {
                         "name": "serverGroupId",

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -116,6 +116,16 @@ class TestExistingMutateMachineDeployment:
             {"name": "fake-flavor", "disk": 10, "ram": 1024, "vcpus": 1},
         )
 
+        mock_get_default_boot_volume_type = mocker.patch(
+            "magnum_cluster_api.integrations.cinder.get_default_boot_volume_type"
+        )
+        mock_get_default_boot_volume_type.return_value = "fake-volume-type"
+
+        mock_ensure_worker_server_group = mocker.patch(
+            "magnum_cluster_api.utils.ensure_worker_server_group"
+        )
+        mock_ensure_worker_server_group.return_value = "server-group-id"
+
     def _assert_no_mutations(self, md):
         assert md["name"] == self.node_group.name
         assert "class" not in md
@@ -161,3 +171,25 @@ class TestExistingMutateMachineDeployment:
         else:
             assert md["replicas"] == self.node_group.node_count
             assert md["metadata"]["annotations"] == {}
+
+    def test_new_machine_deployment_merges_kubelet_extra_args(self, context):
+        self.cluster.labels["kubelet_extra_args"] = (
+            "max-pods=150;serialize-image-pulls=true"
+        )
+        self.node_group.labels["kubelet_extra_args"] = (
+            "max-pods=200;system-reserved=cpu=100m,memory=128Mi"
+        )
+
+        md = resources.mutate_machine_deployment(context, self.cluster, self.node_group)
+
+        self._assert_common_machine_deployment_values(md)
+        kubelet_extra_args = next(
+            override["value"]
+            for override in md["variables"]["overrides"]
+            if override["name"] == "kubeletExtraArgs"
+        )
+        assert kubelet_extra_args == (
+            '\nmax-pods: "200"'
+            '\nserialize-image-pulls: "true"'
+            '\nsystem-reserved: "cpu=100m,memory=128Mi"'
+        )

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -344,6 +344,38 @@ class TestGetKubeletExtraArgs:
         assert utils.get_kubelet_extra_args(cluster) == '\nvalid: "ok"'
 
 
+class TestGetNodeGroupKubeletExtraArgs:
+    def test_merges_cluster_and_node_group_labels(self, context):
+        cluster = magnum_test_utils.get_test_cluster(
+            context,
+            labels={"kubelet_extra_args": "max-pods=150;system-reserved=cpu=100m"},
+        )
+        node_group = magnum_test_utils.get_test_nodegroup(
+            context,
+            labels={"kubelet_extra_args": "eviction-hard=memory.available<100Mi"},
+        )
+
+        assert utils.get_node_group_kubelet_extra_args(cluster, node_group) == (
+            '\nmax-pods: "150"'
+            '\nsystem-reserved: "cpu=100m"'
+            '\neviction-hard: "memory.available<100Mi"'
+        )
+
+    def test_node_group_overrides_matching_cluster_keys(self, context):
+        cluster = magnum_test_utils.get_test_cluster(
+            context,
+            labels={"kubelet_extra_args": "max-pods=150;serialize-image-pulls=true"},
+        )
+        node_group = magnum_test_utils.get_test_nodegroup(
+            context,
+            labels={"kubelet_extra_args": "max-pods=200"},
+        )
+
+        assert utils.get_node_group_kubelet_extra_args(cluster, node_group) == (
+            '\nmax-pods: "200"' '\nserialize-image-pulls: "true"'
+        )
+
+
 class TestUtils(base.BaseTestCase):
     """Test case for utils."""
 

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -299,6 +299,51 @@ class TestGenerateAptProxyConfig:
         assert config == ""
 
 
+class TestGetKubeletExtraArgs:
+    def _cluster(self, context, label_value):
+        labels = {"kubelet_extra_args": label_value} if label_value is not None else {}
+        return magnum_test_utils.get_test_cluster(context, labels=labels)
+
+    def test_unset(self, context):
+        cluster = magnum_test_utils.get_test_cluster(context, labels={})
+
+        assert utils.get_kubelet_extra_args(cluster) == ""
+
+    def test_empty_string(self, context):
+        cluster = self._cluster(context, "")
+
+        assert utils.get_kubelet_extra_args(cluster) == ""
+
+    def test_single_pair(self, context):
+        cluster = self._cluster(context, "max-pods=150")
+
+        assert utils.get_kubelet_extra_args(cluster) == '\nmax-pods: "150"'
+
+    def test_multiple_pairs(self, context):
+        cluster = self._cluster(
+            context,
+            "max-pods=150;system-reserved=cpu=100m,memory=128Mi",
+        )
+
+        assert utils.get_kubelet_extra_args(cluster) == (
+            '\nmax-pods: "150"' '\nsystem-reserved: "cpu=100m,memory=128Mi"'
+        )
+
+    def test_strips_whitespace(self, context):
+        cluster = self._cluster(
+            context, "  max-pods = 150 ;  eviction-hard=memory.available<100Mi  "
+        )
+
+        assert utils.get_kubelet_extra_args(cluster) == (
+            '\nmax-pods: "150"' '\neviction-hard: "memory.available<100Mi"'
+        )
+
+    def test_skips_invalid_entries(self, context):
+        cluster = self._cluster(context, ";=value;valid=ok;no-equals;")
+
+        assert utils.get_kubelet_extra_args(cluster) == '\nvalid: "ok"'
+
+
 class TestUtils(base.BaseTestCase):
     """Test case for utils."""
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -318,6 +318,47 @@ def get_cluster_label_as_bool(
     return strutils.bool_from_string(value, strict=True)
 
 
+def get_kubelet_extra_args(cluster: magnum_objects.Cluster) -> str:
+    """Render the user-supplied ``kubelet_extra_args`` cluster label.
+
+    Returns a YAML snippet (with leading newline) that gets spliced into the
+    rendered ``kubeletExtraArgs`` map by the matching ClusterClass patch.
+    Returns an empty string when the label is unset, so the patch only emits
+    the defaults owned by the feature (``cloud-provider`` and
+    ``tls-cipher-suites``).
+
+    The label value is a semicolon-separated list of ``key=value`` pairs, e.g.::
+
+        kubelet_extra_args=max-pods=150;system-reserved=cpu=100m,memory=128Mi
+
+    Semicolon is used as the pair separator (rather than comma) so that
+    values which themselves contain commas — such as kubelet's
+    ``--system-reserved`` flag — pass through unchanged.  Whitespace around
+    pairs is stripped, an empty key is rejected, and entries without ``=``
+    are ignored.  Each pair becomes a line in the rendered YAML snippet,
+    with the value emitted as a double-quoted YAML scalar.
+    """
+    raw = cluster.labels.get("kubelet_extra_args", "")
+    if not raw:
+        return ""
+
+    lines = []
+    for pair in raw.split(";"):
+        pair = pair.strip()
+        if not pair or "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        encoded = yaml.safe_dump(value.strip(), default_style='"').strip()
+        lines.append(f"{key}: {encoded}")
+
+    if not lines:
+        return ""
+    return "\n" + "\n".join(lines)
+
+
 def delete_loadbalancers(ctx, cluster):
     # NOTE(mnaser): This code is duplicated from magnum.common.octavia
     #               since the original code is very Heat-specific.

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -318,6 +318,36 @@ def get_cluster_label_as_bool(
     return strutils.bool_from_string(value, strict=True)
 
 
+def _parse_kubelet_extra_args(raw: str) -> dict[str, str]:
+    extra_args = {}
+    if not raw:
+        return extra_args
+
+    for pair in raw.split(";"):
+        pair = pair.strip()
+        if not pair or "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        extra_args[key] = value.strip()
+
+    return extra_args
+
+
+def _render_kubelet_extra_args(extra_args: dict[str, str]) -> str:
+    if not extra_args:
+        return ""
+
+    lines = []
+    for key, value in extra_args.items():
+        encoded = yaml.safe_dump(value, default_style='"').strip()
+        lines.append(f"{key}: {encoded}")
+
+    return "\n" + "\n".join(lines)
+
+
 def get_kubelet_extra_args(cluster: magnum_objects.Cluster) -> str:
     """Render the user-supplied ``kubelet_extra_args`` cluster label.
 
@@ -338,25 +368,25 @@ def get_kubelet_extra_args(cluster: magnum_objects.Cluster) -> str:
     are ignored.  Each pair becomes a line in the rendered YAML snippet,
     with the value emitted as a double-quoted YAML scalar.
     """
-    raw = cluster.labels.get("kubelet_extra_args", "")
-    if not raw:
-        return ""
+    return _render_kubelet_extra_args(
+        _parse_kubelet_extra_args(cluster.labels.get("kubelet_extra_args", ""))
+    )
 
-    lines = []
-    for pair in raw.split(";"):
-        pair = pair.strip()
-        if not pair or "=" not in pair:
-            continue
-        key, _, value = pair.partition("=")
-        key = key.strip()
-        if not key:
-            continue
-        encoded = yaml.safe_dump(value.strip(), default_style='"').strip()
-        lines.append(f"{key}: {encoded}")
 
-    if not lines:
-        return ""
-    return "\n" + "\n".join(lines)
+def get_node_group_kubelet_extra_args(
+    cluster: magnum_objects.Cluster, node_group: magnum_objects.NodeGroup
+) -> str:
+    """Render merged cluster and node group ``kubelet_extra_args`` labels.
+
+    Node group arguments are layered on top of the cluster-level label so a
+    worker pool can add new flags or override individual keys without dropping
+    the template-provided defaults for the rest of the cluster.
+    """
+    extra_args = _parse_kubelet_extra_args(cluster.labels.get("kubelet_extra_args", ""))
+    extra_args.update(
+        _parse_kubelet_extra_args(node_group.labels.get("kubelet_extra_args", ""))
+    )
+    return _render_kubelet_extra_args(extra_args)
 
 
 def delete_loadbalancers(ctx, cluster):

--- a/src/features/kubelet_extra_args.rs
+++ b/src/features/kubelet_extra_args.rs
@@ -1,0 +1,224 @@
+use crate::{
+    cluster_api::{
+        clusterclasses::{
+            ClusterClassPatches, ClusterClassPatchesDefinitions,
+            ClusterClassPatchesDefinitionsJsonPatches,
+            ClusterClassPatchesDefinitionsJsonPatchesValueFrom,
+            ClusterClassPatchesDefinitionsSelector,
+            ClusterClassPatchesDefinitionsSelectorMatchResources,
+            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass,
+            ClusterClassVariables, ClusterClassVariablesSchema,
+        },
+        kubeadmconfigtemplates::KubeadmConfigTemplate,
+        kubeadmcontrolplanetemplates::KubeadmControlPlaneTemplate,
+    },
+    features::{
+        ClusterClassVariablesSchemaExt, ClusterFeatureEntry, ClusterFeaturePatches,
+        ClusterFeatureVariables,
+    },
+};
+use cluster_feature_derive::ClusterFeatureValues;
+use indoc::indoc;
+use kube::CustomResourceExt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, ClusterFeatureValues)]
+#[allow(dead_code)]
+pub struct FeatureValues {
+    /// `kubeletExtraArgs` is a YAML snippet listing additional kubelet flags
+    /// supplied by the user via the `kubelet_extra_args` cluster label.
+    ///
+    /// The value is spliced into the rendered `kubeletExtraArgs` map alongside
+    /// the defaults that this feature owns (`cloud-provider` and
+    /// `tls-cipher-suites`).  When the label is unset, the variable is the
+    /// empty string and only the defaults are emitted.
+    ///
+    /// Example: `"\nmax-pods: \"150\"\nsystem-reserved: \"cpu=100m,memory=128Mi\""`.
+    #[serde(rename = "kubeletExtraArgs")]
+    pub kubelet_extra_args: String,
+}
+
+pub struct Feature {}
+
+// NOTE: This feature owns the `kubeletExtraArgs` map.  We render the full map
+// (including the defaults `cloud-provider: external` and `tls-cipher-suites`)
+// so the patch is order-independent: replacing the parent map cannot
+// accidentally drop other features' defaults, because they are emitted here
+// as well.
+const KUBELET_EXTRA_ARGS_TEMPLATE: &str = indoc!(
+    r#"
+    cloud-provider: external
+    tls-cipher-suites: {{ .kubeletTLSCipherSuites }}{{ .kubeletExtraArgs }}"#
+);
+
+impl ClusterFeaturePatches for Feature {
+    fn patches(&self) -> Vec<ClusterClassPatches> {
+        vec![ClusterClassPatches {
+            name: "kubeletExtraArgs".into(),
+            definitions: Some(vec![
+                ClusterClassPatchesDefinitions {
+                    selector: ClusterClassPatchesDefinitionsSelector {
+                        api_version: KubeadmControlPlaneTemplate::api_resource().api_version,
+                        kind: KubeadmControlPlaneTemplate::api_resource().kind,
+                        match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                            control_plane: Some(true),
+                            ..Default::default()
+                        },
+                    },
+                    json_patches: vec![
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs".into(),
+                            value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                                template: Some(KUBELET_EXTRA_ARGS_TEMPLATE.to_string()),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs".into(),
+                            value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                                template: Some(KUBELET_EXTRA_ARGS_TEMPLATE.to_string()),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                    ],
+                },
+                ClusterClassPatchesDefinitions {
+                    selector: ClusterClassPatchesDefinitionsSelector {
+                        api_version: KubeadmConfigTemplate::api_resource().api_version,
+                        kind: KubeadmConfigTemplate::api_resource().kind,
+                        match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                            machine_deployment_class: Some(
+                                ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                    names: Some(vec!["default-worker".to_string()]),
+                                },
+                            ),
+                            ..Default::default()
+                        },
+                    },
+                    json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                        op: "add".into(),
+                        path: "/spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs".into(),
+                        value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                            template: Some(KUBELET_EXTRA_ARGS_TEMPLATE.to_string()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }],
+                },
+            ]),
+            ..Default::default()
+        }]
+    }
+}
+
+inventory::submit! {
+    ClusterFeatureEntry{ feature: &Feature {} }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test::TestClusterResources;
+    use crate::resources::fixtures::default_values;
+    use maplit::btreemap;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_patches_with_user_args() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.kubelet_extra_args = "\nmax-pods: \"150\"\nsystem-reserved: \"cpu=100m,memory=128Mi\"".to_string();
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let kubeadm_config_spec = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec;
+
+        let expected = btreemap! {
+            "cloud-provider".to_string() => "external".to_string(),
+            "tls-cipher-suites".to_string() => values.kubelet_tls_cipher_suites.clone(),
+            "max-pods".to_string() => "150".to_string(),
+            "system-reserved".to_string() => "cpu=100m,memory=128Mi".to_string(),
+        };
+
+        assert_eq!(
+            kubeadm_config_spec
+                .init_configuration
+                .expect("init configuration should be set")
+                .node_registration
+                .expect("node registration should be set")
+                .kubelet_extra_args
+                .expect("kubelet extra args should be set"),
+            expected,
+        );
+
+        assert_eq!(
+            kubeadm_config_spec
+                .join_configuration
+                .expect("join configuration should be set")
+                .node_registration
+                .expect("node registration should be set")
+                .kubelet_extra_args
+                .expect("kubelet extra args should be set"),
+            expected,
+        );
+
+        assert_eq!(
+            resources
+                .kubeadm_config_template
+                .spec
+                .template
+                .spec
+                .expect("spec should be set")
+                .join_configuration
+                .expect("join configuration should be set")
+                .node_registration
+                .expect("node registration should be set")
+                .kubelet_extra_args
+                .expect("kubelet extra args should be set"),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_patches_with_empty_user_args() {
+        let feature = Feature {};
+
+        let values = default_values();
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let expected = btreemap! {
+            "cloud-provider".to_string() => "external".to_string(),
+            "tls-cipher-suites".to_string() => values.kubelet_tls_cipher_suites.clone(),
+        };
+
+        assert_eq!(
+            resources
+                .kubeadm_control_plane_template
+                .spec
+                .template
+                .spec
+                .kubeadm_config_spec
+                .init_configuration
+                .expect("init configuration should be set")
+                .node_registration
+                .expect("node registration should be set")
+                .kubelet_extra_args
+                .expect("kubelet extra args should be set"),
+            expected,
+        );
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -63,6 +63,7 @@ pub mod flavors;
 pub mod image_repository;
 pub mod images;
 pub mod keystone_auth;
+pub mod kubelet_extra_args;
 pub mod networks;
 pub mod openid_connect;
 pub mod operating_system;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -264,6 +264,7 @@ pub mod fixtures {
             .api_server_tls_cipher_suites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305".into())
             .api_server_sans("".into())
             .kubelet_tls_cipher_suites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305".into())
+            .kubelet_extra_args("".into())
             .hardware_disk_bus("".into())
             .enable_docker_volume(false)
             .docker_volume_size(0)
@@ -310,7 +311,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 39);
+        assert_eq!(variables.len(), 40);
 
         for var in &variables {
             match var.name.as_str() {
@@ -415,6 +416,9 @@ mod tests {
                 }
                 "kubeletTLSCipherSuites" => {
                     assert_eq!(var.value, json!(default_values().kubelet_tls_cipher_suites));
+                }
+                "kubeletExtraArgs" => {
+                    assert_eq!(var.value, json!(default_values().kubelet_extra_args));
                 }
                 "apiServerSANs" => {
                     assert_eq!(var.value, json!(default_values().api_server_sans));


### PR DESCRIPTION
Pass extra command-line flags to the kubelet on every control-plane and worker node in the cluster.
fixes #442