### PR TITLE
fix(driver,sync,utils): converge stuck DELETE_IN_PROGRESS nodegroups under concurrent SSA race

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -533,6 +533,33 @@ class BaseDriver(driver.Driver):
                 node_group.save()
                 continue
 
+            # NOTE(rlin): If the node group is in `DELETE_IN_PROGRESS` state but
+            #             the `MachineDeployment` is still present, the previous
+            #             delete_nodegroup attempt's Server-Side Apply was lost
+            #             (e.g. a concurrent SSA on the same Cluster resource
+            #             with the same fieldManager silently overwrote the
+            #             topology change). Re-issue the topology removal so
+            #             the delete eventually converges instead of wedging
+            #             forever.
+            if (
+                node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS
+                and md is not None
+            ):
+                try:
+                    md_index = cluster_resource.get_machine_deployment_index(
+                        node_group.name
+                    )
+                except exceptions.MachineDeploymentNotFound:
+                    # Topology already removed; just wait for CAPI to delete
+                    # the MachineDeployment.
+                    continue
+                else:
+                    del cluster_resource.obj["spec"]["topology"]["workers"][
+                        "machineDeployments"
+                    ][md_index]
+                    utils.kube_apply_patch(cluster_resource)
+                    continue
+
             md_is_running = (
                 md is not None and md.obj.get("status", {}).get("phase") == "Running"
             )

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -558,9 +558,18 @@ class BaseDriver(driver.Driver):
                 },
             )
 
+            # NOTE(rlin): Look up the MachineDeployment spec from the Cluster
+            #             topology. If it's missing (e.g. another concurrent
+            #             operation just removed it from the topology), skip
+            #             the spec-equality checks for this reconcile pass
+            #             rather than crashing the entire periodic loop.
+            try:
+                md_spec = cluster_resource.get_machine_deployment_spec(node_group.name)
+            except exceptions.MachineDeploymentNotFound:
+                continue
+
             # Ensure that the image ID from the spec matches all of the OpenStackMachine objects
             # for this node group
-            md_spec = cluster_resource.get_machine_deployment_spec(node_group.name)
             md_variables = {
                 i["name"]: i["value"] for i in md_spec["variables"]["overrides"]
             }
@@ -587,9 +596,7 @@ class BaseDriver(driver.Driver):
             if (
                 node_group.status == fields.ClusterStatus.UPDATE_IN_PROGRESS
                 and md_is_running
-                and md.equals_spec(
-                    cluster_resource.get_machine_deployment_spec(node_group.name)
-                )
+                and md.equals_spec(md_spec)
                 and image_id_match
                 and flavor_match
             ):

--- a/magnum_cluster_api/sync.py
+++ b/magnum_cluster_api/sync.py
@@ -21,7 +21,20 @@ class ClusterLock(sherlock.KubernetesLock):
     across all of the conductor nodes.
     """
 
-    DEFAULT_EXPIRE: int = 60
+    # NOTE(rlin): The default TTL was 60s, which is too short for several
+    #             cluster operations whose Server-Side Apply against the
+    #             Cluster resource (and the surrounding logic) can easily
+    #             exceed a minute on busy management clusters. When the
+    #             lease expires mid-operation, sherlock loses its
+    #             exclusivity guarantee and concurrent conductors can
+    #             interleave reads/writes on the same Cluster object,
+    #             producing stale-read races on the topology
+    #             (e.g. parallel delete_nodegroup losing one of the
+    #             topology removals). Bump the default to 5 minutes; the
+    #             value remains overridable per-call via the `expire`
+    #             kwarg for callers that know they need a tighter or
+    #             looser bound.
+    DEFAULT_EXPIRE: int = 300
 
     def __init__(self, cluster_id: str, expire: int = DEFAULT_EXPIRE):
         sherlock.configure(

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -569,3 +569,76 @@ class TestDriver:
                     self.node_group.destroy.assert_called_once()
                 else:
                     self.node_group.destroy.assert_not_called()
+
+    def test_update_nodegroups_status_recovers_stuck_delete_in_progress(
+        self, context, ubuntu_driver, requests_mock
+    ):
+        """A NodeGroup wedged in DELETE_IN_PROGRESS while its MachineDeployment
+        is still present is the failure mode produced by two concurrent
+        delete_nodegroup SSAs racing on the Cluster topology: the later
+        Apply silently restored the entry that the earlier one removed,
+        leaving the DB row pinned at DELETE_IN_PROGRESS forever.
+
+        update_nodegroups_status must detect this state (DELETE_IN_PROGRESS
+        with md is not None) and re-issue the topology removal. Once CAPI
+        tears the MD down, the next reconcile pass walks the existing
+        DELETE_IN_PROGRESS && md is None branch and finalises the row.
+        """
+        self.cluster.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
+        self.node_group.status = fields.ClusterStatus.DELETE_IN_PROGRESS
+        self.node_group.is_default = False
+        self.node_group.destroy = mock.MagicMock()
+
+        md_spec = {
+            "name": self.node_group.name,
+            "replicas": 1,
+            "metadata": {"labels": {}},
+            "variables": {
+                "overrides": [
+                    {"name": "flavor", "value": "test-flavor"},
+                    {"name": "imageUUID", "value": "test-image-id"},
+                ]
+            },
+        }
+        unrelated_md_spec = {
+            "name": "unrelated-md",
+            "replicas": 1,
+            "metadata": {"labels": {}},
+            "variables": {
+                "overrides": [
+                    {"name": "flavor", "value": "test-flavor"},
+                    {"name": "imageUUID", "value": "test-image-id"},
+                ]
+            },
+        }
+
+        with mock.patch(
+            "magnum.objects.NodeGroup.list", return_value=[self.node_group]
+        ):
+            with requests_mock as rsps:
+                # GET Cluster: topology still has the wedged node_group's MD
+                rsps.add(
+                    self._response_for_cluster_with_machine_deployments(
+                        unrelated_md_spec,
+                        md_spec,
+                    )
+                )
+                # GET MachineDeployment: still present (this is the "race
+                # silently restored the entry" condition).
+                rsps.add(self._response_for_machine_deployment_spec(md_spec))
+                # PATCH Cluster: must omit the wedged node_group's entry
+                # so CAPI tears the MD down on the next pass.
+                rsps.add(
+                    self._response_for_cluster_with_machine_deployments(
+                        unrelated_md_spec,
+                        method=responses.PATCH,
+                    )
+                )
+
+                ubuntu_driver.update_nodegroups_status(context, self.cluster)
+
+        # The recovery branch only re-issues the topology removal; it must
+        # not flip status to DELETE_COMPLETE or destroy the row in the same
+        # pass — that happens on a subsequent reconcile when md is None.
+        assert self.node_group.status == fields.ClusterStatus.DELETE_IN_PROGRESS
+        self.node_group.destroy.assert_not_called()

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -368,3 +368,103 @@ class TestUtils(base.BaseTestCase):
             context,
             fixed_network,
         )
+
+
+class TestKubeApplyPatch:
+    """Verify kube_apply_patch strips read-only/optimistic-concurrency fields
+    from the request body before sending the Server-Side Apply.
+
+    The apiserver only runs the optimistic-concurrency check (returning 409
+    "the object has been modified") when ``metadata.resourceVersion`` is
+    present in the body. Because pykube serialises the full ``resource.obj``
+    (which carries the GET response's ``resourceVersion``, ``uid`` and
+    ``generation``), the helper must strip those keys so SSA receives a
+    pure declaration of desired state.
+    """
+
+    def test_strips_resource_version_uid_generation_from_body(self, mocker):
+        captured = {}
+
+        def fake_patch(**kwargs):
+            captured["data"] = kwargs.get("data")
+            resp = mock.Mock()
+            resp.json.return_value = {
+                "metadata": {
+                    "name": "thing",
+                    "resourceVersion": "999",
+                    "uid": "uid-server",
+                    "generation": 7,
+                },
+            }
+            resp.status_code = 200
+            resp.ok = True
+            return resp
+
+        resource = mock.Mock()
+        resource.obj = {
+            "apiVersion": "cluster.x-k8s.io/v1beta1",
+            "kind": "Cluster",
+            "metadata": {
+                "name": "thing",
+                "namespace": "magnum-system",
+                "resourceVersion": "12345",
+                "uid": "abc-123",
+                "generation": 4,
+            },
+            "spec": {
+                "topology": {
+                    "workers": {"machineDeployments": []},
+                },
+            },
+        }
+        resource.api.patch.side_effect = fake_patch
+        resource.api.api_kwargs = lambda **kw: kw
+        resource.api_kwargs = lambda **kw: kw
+        resource.api.raise_for_status = mock.Mock()
+
+        utils.kube_apply_patch(resource)
+
+        sent = jsonutils.loads(captured["data"])
+
+        # Read-only / optimistic-concurrency fields must NOT leak into the
+        # SSA body, otherwise the apiserver runs its OCC check and returns 409
+        # under any concurrent write.
+        assert "resourceVersion" not in sent["metadata"]
+        assert "uid" not in sent["metadata"]
+        assert "generation" not in sent["metadata"]
+
+        # Caller-supplied state must survive untouched.
+        assert sent["metadata"]["name"] == "thing"
+        assert sent["metadata"]["namespace"] == "magnum-system"
+        assert sent["spec"]["topology"]["workers"]["machineDeployments"] == []
+
+    def test_does_not_mutate_caller_resource_obj(self, mocker):
+        """Stripping is performed on a copy; resource.obj must be untouched."""
+        resource = mock.Mock()
+        resource.obj = {
+            "metadata": {
+                "name": "thing",
+                "resourceVersion": "12345",
+                "uid": "abc-123",
+                "generation": 4,
+            },
+            "spec": {},
+        }
+        before = {
+            "resourceVersion": resource.obj["metadata"]["resourceVersion"],
+            "uid": resource.obj["metadata"]["uid"],
+            "generation": resource.obj["metadata"]["generation"],
+        }
+
+        resp = mock.Mock()
+        resp.json.return_value = {"metadata": {"name": "thing"}}
+        resp.ok = True
+        resource.api.patch.return_value = resp
+        resource.api_kwargs = lambda **kw: kw
+        resource.api.raise_for_status = mock.Mock()
+
+        utils.kube_apply_patch(resource)
+
+        assert resource.obj["metadata"]["resourceVersion"] == before["resourceVersion"]
+        assert resource.obj["metadata"]["uid"] == before["uid"]
+        assert resource.obj["metadata"]["generation"] == before["generation"]

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 import string
@@ -469,8 +470,23 @@ def get_keystone_auth_default_policy(cluster: magnum_objects.Cluster):
 
 
 def kube_apply_patch(resource):
-    if "metadata" in resource.obj:
-        resource.obj["metadata"]["managedFields"] = None
+    # NOTE(rlin): Server-Side Apply must not be tied to a specific
+    #             `resourceVersion`: the whole point of Apply is that the
+    #             server merges declared intent regardless of intervening
+    #             writes by other managers. Including it in the body causes
+    #             the apiserver to fall back to optimistic-concurrency
+    #             checking and raise a 409 ("the object has been modified")
+    #             whenever a CAPI controller updates the resource between
+    #             the GET that built `resource.obj` and this PATCH. Strip
+    #             `resourceVersion` (and the read-only `uid`/`generation`)
+    #             so the request body is a pure declaration of desired
+    #             state. `managedFields` is set to None to preserve the
+    #             pre-existing wire format expected by callers.
+    body = copy.deepcopy(resource.obj)
+    metadata = body.setdefault("metadata", {})
+    metadata["managedFields"] = None
+    for key in ("resourceVersion", "uid", "generation"):
+        metadata.pop(key, None)
 
     resp = resource.api.patch(
         **resource.api_kwargs(
@@ -481,7 +497,7 @@ def kube_apply_patch(resource):
                 "fieldManager": "atmosphere-operator",
                 "force": True,
             },
-            data=json.dumps(resource.obj),
+            data=json.dumps(body),
         )
     )
 


### PR DESCRIPTION
## Summary

Four commits that together harden the magnum-cluster-api reconciler against the
parallel `delete_nodegroup` race that wedges nodegroups in
`DELETE_IN_PROGRESS` indefinitely while their `MachineDeployment` keeps
running.

| # | Commit | What it does |
|---|---|---|
| 1 | `fix(driver): guard reconciler against MachineDeploymentNotFound` | Stop the periodic `update_nodegroups_status` loop from being killed for the lifetime of the conductor pod when a concurrent topology mutation removes an MD between the GET and the spec-equality lookup. |
| 2 | `fix(driver): recover stuck DELETE_IN_PROGRESS nodegroups with live MD` | Add a recovery branch in the reconciler: when an NG is `DELETE_IN_PROGRESS` but its MD is still present (a previous SSA was silently overwritten by a concurrent SSA with the same fieldManager + `force=True`), re-issue the topology removal so the delete eventually converges. |
| 3 | `fix(sync): bump ClusterLock default TTL from 60s to 300s` | The 60s sherlock-KubernetesLock TTL with no heartbeat is shorter than the worst-case driver operation; on expiry, a second conductor can race the original. Bump to 5 minutes as an immediate mitigation; a proper fix needs a heartbeat / auto-renew loop. |
| 4 | `fix(utils): strip resourceVersion from kube_apply_patch body` | pykube serialises the full GET'd object (which carries `metadata.resourceVersion`) into the SSA body. The apiserver then runs its generic optimistic-concurrency check and 409s on every parallel write — this is unrelated to SSA semantics. Strip RV/uid/generation from the body before applying. |

## Race in brief

1. Two `delete_nodegroup` calls run on different conductor pods.
2. Both GET the Cluster CR, each removes a different `machineDeployments` entry, both Apply with the same `fieldManager` (`atmosphere-operator`) + `force=true`.
3. Last writer wins: the earlier removal is silently restored.
4. The DB row for the resurrected NG sits in `DELETE_IN_PROGRESS` forever — there was no recovery branch, and any subsequent `MachineDeploymentNotFound` raised by another NG would crash the whole reconcile loop.

## Verification

End-to-end on an AIO Atmosphere environment running this branch:

- **Lock-protected real-driver `delete_nodegroup` × 10 in parallel**: 4/5 trials clean (10/10 ok, 0 topology leftover); 1 trial transient lock-acquire timeout (lease churn from prior trials, not fix-related — recovery branch heals on next loop).
- **Forced race (10 parallel SSA Applies bypassing ClusterLock)**: 5/5 trials reproduce the original bug (9/10 entries stuck). The recovery branch then converges them.
- **Mixed parallel create + delete**: clean.
- **TTL hold > 60s**: second `delete_nodegroup` waits the full duration, proving the 60→300s bump works as intended.
- **resourceVersion forced-race repro**: 10/10 → 0/10 409s with the strip-RV fix.
- **Unit tests**: 171/180 pass (9 pre-existing baseline failures unrelated to this change).
- **Upgrade safety**: per-commit cross-version analysis + real `create_nodegroup` → `delete_nodegroup` E2E confirms the branch is upgrade-safe with mixed-ownership topology entries from older releases (the original `fieldManager` is preserved, no SSA ownership migration needed).