### PR TITLE
Support config profiles

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,51 @@ use glob::glob;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::{env, error::Error, fs, path::Path};
-use syn::{parse_file, Ident, Item, Type};
+use syn::{parse_file, GenericArgument, Ident, Item, PathArguments, Type, TypePath};
 use vergen_gix::{Emitter, Gix};
+
+fn extract_vec_inner(type_path: &TypePath) -> Option<TokenStream> {
+    let last = type_path.path.segments.last()?;
+    if last.ident != "Vec" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    if args.args.len() != 1 {
+        return None;
+    }
+    let GenericArgument::Type(Type::Path(inner_path)) = args.args.first()? else {
+        return None;
+    };
+    if inner_path.path.segments.len() != 1 {
+        return None;
+    }
+    let inner_seg = inner_path.path.segments.first()?;
+    if !matches!(inner_seg.arguments, PathArguments::None) {
+        return None;
+    }
+    let ident = &inner_seg.ident;
+    let ident_str = ident.to_string();
+    if matches!(
+        ident_str.as_str(),
+        "String"
+            | "bool"
+            | "i8"
+            | "i16"
+            | "i32"
+            | "i64"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "f32"
+            | "f64"
+    ) {
+        return None;
+    }
+    Some(quote! { #ident })
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let gix = Gix::builder()
@@ -62,6 +105,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                                         || type_name == "Vec < String >"
                                     {
                                         quote! { #ty }
+                                    } else if let Some(inner) = extract_vec_inner(type_path) {
+                                        quote! { Vec<crate::features::#mod_ident::#inner> }
                                     } else {
                                         println!(
                                             "cargo-warning: {} is not a primitive type",

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -65,7 +65,10 @@ Users select the cluster default profile with the `config_profile` cluster
 template label.  Users select nodegroup-specific layout with the
 `nodegroup_config_profile_set` cluster template label.  Unknown profile names,
 invalid layout profiles, and layout profiles that reference unknown profiles
-must be rejected during cluster validation and rendering.
+must be rejected during cluster validation and rendering.  Cluster-create label
+overrides for these selector labels are rejected because profile content is
+bootstrap-time configuration; changing the cluster row labels alone would not
+rerun cloud-init or kubeadm on existing nodes.
 
 The cluster default profile renders as the `configProfile` Cluster topology
 variable.  Layout profile entries render as MachineDeployment-level

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -10,3 +10,47 @@ In order to do this, the driver creates a [`ClusterClass`](https://cluster-api.s
 It's important to note that there are only _one_ scenarios where the `spec.topology.class` for a given `Cluster` will be modified and this will be when a cluster upgrade is done.  This is because there is an expectation by the user that a rolling restart operation will occur if a cluster upgrade is requested.  No other action should be allowed to change the `spec.topology.class` of a `Cluster`.
 
 For users, it's important to keep in mind that if they want to use a newer `ClusterClass` in order to make sure of a new feature available in a newer `ClusterClass`, they can simply do an upgrade within Magnum to the same cluster template and it will actually force an update of the `spec.topology.class`, which might then naturally cause a full rollout to occur.
+
+## Kubelet configuration profiles
+
+Kubelet configuration profiles are operator-defined management-cluster
+resources.  They let users select a reviewed kubelet tuning mode without
+exposing an arbitrary `KubeletConfiguration` JSON passthrough in Magnum labels.
+
+Profiles are defined in the `mcapi-kubelet-config-profiles` ConfigMap in the
+management cluster namespace, normally `magnum-system`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcapi-kubelet-config-profiles
+  namespace: magnum-system
+data:
+  profile-gpu: |
+    cpuManagerPolicy: static
+    topologyManagerPolicy: single-numa-node
+    reservedSystemCPUs: 0-1
+    maxPods: 250
+
+  profile-bm-gpu-layout: |
+    nodegroups:
+      gpu-workers:
+        kubeletConfigProfile: profile-gpu
+```
+
+Each kubelet profile value is a YAML object.  Supported kubelet profile fields
+are `cpuManagerPolicy`, `topologyManagerPolicy`, `reservedSystemCPUs`, and
+`maxPods`.  Layout profiles use a `nodegroups` object that maps nodegroup names
+to `kubeletConfigProfile` references.
+
+Users select the cluster default profile with the `kubelet_config_profile`
+label.  Users select nodegroup-specific layout with
+`kubelet_nodegroup_config_profile_set`.  Unknown profile names, invalid layout
+profiles, and layout profiles that reference unknown kubelet profiles must be
+rejected during cluster validation and in the kubelet config rendering path.
+
+The cluster default profile renders as the `kubeletConfig` Cluster topology
+variable.  Layout profile entries render as MachineDeployment-level
+`kubeletConfig` variable overrides, so a worker pool such as `gpu-workers` can
+receive a different kubelet configuration from the cluster default.

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -18,8 +18,7 @@ let users select reviewed node bootstrap changes without exposing arbitrary
 cloud-init or kubeadm configuration in Magnum labels.
 
 Profiles are defined in the `mcapi-config-profiles` ConfigMap in the management
-cluster namespace, normally `magnum-system`.  The legacy
-`mcapi-kubelet-config-profiles` ConfigMap name is still accepted as a fallback:
+cluster namespace, normally `magnum-system`:
 
 ```yaml
 apiVersion: v1
@@ -57,18 +56,15 @@ Each profile value is a YAML object.  `kubeletConfig` contains a kubeadm
 `KubeletConfiguration` fragment; Magnum renders `apiVersion` and `kind`, so the
 fragment must not set those fields.  `files`, `preKubeadmCommands`, and
 `postKubeadmCommands` are rendered into CAPI kubeadm config fields for the
-control plane and workers.  Legacy kubelet-only profile values without a
-`kubeletConfig` wrapper are still accepted.
+control plane and workers.
 
 Layout profiles use a `nodegroups` object that maps nodegroup names to `profile`
-references.  The legacy `kubeletConfigProfile` key is still accepted.
+references.
 
 Users select the cluster default profile with the `config_profile` label.  Users
-select nodegroup-specific layout with `nodegroup_config_profile_set`.  The
-legacy `kubelet_config_profile` and `kubelet_nodegroup_config_profile_set`
-labels remain aliases.  Unknown profile names, invalid layout profiles, and
-layout profiles that reference unknown profiles must be rejected during cluster
-validation and rendering.
+select nodegroup-specific layout with `nodegroup_config_profile_set`.  Unknown
+profile names, invalid layout profiles, and layout profiles that reference
+unknown profiles must be rejected during cluster validation and rendering.
 
 The cluster default profile renders as the `configProfile` Cluster topology
 variable.  Layout profile entries render as MachineDeployment-level

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -11,51 +11,67 @@ It's important to note that there are only _one_ scenarios where the `spec.topol
 
 For users, it's important to keep in mind that if they want to use a newer `ClusterClass` in order to make sure of a new feature available in a newer `ClusterClass`, they can simply do an upgrade within Magnum to the same cluster template and it will actually force an update of the `spec.topology.class`, which might then naturally cause a full rollout to occur.
 
-## Kubelet configuration profiles
+## Configuration profiles
 
-Kubelet configuration profiles are operator-defined management-cluster
-resources.  They let users select a reviewed kubelet tuning mode without
-exposing an arbitrary `KubeletConfiguration` JSON passthrough in Magnum labels.
+Configuration profiles are operator-defined management-cluster resources.  They
+let users select reviewed node bootstrap changes without exposing arbitrary
+cloud-init or kubeadm configuration in Magnum labels.
 
-Profiles are defined in the `mcapi-kubelet-config-profiles` ConfigMap in the
-management cluster namespace, normally `magnum-system`:
+Profiles are defined in the `mcapi-config-profiles` ConfigMap in the management
+cluster namespace, normally `magnum-system`.  The legacy
+`mcapi-kubelet-config-profiles` ConfigMap name is still accepted as a fallback:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mcapi-kubelet-config-profiles
+  name: mcapi-config-profiles
   namespace: magnum-system
 data:
   profile-gpu: |
-    cpuManagerPolicy: static
-    cpuManagerPolicyOptions:
-      full-pcpus-only: "true"
-    memoryManagerPolicy: Static
-    topologyManagerPolicy: single-numa-node
-    topologyManagerScope: pod
-    reservedSystemCPUs: 0-1
-    maxPods: 250
+    kubeletConfig:
+      cpuManagerPolicy: static
+      cpuManagerPolicyOptions:
+        full-pcpus-only: "true"
+      memoryManagerPolicy: Static
+      topologyManagerPolicy: single-numa-node
+      topologyManagerScope: pod
+      reservedSystemCPUs: 0-1
+      maxPods: 250
+    files:
+      - path: /etc/gpu-init.sh
+        permissions: "0755"
+        content: |
+          #!/bin/bash
+          modprobe nvidia || true
+    preKubeadmCommands:
+      - bash /etc/gpu-init.sh
 
   profile-bm-gpu-layout: |
     nodegroups:
       gpu-workers:
-        kubeletConfigProfile: profile-gpu
+        profile: profile-gpu
 ```
 
-Each kubelet profile value is a YAML object containing a kubeadm
-`KubeletConfiguration` fragment.  Magnum renders `apiVersion` and `kind`, so
-profiles must not set those fields.  Layout profiles use a `nodegroups` object
-that maps nodegroup names to `kubeletConfigProfile` references, so ordinary
-kubelet profiles must not set `nodegroups`.
+Each profile value is a YAML object.  `kubeletConfig` contains a kubeadm
+`KubeletConfiguration` fragment; Magnum renders `apiVersion` and `kind`, so the
+fragment must not set those fields.  `files`, `preKubeadmCommands`, and
+`postKubeadmCommands` are rendered into CAPI kubeadm config fields for the
+control plane and workers.  Legacy kubelet-only profile values without a
+`kubeletConfig` wrapper are still accepted.
 
-Users select the cluster default profile with the `kubelet_config_profile`
-label.  Users select nodegroup-specific layout with
-`kubelet_nodegroup_config_profile_set`.  Unknown profile names, invalid layout
-profiles, and layout profiles that reference unknown kubelet profiles must be
-rejected during cluster validation and in the kubelet config rendering path.
+Layout profiles use a `nodegroups` object that maps nodegroup names to `profile`
+references.  The legacy `kubeletConfigProfile` key is still accepted.
 
-The cluster default profile renders as the `kubeletConfig` Cluster topology
+Users select the cluster default profile with the `config_profile` label.  Users
+select nodegroup-specific layout with `nodegroup_config_profile_set`.  The
+legacy `kubelet_config_profile` and `kubelet_nodegroup_config_profile_set`
+labels remain aliases.  Unknown profile names, invalid layout profiles, and
+layout profiles that reference unknown profiles must be rejected during cluster
+validation and rendering.
+
+The cluster default profile renders as the `configProfile` Cluster topology
 variable.  Layout profile entries render as MachineDeployment-level
-`kubeletConfig` variable overrides, so a worker pool such as `gpu-workers` can
-receive a different kubelet configuration from the cluster default.
+`configProfile` variable overrides, so a worker pool such as `gpu-workers` can
+receive different files, commands, and kubelet configuration from the cluster
+default.

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -35,7 +35,7 @@ data:
       memoryManagerPolicy: Static
       topologyManagerPolicy: single-numa-node
       topologyManagerScope: pod
-      reservedSystemCPUs: 0-1
+      reservedSystemCPUs: "0-1"
       maxPods: 250
     files:
       - path: /etc/gpu-init.sh
@@ -57,6 +57,11 @@ Each profile value is a YAML object.  `kubeletConfig` contains a kubeadm
 fragment must not set those fields.  `files`, `preKubeadmCommands`, and
 `postKubeadmCommands` are rendered into CAPI kubeadm config fields for the
 control plane and workers.
+
+Any of `kubeletConfig`, `files`, `preKubeadmCommands`, or
+`postKubeadmCommands` can be used by itself in a profile. String-typed kubelet
+fields must remain YAML strings even when the value looks numeric; for example,
+use `reservedSystemCPUs: "0"` or `reservedSystemCPUs: "0-1"`.
 
 Layout profiles use a `nodegroups` object that maps nodegroup names to `profile`
 references.

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -61,10 +61,11 @@ control plane and workers.
 Layout profiles use a `nodegroups` object that maps nodegroup names to `profile`
 references.
 
-Users select the cluster default profile with the `config_profile` label.  Users
-select nodegroup-specific layout with `nodegroup_config_profile_set`.  Unknown
-profile names, invalid layout profiles, and layout profiles that reference
-unknown profiles must be rejected during cluster validation and rendering.
+Users select the cluster default profile with the `config_profile` cluster
+template label.  Users select nodegroup-specific layout with the
+`nodegroup_config_profile_set` cluster template label.  Unknown profile names,
+invalid layout profiles, and layout profiles that reference unknown profiles
+must be rejected during cluster validation and rendering.
 
 The cluster default profile renders as the `configProfile` Cluster topology
 variable.  Layout profile entries render as MachineDeployment-level

--- a/docs/developer/cluster-topology.md
+++ b/docs/developer/cluster-topology.md
@@ -29,7 +29,11 @@ metadata:
 data:
   profile-gpu: |
     cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    memoryManagerPolicy: Static
     topologyManagerPolicy: single-numa-node
+    topologyManagerScope: pod
     reservedSystemCPUs: 0-1
     maxPods: 250
 
@@ -39,10 +43,11 @@ data:
         kubeletConfigProfile: profile-gpu
 ```
 
-Each kubelet profile value is a YAML object.  Supported kubelet profile fields
-are `cpuManagerPolicy`, `topologyManagerPolicy`, `reservedSystemCPUs`, and
-`maxPods`.  Layout profiles use a `nodegroups` object that maps nodegroup names
-to `kubeletConfigProfile` references.
+Each kubelet profile value is a YAML object containing a kubeadm
+`KubeletConfiguration` fragment.  Magnum renders `apiVersion` and `kind`, so
+profiles must not set those fields.  Layout profiles use a `nodegroups` object
+that maps nodegroup names to `kubeletConfigProfile` references, so ordinary
+kubelet profiles must not set `nodegroups`.
 
 Users select the cluster default profile with the `kubelet_config_profile`
 label.  Users select nodegroup-specific layout with

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -236,6 +236,8 @@ is often accomplished by deploying a driver on each node.
    Select an operator-defined kubelet configuration profile rendered through a
    kubeadm `KubeletConfiguration` patch.  Supported values depend on the
    `mcapi-kubelet-config-profiles` ConfigMap in the management cluster.
+   Profiles are kubeadm `KubeletConfiguration` fragments; Magnum adds
+   `apiVersion` and `kind` when rendering the patch.
    Users cannot create new profiles through cluster labels.  Unknown profile
    names are rejected during cluster validation.  Magnum's cluster update API
    does not currently allow changing `labels`, so change this value after

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -231,6 +231,40 @@ is often accomplished by deploying a driver on each node.
 
    Default value: `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`
 
+* `kubelet_config_profile`
+
+   Select an operator-defined kubelet configuration profile rendered through a
+   kubeadm `KubeletConfiguration` patch.  Supported values depend on the
+   `mcapi-kubelet-config-profiles` ConfigMap in the management cluster.
+   Users cannot create new profiles through cluster labels.  Unknown profile
+   names are rejected during cluster validation.  Magnum's cluster update API
+   does not currently allow changing `labels`, so change this value after
+   creation by upgrading to a cluster template that selects a different profile.
+
+   Default value: unset
+
+* `kubelet_nodegroup_config_profile_set`
+
+   Select an operator-defined nodegroup layout profile from the same
+   `mcapi-kubelet-config-profiles` ConfigMap.  The layout maps nodegroup names
+   to kubelet profiles and renders MachineDeployment-level `kubeletConfig`
+   overrides.  Unknown layout profiles or layouts that reference unknown kubelet
+   profiles are rejected during cluster validation.
+
+   Default value: unset
+
+   Example:
+
+   ```bash
+   openstack coe cluster create bm-gpu \
+     --cluster-template k8s-bm \
+     --labels kubelet_config_profile=profile-standard \
+     --labels kubelet_nodegroup_config_profile_set=profile-bm-gpu-layout
+   ```
+
+   See [Use Cases](use-cases.md#gpu-and-numa-aware-kubelet-tuning) for a
+   complete GPU and NUMA-aware cluster example.
+
 * `kube_tag`
 
    The version of Kubernetes to use.

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -238,7 +238,9 @@ is often accomplished by deploying a driver on each node.
    `mcapi-config-profiles` ConfigMap in the management cluster.  Profiles can
    include `kubeletConfig`, `files`, `preKubeadmCommands`, and
    `postKubeadmCommands`.  Magnum adds `apiVersion` and `kind` when rendering
-   the kubelet patch.
+   the kubelet patch.  Each of those profile keys can be used on its own.
+   String-typed kubelet fields must be quoted in profile YAML when they look
+   numeric, for example `reservedSystemCPUs: "0"`.
    Users cannot create new profiles through Magnum labels.  Unknown profile
    names are rejected during cluster validation.  Magnum's cluster update API
    does not currently allow changing `labels`, so change this value after

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -243,6 +243,8 @@ is often accomplished by deploying a driver on each node.
    names are rejected during cluster validation.  Magnum's cluster update API
    does not currently allow changing `labels`, so change this value after
    creation by upgrading to a cluster template that selects a different profile.
+   Passing this label directly to `openstack coe cluster create --labels`
+   is rejected unless the value matches the selected cluster template.
 
    Default value: unset
 
@@ -252,7 +254,9 @@ is often accomplished by deploying a driver on each node.
    `mcapi-config-profiles` ConfigMap.  The layout maps nodegroup names to
    profiles and renders MachineDeployment-level `configProfile` overrides.
    Unknown layout profiles or layouts that reference unknown profiles are
-   rejected during cluster validation.
+   rejected during cluster validation.  Passing this label directly to
+   `openstack coe cluster create --labels` is rejected unless the value matches
+   the selected cluster template.
 
    Default value: unset
 

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -243,7 +243,6 @@ is often accomplished by deploying a driver on each node.
    names are rejected during cluster validation.  Magnum's cluster update API
    does not currently allow changing `labels`, so change this value after
    creation by upgrading to a cluster template that selects a different profile.
-   The legacy `kubelet_config_profile` label is still accepted as an alias.
 
    Default value: unset
 
@@ -253,8 +252,7 @@ is often accomplished by deploying a driver on each node.
    `mcapi-config-profiles` ConfigMap.  The layout maps nodegroup names to
    profiles and renders MachineDeployment-level `configProfile` overrides.
    Unknown layout profiles or layouts that reference unknown profiles are
-   rejected during cluster validation.  The legacy
-   `kubelet_nodegroup_config_profile_set` label is still accepted as an alias.
+   rejected during cluster validation.
 
    Default value: unset
 

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -239,7 +239,7 @@ is often accomplished by deploying a driver on each node.
    include `kubeletConfig`, `files`, `preKubeadmCommands`, and
    `postKubeadmCommands`.  Magnum adds `apiVersion` and `kind` when rendering
    the kubelet patch.
-   Users cannot create new profiles through cluster labels.  Unknown profile
+   Users cannot create new profiles through Magnum labels.  Unknown profile
    names are rejected during cluster validation.  Magnum's cluster update API
    does not currently allow changing `labels`, so change this value after
    creation by upgrading to a cluster template that selects a different profile.
@@ -259,10 +259,13 @@ is often accomplished by deploying a driver on each node.
    Example:
 
    ```bash
-   openstack coe cluster create bm-gpu \
-     --cluster-template k8s-bm \
+   openstack coe cluster template create k8s-bm-gpu \
+     ...same base template options... \
      --labels config_profile=profile-standard \
      --labels nodegroup_config_profile_set=profile-bm-gpu-layout
+
+   openstack coe cluster create bm-gpu \
+     --cluster-template k8s-bm-gpu
    ```
 
    See [Use Cases](use-cases.md#gpu-and-numa-aware-kubelet-tuning) for a

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -231,27 +231,30 @@ is often accomplished by deploying a driver on each node.
 
    Default value: `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`
 
-* `kubelet_config_profile`
+* `config_profile`
 
-   Select an operator-defined kubelet configuration profile rendered through a
-   kubeadm `KubeletConfiguration` patch.  Supported values depend on the
-   `mcapi-kubelet-config-profiles` ConfigMap in the management cluster.
-   Profiles are kubeadm `KubeletConfiguration` fragments; Magnum adds
-   `apiVersion` and `kind` when rendering the patch.
+   Select an operator-defined configuration profile rendered through CAPI
+   kubeadm config fields.  Supported values depend on the
+   `mcapi-config-profiles` ConfigMap in the management cluster.  Profiles can
+   include `kubeletConfig`, `files`, `preKubeadmCommands`, and
+   `postKubeadmCommands`.  Magnum adds `apiVersion` and `kind` when rendering
+   the kubelet patch.
    Users cannot create new profiles through cluster labels.  Unknown profile
    names are rejected during cluster validation.  Magnum's cluster update API
    does not currently allow changing `labels`, so change this value after
    creation by upgrading to a cluster template that selects a different profile.
+   The legacy `kubelet_config_profile` label is still accepted as an alias.
 
    Default value: unset
 
-* `kubelet_nodegroup_config_profile_set`
+* `nodegroup_config_profile_set`
 
    Select an operator-defined nodegroup layout profile from the same
-   `mcapi-kubelet-config-profiles` ConfigMap.  The layout maps nodegroup names
-   to kubelet profiles and renders MachineDeployment-level `kubeletConfig`
-   overrides.  Unknown layout profiles or layouts that reference unknown kubelet
-   profiles are rejected during cluster validation.
+   `mcapi-config-profiles` ConfigMap.  The layout maps nodegroup names to
+   profiles and renders MachineDeployment-level `configProfile` overrides.
+   Unknown layout profiles or layouts that reference unknown profiles are
+   rejected during cluster validation.  The legacy
+   `kubelet_nodegroup_config_profile_set` label is still accepted as an alias.
 
    Default value: unset
 
@@ -260,8 +263,8 @@ is often accomplished by deploying a driver on each node.
    ```bash
    openstack coe cluster create bm-gpu \
      --cluster-template k8s-bm \
-     --labels kubelet_config_profile=profile-standard \
-     --labels kubelet_nodegroup_config_profile_set=profile-bm-gpu-layout
+     --labels config_profile=profile-standard \
+     --labels nodegroup_config_profile_set=profile-bm-gpu-layout
    ```
 
    See [Use Cases](use-cases.md#gpu-and-numa-aware-kubelet-tuning) for a

--- a/docs/user/use-cases.md
+++ b/docs/user/use-cases.md
@@ -1,0 +1,108 @@
+# Use Cases
+
+## GPU and NUMA-aware kubelet tuning
+
+Baremetal and GPU clusters often need kubelet CPU and topology settings so
+workloads can use predictable CPU pinning and NUMA-aware scheduling behavior.
+Use an operator-defined `profile-gpu` kubelet configuration profile to select a
+reviewed kubelet configuration.
+
+The cloud operator must define the profile in the management cluster before
+users can select it.  Profiles are operator-managed entries in the
+`mcapi-kubelet-config-profiles` ConfigMap, normally in the `magnum-system`
+namespace:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcapi-kubelet-config-profiles
+  namespace: magnum-system
+data:
+  profile-gpu: |
+    cpuManagerPolicy: static
+    topologyManagerPolicy: single-numa-node
+    reservedSystemCPUs: 0-1
+    maxPods: 250
+```
+
+```bash
+openstack coe cluster create bm-gpu \
+  --cluster-template k8s-bm \
+  --labels kubelet_config_profile=profile-gpu
+```
+
+This renders a kubeadm `KubeletConfiguration` patch similar to:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cpuManagerPolicy: static
+topologyManagerPolicy: single-numa-node
+reservedSystemCPUs: 0-1
+maxPods: 250
+```
+
+Kubelet profiles are defined by the cloud operator in the management cluster.
+Magnum users select a supported profile with `kubelet_config_profile`; they do
+not create new profiles through cluster labels.  If the ConfigMap is missing or
+an unknown profile name is passed, cluster validation fails.
+
+To change kubelet configuration after cluster creation, use Magnum cluster
+upgrade to a cluster template that selects a different profile:
+
+```bash
+openstack coe cluster template create k8s-bm-gpu-v2 \
+  ...same base template options... \
+  --labels kubelet_config_profile=profile-gpu
+
+openstack coe cluster upgrade bm-gpu k8s-bm-gpu-v2
+```
+
+The driver does not accept arbitrary kubelet JSON configuration through labels.
+It also does not expose individual kubelet fields as Magnum labels.  If another
+kubelet field needs to be exposed, the cloud operator should add it to a named
+profile.
+
+## Nodegroup-specific kubelet tuning
+
+Some baremetal clusters need special kubelet settings only for a subset of
+worker pools.  For example, a `gpu-workers` nodegroup may need static CPU
+manager and NUMA-aware topology settings, while default workers should keep the
+standard kubelet configuration.
+
+Use `kubelet_config_profile` for the cluster default and
+`kubelet_nodegroup_config_profile_set` for an operator-defined nodegroup layout:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcapi-kubelet-config-profiles
+  namespace: magnum-system
+data:
+  profile-standard: |
+    maxPods: 110
+
+  profile-gpu: |
+    cpuManagerPolicy: static
+    topologyManagerPolicy: single-numa-node
+    reservedSystemCPUs: 0-1
+    maxPods: 250
+
+  profile-bm-gpu-layout: |
+    nodegroups:
+      gpu-workers:
+        kubeletConfigProfile: profile-gpu
+```
+
+```bash
+openstack coe cluster create bm-gpu \
+  --cluster-template k8s-bm \
+  --labels kubelet_config_profile=profile-standard \
+  --labels kubelet_nodegroup_config_profile_set=profile-bm-gpu-layout
+```
+
+The cluster default profile applies to the control plane and worker
+MachineDeployments not mentioned by the layout.  The layout profile renders a
+MachineDeployment-level `kubeletConfig` override for `gpu-workers`.

--- a/docs/user/use-cases.md
+++ b/docs/user/use-cases.md
@@ -67,7 +67,9 @@ Configuration profiles are defined by the cloud operator in the management
 cluster.  Magnum users select a supported profile with the `config_profile`
 cluster template label; they do not create new profiles through Magnum labels.
 If the ConfigMap is missing or an unknown profile name is passed, cluster
-validation fails.
+validation fails.  Magnum rejects cluster-create label overrides for profile
+selector labels so existing nodes do not appear to accept mutable bootstrap
+configuration that would not be rerun in place.
 
 To change kubelet configuration after cluster creation, use Magnum cluster
 upgrade to a cluster template that selects a different profile:

--- a/docs/user/use-cases.md
+++ b/docs/user/use-cases.md
@@ -4,36 +4,45 @@
 
 Baremetal and GPU clusters often need kubelet CPU and topology settings so
 workloads can use predictable CPU pinning and NUMA-aware scheduling behavior.
-Use an operator-defined `profile-gpu` kubelet configuration profile to select a
-reviewed kubelet configuration.
+Use an operator-defined `profile-gpu` configuration profile to select reviewed
+kubelet and bootstrap configuration.
 
 The cloud operator must define the profile in the management cluster before
 users can select it.  Profiles are operator-managed entries in the
-`mcapi-kubelet-config-profiles` ConfigMap, normally in the `magnum-system`
+`mcapi-config-profiles` ConfigMap, normally in the `magnum-system`
 namespace:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mcapi-kubelet-config-profiles
+  name: mcapi-config-profiles
   namespace: magnum-system
 data:
   profile-gpu: |
-    cpuManagerPolicy: static
-    cpuManagerPolicyOptions:
-      full-pcpus-only: "true"
-    memoryManagerPolicy: Static
-    topologyManagerPolicy: single-numa-node
-    topologyManagerScope: pod
-    reservedSystemCPUs: 0-1
-    maxPods: 250
+    kubeletConfig:
+      cpuManagerPolicy: static
+      cpuManagerPolicyOptions:
+        full-pcpus-only: "true"
+      memoryManagerPolicy: Static
+      topologyManagerPolicy: single-numa-node
+      topologyManagerScope: pod
+      reservedSystemCPUs: 0-1
+      maxPods: 250
+    files:
+      - path: /etc/gpu-init.sh
+        permissions: "0755"
+        content: |
+          #!/bin/bash
+          modprobe nvidia || true
+    preKubeadmCommands:
+      - bash /etc/gpu-init.sh
 ```
 
 ```bash
 openstack coe cluster create bm-gpu \
   --cluster-template k8s-bm \
-  --labels kubelet_config_profile=profile-gpu
+  --labels config_profile=profile-gpu
 ```
 
 This renders a kubeadm `KubeletConfiguration` patch similar to:
@@ -51,8 +60,8 @@ reservedSystemCPUs: 0-1
 maxPods: 250
 ```
 
-Kubelet profiles are defined by the cloud operator in the management cluster.
-Magnum users select a supported profile with `kubelet_config_profile`; they do
+Configuration profiles are defined by the cloud operator in the management cluster.
+Magnum users select a supported profile with `config_profile`; they do
 not create new profiles through cluster labels.  If the ConfigMap is missing or
 an unknown profile name is passed, cluster validation fails.
 
@@ -62,15 +71,15 @@ upgrade to a cluster template that selects a different profile:
 ```bash
 openstack coe cluster template create k8s-bm-gpu-v2 \
   ...same base template options... \
-  --labels kubelet_config_profile=profile-gpu
+  --labels config_profile=profile-gpu
 
 openstack coe cluster upgrade bm-gpu k8s-bm-gpu-v2
 ```
 
 The driver does not accept arbitrary kubelet JSON configuration through labels.
-It also does not expose individual kubelet fields as Magnum labels.  Cloud
-operators define named kubeadm `KubeletConfiguration` fragments in the profile
-ConfigMap, and users select those named profiles.
+It also does not expose individual kubelet fields or cloud-init snippets as
+Magnum labels.  Cloud operators define named profiles in the profile ConfigMap,
+and users select those named profiles.
 
 ## Nodegroup-specific kubelet tuning
 
@@ -79,42 +88,44 @@ worker pools.  For example, a `gpu-workers` nodegroup may need static CPU
 manager and NUMA-aware topology settings, while default workers should keep the
 standard kubelet configuration.
 
-Use `kubelet_config_profile` for the cluster default and
-`kubelet_nodegroup_config_profile_set` for an operator-defined nodegroup layout:
+Use `config_profile` for the cluster default and
+`nodegroup_config_profile_set` for an operator-defined nodegroup layout:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mcapi-kubelet-config-profiles
+  name: mcapi-config-profiles
   namespace: magnum-system
 data:
   profile-standard: |
-    maxPods: 110
+    kubeletConfig:
+      maxPods: 110
 
   profile-gpu: |
-    cpuManagerPolicy: static
-    cpuManagerPolicyOptions:
-      full-pcpus-only: "true"
-    memoryManagerPolicy: Static
-    topologyManagerPolicy: single-numa-node
-    topologyManagerScope: pod
-    reservedSystemCPUs: 0-1
-    maxPods: 250
+    kubeletConfig:
+      cpuManagerPolicy: static
+      cpuManagerPolicyOptions:
+        full-pcpus-only: "true"
+      memoryManagerPolicy: Static
+      topologyManagerPolicy: single-numa-node
+      topologyManagerScope: pod
+      reservedSystemCPUs: 0-1
+      maxPods: 250
 
   profile-bm-gpu-layout: |
     nodegroups:
       gpu-workers:
-        kubeletConfigProfile: profile-gpu
+        profile: profile-gpu
 ```
 
 ```bash
 openstack coe cluster create bm-gpu \
   --cluster-template k8s-bm \
-  --labels kubelet_config_profile=profile-standard \
-  --labels kubelet_nodegroup_config_profile_set=profile-bm-gpu-layout
+  --labels config_profile=profile-standard \
+  --labels nodegroup_config_profile_set=profile-bm-gpu-layout
 ```
 
 The cluster default profile applies to the control plane and worker
 MachineDeployments not mentioned by the layout.  The layout profile renders a
-MachineDeployment-level `kubeletConfig` override for `gpu-workers`.
+MachineDeployment-level `configProfile` override for `gpu-workers`.

--- a/docs/user/use-cases.md
+++ b/docs/user/use-cases.md
@@ -40,9 +40,12 @@ data:
 ```
 
 ```bash
-openstack coe cluster create bm-gpu \
-  --cluster-template k8s-bm \
+openstack coe cluster template create k8s-bm-gpu \
+  ...same base template options... \
   --labels config_profile=profile-gpu
+
+openstack coe cluster create bm-gpu \
+  --cluster-template k8s-bm-gpu
 ```
 
 This renders a kubeadm `KubeletConfiguration` patch similar to:
@@ -60,10 +63,11 @@ reservedSystemCPUs: 0-1
 maxPods: 250
 ```
 
-Configuration profiles are defined by the cloud operator in the management cluster.
-Magnum users select a supported profile with `config_profile`; they do
-not create new profiles through cluster labels.  If the ConfigMap is missing or
-an unknown profile name is passed, cluster validation fails.
+Configuration profiles are defined by the cloud operator in the management
+cluster.  Magnum users select a supported profile with the `config_profile`
+cluster template label; they do not create new profiles through Magnum labels.
+If the ConfigMap is missing or an unknown profile name is passed, cluster
+validation fails.
 
 To change kubelet configuration after cluster creation, use Magnum cluster
 upgrade to a cluster template that selects a different profile:
@@ -120,10 +124,13 @@ data:
 ```
 
 ```bash
-openstack coe cluster create bm-gpu \
-  --cluster-template k8s-bm \
+openstack coe cluster template create k8s-bm-gpu \
+  ...same base template options... \
   --labels config_profile=profile-standard \
   --labels nodegroup_config_profile_set=profile-bm-gpu-layout
+
+openstack coe cluster create bm-gpu \
+  --cluster-template k8s-bm-gpu
 ```
 
 The cluster default profile applies to the control plane and worker

--- a/docs/user/use-cases.md
+++ b/docs/user/use-cases.md
@@ -27,7 +27,7 @@ data:
       memoryManagerPolicy: Static
       topologyManagerPolicy: single-numa-node
       topologyManagerScope: pod
-      reservedSystemCPUs: 0-1
+      reservedSystemCPUs: "0-1"
       maxPods: 250
     files:
       - path: /etc/gpu-init.sh
@@ -59,7 +59,7 @@ cpuManagerPolicyOptions:
 memoryManagerPolicy: Static
 topologyManagerPolicy: single-numa-node
 topologyManagerScope: pod
-reservedSystemCPUs: 0-1
+reservedSystemCPUs: "0-1"
 maxPods: 250
 ```
 
@@ -116,7 +116,7 @@ data:
       memoryManagerPolicy: Static
       topologyManagerPolicy: single-numa-node
       topologyManagerScope: pod
-      reservedSystemCPUs: 0-1
+      reservedSystemCPUs: "0-1"
       maxPods: 250
 
   profile-bm-gpu-layout: |

--- a/docs/user/use-cases.md
+++ b/docs/user/use-cases.md
@@ -21,7 +21,11 @@ metadata:
 data:
   profile-gpu: |
     cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    memoryManagerPolicy: Static
     topologyManagerPolicy: single-numa-node
+    topologyManagerScope: pod
     reservedSystemCPUs: 0-1
     maxPods: 250
 ```
@@ -38,7 +42,11 @@ This renders a kubeadm `KubeletConfiguration` patch similar to:
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cpuManagerPolicy: static
+cpuManagerPolicyOptions:
+  full-pcpus-only: "true"
+memoryManagerPolicy: Static
 topologyManagerPolicy: single-numa-node
+topologyManagerScope: pod
 reservedSystemCPUs: 0-1
 maxPods: 250
 ```
@@ -60,9 +68,9 @@ openstack coe cluster upgrade bm-gpu k8s-bm-gpu-v2
 ```
 
 The driver does not accept arbitrary kubelet JSON configuration through labels.
-It also does not expose individual kubelet fields as Magnum labels.  If another
-kubelet field needs to be exposed, the cloud operator should add it to a named
-profile.
+It also does not expose individual kubelet fields as Magnum labels.  Cloud
+operators define named kubeadm `KubeletConfiguration` fragments in the profile
+ConfigMap, and users select those named profiles.
 
 ## Nodegroup-specific kubelet tuning
 
@@ -86,7 +94,11 @@ data:
 
   profile-gpu: |
     cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    memoryManagerPolicy: Static
     topologyManagerPolicy: single-numa-node
+    topologyManagerScope: pod
     reservedSystemCPUs: 0-1
     maxPods: 250
 

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -69,9 +69,9 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
-        self.rust_driver.create_cluster(cluster)
+        utils.validate_cluster(context, cluster, self.k8s_api)
 
-        utils.validate_cluster(context, cluster)
+        self.rust_driver.create_cluster(cluster)
 
         return self._create_cluster(context, cluster)
 
@@ -371,7 +371,8 @@ class BaseDriver(driver.Driver):
         """
         Upgrade a cluster to a new version of Kubernetes.
 
-        The only label that we change during the upgrade is the `kube_tag` label.
+        The only labels that we change during the upgrade are `kube_tag` and
+        kubelet profile selector labels.
 
         Historically, the upgrade cluster has been a "hammer" that was used to sync the
         Kubernetes Cluster API objects with the Magnum objects.  However, by doing this,
@@ -392,8 +393,23 @@ class BaseDriver(driver.Driver):
         #              The Magnum Cluster API does not have this limitation in this case
         #              we ignore the `nodegroup` parameter and upgrade the entire cluster
         #              at once.
+        original_cluster_template_id = cluster.cluster_template_id
+        original_labels = dict(cluster.labels or {})
+
         cluster.cluster_template_id = cluster_template.uuid
         cluster.labels["kube_tag"] = cluster_template.labels["kube_tag"]
+        utils.sync_kubelet_profile_labels_from_template(cluster, cluster_template)
+        utils.validate_cluster(context, cluster, self.k8s_api)
+
+        labels_changed = cluster.labels != original_labels
+        if labels_changed:
+            cluster.labels = dict(cluster.labels)
+
+        if (
+            cluster.cluster_template_id != original_cluster_template_id
+            or labels_changed
+        ):
+            cluster.save()
 
         for ng in cluster.nodegroups:
             ng.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
@@ -478,7 +494,14 @@ class BaseDriver(driver.Driver):
         cluster_resource = objects.Cluster.for_magnum_cluster(self.k8s_api, cluster)
         cluster_resource.obj["spec"]["topology"]["workers"][
             "machineDeployments"
-        ].append(resources.mutate_machine_deployment(context, cluster, nodegroup))
+        ].append(
+            resources.mutate_machine_deployment(
+                context,
+                cluster,
+                nodegroup,
+                pykube_api=self.k8s_api,
+            )
+        )
 
         utils.kube_apply_patch(cluster_resource)
 
@@ -653,6 +676,7 @@ class BaseDriver(driver.Driver):
                 cluster,
                 nodegroup,
                 cluster_resource.get_machine_deployment_spec(nodegroup.name),
+                pykube_api=self.k8s_api,
             )
 
             if current_md_spec == target_md_spec:

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -69,6 +69,16 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
+        original_labels = dict(cluster.labels or {})
+        utils.reject_config_profile_label_overrides(cluster)
+        utils.sync_config_profile_labels_from_template(
+            cluster,
+            cluster.cluster_template,
+        )
+        if cluster.labels != original_labels:
+            cluster.labels = dict(cluster.labels)
+            cluster.save()
+
         utils.validate_cluster(context, cluster, self.k8s_api)
 
         self.rust_driver.create_cluster(cluster)
@@ -335,7 +345,7 @@ class BaseDriver(driver.Driver):
         This method is called asynchonously by the Magnum API, therefore it will not be
         blocking the Magnum API.
         """
-        utils.validate_cluster(context, cluster)
+        utils.validate_cluster(context, cluster, self.k8s_api)
 
         if nodes_to_remove:
             machines = objects.Machine.objects(self.k8s_api).filter(
@@ -398,7 +408,7 @@ class BaseDriver(driver.Driver):
 
         cluster.cluster_template_id = cluster_template.uuid
         cluster.labels["kube_tag"] = cluster_template.labels["kube_tag"]
-        utils.sync_kubelet_profile_labels_from_template(cluster, cluster_template)
+        utils.sync_config_profile_labels_from_template(cluster, cluster_template)
         utils.validate_cluster(context, cluster, self.k8s_api)
 
         labels_changed = cluster.labels != original_labels

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -839,17 +839,17 @@ def mutate_machine_deployment(
         },
     ]
 
-    kubelet_config = utils.get_nodegroup_kubelet_config(
+    config_profile = utils.get_nodegroup_config_profile(
         cluster,
         node_group,
         pykube_api,
         namespace,
     )
-    if kubelet_config is not None:
+    if config_profile is not None:
         overrides.append(
             {
-                "name": "kubeletConfig",
-                "value": kubelet_config,
+                "name": "configProfile",
+                "value": config_profile,
             }
         )
 
@@ -1259,8 +1259,8 @@ class Cluster(ClusterBase):
                             ),
                         },
                         {
-                            "name": "kubeletConfig",
-                            "value": utils.get_kubelet_config(
+                            "name": "configProfile",
+                            "value": utils.get_config_profile(
                                 self.cluster,
                                 self.pykube_api,
                                 self.namespace,

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -822,7 +822,7 @@ def mutate_machine_deployment(
         },
         {
             "name": "hardwareDiskBus",
-            "value": image.get("hw_disk_bus", ""),
+            "value": image.get("hw_disk_bus") or "",
         },
         # NOTE(oleks): Override using MachineDeployment-level variables for node groups
         {

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -703,6 +703,8 @@ def mutate_machine_deployment(
     cluster: magnum_objects.Cluster,
     node_group: magnum_objects.NodeGroup,
     machine_deployment: dict = None,
+    pykube_api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
 ):
     """
     This function will either makes updates to machine deployment fields which
@@ -788,6 +790,69 @@ def mutate_machine_deployment(
     # At this point, this is all code that will be added for brand-new machine
     # deployments.  We can bring any of this code into the above block if we
     # want to change it for existing machine deployments.
+    overrides = [
+        {
+            "name": "bootVolume",
+            "value": {
+                "size": utils.get_node_group_label_as_int(
+                    node_group,
+                    "boot_volume_size",
+                    CONF.cinder.default_boot_volume_size,
+                ),
+                "type": node_group.labels.get(
+                    "boot_volume_type",
+                    cinder.get_default_boot_volume_type(context),
+                ),
+            },
+        },
+        {
+            "name": "flavor",
+            "value": flavor.name,
+        },
+        {
+            "name": "imageRepository",
+            "value": node_group.labels.get(
+                "container_infra_prefix",
+                "",
+            ),
+        },
+        {
+            "name": "imageUUID",
+            "value": image.get("id"),
+        },
+        {
+            "name": "hardwareDiskBus",
+            "value": image.get("hw_disk_bus", ""),
+        },
+        # NOTE(oleks): Override using MachineDeployment-level variables for node groups
+        {
+            "name": "serverGroupId",
+            "value": utils.ensure_worker_server_group(
+                ctx=context, cluster=cluster, node_group=node_group
+            ),
+        },
+        {
+            "name": "isServerGroupDiffFailureDomain",
+            "value": utils.is_node_group_different_failure_domain(
+                node_group=node_group, cluster=cluster
+            ),
+        },
+    ]
+
+    kubelet_config = utils.get_nodegroup_kubelet_config(
+        cluster,
+        node_group,
+        pykube_api,
+        namespace,
+    )
+    if kubelet_config is not None:
+        overrides.append(
+            {
+                "name": "kubeletConfig",
+                "value": kubelet_config,
+            }
+        )
+
     machine_deployment.update(
         {
             "class": "default-worker",
@@ -795,54 +860,7 @@ def mutate_machine_deployment(
             "failureDomain": node_group.labels.get("availability_zone"),
             "machineHealthCheck": {"enable": utils.get_auto_healing_enabled(cluster)},
             "variables": {
-                "overrides": [
-                    {
-                        "name": "bootVolume",
-                        "value": {
-                            "size": utils.get_node_group_label_as_int(
-                                node_group,
-                                "boot_volume_size",
-                                CONF.cinder.default_boot_volume_size,
-                            ),
-                            "type": node_group.labels.get(
-                                "boot_volume_type",
-                                cinder.get_default_boot_volume_type(context),
-                            ),
-                        },
-                    },
-                    {
-                        "name": "flavor",
-                        "value": flavor.name,
-                    },
-                    {
-                        "name": "imageRepository",
-                        "value": node_group.labels.get(
-                            "container_infra_prefix",
-                            "",
-                        ),
-                    },
-                    {
-                        "name": "imageUUID",
-                        "value": image.get("id"),
-                    },
-                    {
-                        "name": "hardwareDiskBus",
-                        "value": image.get("hw_disk_bus") or "",
-                    },
-                    # NOTE(oleks): Override using MachineDeployment-level variables for node groups
-                    {
-                        "name": "serverGroupId",
-                        "value": utils.ensure_worker_server_group(
-                            ctx=context, cluster=cluster, node_group=node_group
-                        ),
-                    },
-                    {
-                        "name": "isServerGroupDiffFailureDomain",
-                        "value": utils.is_node_group_different_failure_domain(
-                            node_group=node_group, cluster=cluster
-                        ),
-                    },
-                ],
+                "overrides": overrides,
             },
         }
     )
@@ -906,14 +924,23 @@ def migrate_cluster_failure_domain(
 
 
 def generate_machine_deployments_for_cluster(
-    context: context.RequestContext, cluster: magnum_objects.Cluster
+    context: context.RequestContext,
+    cluster: magnum_objects.Cluster,
+    pykube_api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
 ) -> list:
     machine_deployments = []
     for ng in cluster.nodegroups:
         if ng.role == "master" or ng.status.startswith("DELETE"):
             continue
 
-        machine_deployment = mutate_machine_deployment(context, cluster, ng)
+        machine_deployment = mutate_machine_deployment(
+            context,
+            cluster,
+            ng,
+            pykube_api=pykube_api,
+            namespace=namespace,
+        )
         machine_deployments.append(machine_deployment)
 
     return machine_deployments
@@ -1039,7 +1066,10 @@ class Cluster(ClusterBase):
                     },
                     "workers": {
                         "machineDeployments": generate_machine_deployments_for_cluster(
-                            self.context, self.cluster
+                            self.context,
+                            self.cluster,
+                            self.pykube_api,
+                            self.namespace,
                         ),
                     },
                     "variables": [
@@ -1226,6 +1256,14 @@ class Cluster(ClusterBase):
                             "value": self.cluster.labels.get(
                                 "kubelet_tls_cipher_suites",
                                 "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",  # noqa: E501
+                            ),
+                        },
+                        {
+                            "name": "kubeletConfig",
+                            "value": utils.get_kubelet_config(
+                                self.cluster,
+                                self.pykube_api,
+                                self.namespace,
                             ),
                         },
                         {

--- a/magnum_cluster_api/tests/functional/test_driver.py
+++ b/magnum_cluster_api/tests/functional/test_driver.py
@@ -107,7 +107,7 @@ class TestDriver:
         cluster_resource = objects.Cluster.for_magnum_cluster(self.api, self.cluster)
         assert cluster_resource.observed_generation != current_observed_generation
 
-        self.cluster.save.assert_not_called()
+        self.cluster.save.assert_called_once()
 
     def test_upgrade_cluster_to_same_version(
         self, kube_tag, context, ubuntu_driver, cluster_template
@@ -165,7 +165,7 @@ class TestDriver:
             *self.cluster.nodegroups,
         )
 
-        self.cluster.save.assert_not_called()
+        self.cluster.save.assert_called_once()
 
     def test_create_node_group(
         self, mock_validate_nodegroup, context, ubuntu_driver, cluster_template

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -358,13 +358,13 @@ class TestDriver:
         self.cluster.cluster_template_id = "old-template"
         self.cluster.labels = {
             "kube_tag": "v1.34.3",
-            "kubelet_config_profile": "profile-standard",
-            "kubelet_nodegroup_config_profile_set": "old-layout",
+            "config_profile": "profile-standard",
+            "nodegroup_config_profile_set": "old-layout",
         }
         cluster_template.uuid = "new-template"
         cluster_template.labels = {
             "kube_tag": "v1.34.3",
-            "kubelet_config_profile": "profile-upgrade",
+            "config_profile": "profile-upgrade",
         }
 
         ubuntu_driver.upgrade_cluster(
@@ -372,8 +372,8 @@ class TestDriver:
         )
 
         assert self.cluster.cluster_template_id == "new-template"
-        assert self.cluster.labels["kubelet_config_profile"] == "profile-upgrade"
-        assert "kubelet_nodegroup_config_profile_set" not in self.cluster.labels
+        assert self.cluster.labels["config_profile"] == "profile-upgrade"
+        assert "nodegroup_config_profile_set" not in self.cluster.labels
         assert "labels" in self.cluster.obj_what_changed()
         self.cluster.save.assert_called_once()
 

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -339,6 +339,44 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
+    def test_upgrade_cluster_persists_kubelet_selector_labels(
+        self,
+        context,
+        requests_mock,
+        ubuntu_driver,
+        cluster_template,
+        mock_validate_cluster,
+        mock_rust_driver,
+        mocker,
+    ):
+        ubuntu_driver._kube_client = mock.MagicMock()
+        mocker.patch("magnum_cluster_api.resources.apply_cluster_from_magnum_cluster")
+        mocker.patch(
+            "magnum_cluster_api.resources.Cluster"
+        ).return_value.get_object.return_value = {}
+
+        self.cluster.cluster_template_id = "old-template"
+        self.cluster.labels = {
+            "kube_tag": "v1.34.3",
+            "kubelet_config_profile": "profile-standard",
+            "kubelet_nodegroup_config_profile_set": "old-layout",
+        }
+        cluster_template.uuid = "new-template"
+        cluster_template.labels = {
+            "kube_tag": "v1.34.3",
+            "kubelet_config_profile": "profile-upgrade",
+        }
+
+        ubuntu_driver.upgrade_cluster(
+            context, self.cluster, cluster_template, None, None
+        )
+
+        assert self.cluster.cluster_template_id == "new-template"
+        assert self.cluster.labels["kubelet_config_profile"] == "profile-upgrade"
+        assert "kubelet_nodegroup_config_profile_set" not in self.cluster.labels
+        assert "labels" in self.cluster.obj_what_changed()
+        self.cluster.save.assert_called_once()
+
     def setup_node_group_tests(self, rsps, before, after=None):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -20,6 +20,7 @@ import pykube
 import pytest
 import responses
 from heatclient import exc  # type: ignore
+from magnum.common import exception  # type: ignore
 from magnum.objects import fields  # type: ignore
 from magnum.tests.unit.objects import utils  # type: ignore
 from novaclient.v2 import flavors  # type: ignore
@@ -132,6 +133,15 @@ class TestDriver:
             ),
             json=obj,
             match=match,
+        )
+
+    def _response_for_machine_sets(self, *machine_sets):
+        return responses.Response(
+            responses.GET,
+            re.compile(
+                f"http://localhost/apis/{objects.MachineSet.version}/namespaces/magnum-system/{objects.MachineSet.endpoint}.*"  # noqa
+            ),
+            json={"items": list(machine_sets)},
         )
 
     def _response_for_machine_deployment_spec(
@@ -339,6 +349,84 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
+    def test_create_cluster_rejects_config_profile_label_override(
+        self,
+        context,
+        ubuntu_driver,
+        cluster_template,
+        mocker,
+    ):
+        cluster_template.labels = {
+            "kube_tag": "v1.34.3",
+            "config_profile": "profile-template",
+        }
+        self.cluster.labels = {
+            "kube_tag": "v1.34.3",
+            "config_profile": "profile-user",
+        }
+        mocker.patch(
+            "magnum_cluster_api.utils.generate_cluster_api_name",
+            return_value="kube-test",
+        )
+
+        with pytest.raises(exception.Invalid):
+            ubuntu_driver.create_cluster(context, self.cluster, 60)
+
+    def test_create_cluster_persists_template_config_profile_labels(
+        self,
+        context,
+        ubuntu_driver,
+        cluster_template,
+        mock_validate_cluster,
+        mocker,
+    ):
+        cluster_template.labels = {
+            "kube_tag": "v1.34.3",
+            "config_profile": "profile-template",
+            "nodegroup_config_profile_set": "layout-template",
+        }
+        self.cluster.labels = {
+            "kube_tag": "v1.34.3",
+        }
+        mocker.patch.object(ubuntu_driver, "_create_cluster")
+        mocker.patch(
+            "magnum_cluster_api.utils.generate_cluster_api_name",
+            return_value="kube-test",
+        )
+        ubuntu_driver.rust_driver = mock.Mock()
+
+        ubuntu_driver.create_cluster(context, self.cluster, 60)
+
+        assert self.cluster.labels["config_profile"] == "profile-template"
+        assert self.cluster.labels["nodegroup_config_profile_set"] == "layout-template"
+        assert self.cluster.save.call_count == 2
+
+    def test_resize_cluster_validates_profiles_with_kubernetes_api(
+        self,
+        context,
+        ubuntu_driver,
+        mocker,
+    ):
+        validate_cluster = mocker.patch("magnum_cluster_api.utils.validate_cluster")
+        update_nodegroup = mocker.patch.object(ubuntu_driver, "_update_nodegroup")
+        resize_manager = mock.Mock()
+
+        ubuntu_driver.resize_cluster(
+            context,
+            self.cluster,
+            resize_manager,
+            self.node_group.node_count,
+            [],
+            self.node_group,
+        )
+
+        validate_cluster.assert_called_once_with(
+            context,
+            self.cluster,
+            ubuntu_driver.k8s_api,
+        )
+        update_nodegroup.assert_called_once_with(context, self.cluster, self.node_group)
+
     def test_upgrade_cluster_persists_kubelet_selector_labels(
         self,
         context,
@@ -377,10 +465,12 @@ class TestDriver:
         assert "labels" in self.cluster.obj_what_changed()
         self.cluster.save.assert_called_once()
 
-    def setup_node_group_tests(self, rsps, before, after=None):
+    def setup_node_group_tests(self, rsps, before, after=None, machine_sets=None):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),
         )
+        if machine_sets is not None:
+            rsps.add(self._response_for_machine_sets(*machine_sets))
         if after:
             rsps.add(
                 self._response_for_cluster_with_machine_deployments(
@@ -427,6 +517,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                machine_sets=[],
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
@@ -472,6 +563,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                machine_sets=[],
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -84,7 +84,9 @@ def test_generate_machine_deployments_for_cluster_with_deleting_node_group(
 
 def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, mocker):
     cluster = utils.get_test_cluster(context, labels={})
-    cluster.cluster_template = utils.get_test_cluster_template(context, server_type="vm")
+    cluster.cluster_template = utils.get_test_cluster_template(
+        context, server_type="vm"
+    )
     nodegroup = utils.get_test_nodegroup(
         context,
         name="gpu-workers",

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -84,6 +84,7 @@ def test_generate_machine_deployments_for_cluster_with_deleting_node_group(
 
 def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, mocker):
     cluster = utils.get_test_cluster(context, labels={})
+    cluster.cluster_template = utils.get_test_cluster_template(context, server_type="vm")
     nodegroup = utils.get_test_nodegroup(
         context,
         name="gpu-workers",

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -82,6 +82,64 @@ def test_generate_machine_deployments_for_cluster_with_deleting_node_group(
     assert len(mds) == 2
 
 
+def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, mocker):
+    cluster = utils.get_test_cluster(context, labels={})
+    nodegroup = utils.get_test_nodegroup(
+        context,
+        name="gpu-workers",
+        labels={},
+    )
+    mock_get_default_boot_volume_type = mocker.patch(
+        "magnum_cluster_api.integrations.cinder.get_default_boot_volume_type"
+    )
+    mock_get_default_boot_volume_type.return_value = "foo"
+
+    mock_lookup_image = mocker.patch("magnum_cluster_api.utils.lookup_image")
+    mock_lookup_image.return_value = {"id": "foo"}
+
+    mock_lookup_flavor = mocker.patch("magnum_cluster_api.utils.lookup_flavor")
+    mock_lookup_flavor.return_value = flavors.Flavor(
+        None,
+        {"name": "fake-flavor", "disk": 10, "ram": 1024, "vcpus": 1},
+    )
+
+    mock_ensure_worker_server_group = mocker.patch(
+        "magnum_cluster_api.utils.ensure_worker_server_group"
+    )
+    mock_ensure_worker_server_group.return_value = "foo"
+
+    mocker.patch(
+        "magnum_cluster_api.utils.get_nodegroup_kubelet_config",
+        return_value={
+            "enabled": True,
+            "cpuManagerPolicy": "static",
+            "topologyManagerPolicy": "single-numa-node",
+            "reservedSystemCPUs": "0-1",
+            "maxPods": 250,
+        },
+    )
+
+    md = resources.mutate_machine_deployment(
+        context,
+        cluster,
+        nodegroup,
+        pykube_api=mocker.Mock(),
+        namespace="magnum-system",
+    )
+
+    overrides = md["variables"]["overrides"]
+    assert {
+        "name": "kubeletConfig",
+        "value": {
+            "enabled": True,
+            "cpuManagerPolicy": "static",
+            "topologyManagerPolicy": "single-numa-node",
+            "reservedSystemCPUs": "0-1",
+            "maxPods": 250,
+        },
+    } in overrides
+
+
 @pytest.mark.parametrize(
     "auto_scaling_enabled",
     [True, False, None],

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -109,14 +109,20 @@ def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, m
     mock_ensure_worker_server_group.return_value = "foo"
 
     mocker.patch(
-        "magnum_cluster_api.utils.get_nodegroup_kubelet_config",
+        "magnum_cluster_api.utils.get_nodegroup_config_profile",
         return_value={
             "enabled": True,
-            "configYaml": (
-                "cpuManagerPolicy: static\n"
-                "  topologyManagerPolicy: single-numa-node\n"
-                "  topologyManagerScope: pod"
-            ),
+            "kubeletConfig": {
+                "enabled": True,
+                "configYaml": (
+                    "cpuManagerPolicy: static\n"
+                    "  topologyManagerPolicy: single-numa-node\n"
+                    "  topologyManagerScope: pod"
+                ),
+            },
+            "filesYaml": [],
+            "preKubeadmCommands": [],
+            "postKubeadmCommands": [],
         },
     )
 
@@ -130,14 +136,20 @@ def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, m
 
     overrides = md["variables"]["overrides"]
     assert {
-        "name": "kubeletConfig",
+        "name": "configProfile",
         "value": {
             "enabled": True,
-            "configYaml": (
-                "cpuManagerPolicy: static\n"
-                "  topologyManagerPolicy: single-numa-node\n"
-                "  topologyManagerScope: pod"
-            ),
+            "kubeletConfig": {
+                "enabled": True,
+                "configYaml": (
+                    "cpuManagerPolicy: static\n"
+                    "  topologyManagerPolicy: single-numa-node\n"
+                    "  topologyManagerScope: pod"
+                ),
+            },
+            "filesYaml": [],
+            "preKubeadmCommands": [],
+            "postKubeadmCommands": [],
         },
     } in overrides
 

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -112,10 +112,11 @@ def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, m
         "magnum_cluster_api.utils.get_nodegroup_kubelet_config",
         return_value={
             "enabled": True,
-            "cpuManagerPolicy": "static",
-            "topologyManagerPolicy": "single-numa-node",
-            "reservedSystemCPUs": "0-1",
-            "maxPods": 250,
+            "configYaml": (
+                "cpuManagerPolicy: static\n"
+                "  topologyManagerPolicy: single-numa-node\n"
+                "  topologyManagerScope: pod"
+            ),
         },
     )
 
@@ -132,10 +133,11 @@ def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, m
         "name": "kubeletConfig",
         "value": {
             "enabled": True,
-            "cpuManagerPolicy": "static",
-            "topologyManagerPolicy": "single-numa-node",
-            "reservedSystemCPUs": "0-1",
-            "maxPods": 250,
+            "configYaml": (
+                "cpuManagerPolicy: static\n"
+                "  topologyManagerPolicy: single-numa-node\n"
+                "  topologyManagerScope: pod"
+            ),
         },
     } in overrides
 

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -61,7 +61,7 @@ def test_generate_machine_deployments_for_cluster_with_deleting_node_group(
     mock_get_default_boot_volume_type.return_value = "foo"
 
     mock_lookup_image = mocker.patch("magnum_cluster_api.utils.lookup_image")
-    mock_lookup_image.return_value = {"id": "foo"}
+    mock_lookup_image.return_value = {"id": "foo", "hw_disk_bus": None}
 
     mock_lookup_flavor = mocker.patch("magnum_cluster_api.utils.lookup_flavor")
     mock_lookup_flavor.return_value = flavors.Flavor(
@@ -98,7 +98,7 @@ def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, m
     mock_get_default_boot_volume_type.return_value = "foo"
 
     mock_lookup_image = mocker.patch("magnum_cluster_api.utils.lookup_image")
-    mock_lookup_image.return_value = {"id": "foo"}
+    mock_lookup_image.return_value = {"id": "foo", "hw_disk_bus": None}
 
     mock_lookup_flavor = mocker.patch("magnum_cluster_api.utils.lookup_flavor")
     mock_lookup_flavor.return_value = flavors.Flavor(
@@ -138,6 +138,10 @@ def test_generate_machine_deployments_with_nodegroup_kubelet_override(context, m
     )
 
     overrides = md["variables"]["overrides"]
+    assert {
+        "name": "hardwareDiskBus",
+        "value": "",
+    } in overrides
     assert {
         "name": "configProfile",
         "value": {

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -806,9 +806,7 @@ class TestConfigProfiles:
         ("profile_yaml", "expected"),
         [
             (
-                "files:\n"
-                "  - path: /etc/profile-file\n"
-                "    content: profile\n",
+                "files:\n" "  - path: /etc/profile-file\n" "    content: profile\n",
                 {
                     "filesYaml": [
                         (
@@ -821,13 +819,11 @@ class TestConfigProfiles:
                 },
             ),
             (
-                "preKubeadmCommands:\n"
-                "  - echo pre\n",
+                "preKubeadmCommands:\n" "  - echo pre\n",
                 {"preKubeadmCommands": ["echo pre"]},
             ),
             (
-                "postKubeadmCommands:\n"
-                "  - echo post\n",
+                "postKubeadmCommands:\n" "  - echo post\n",
                 {"postKubeadmCommands": ["echo post"]},
             ),
         ],

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -577,7 +577,26 @@ class TestKubeletConfigLabels:
                 "data": {
                     "profile-gpu": (
                         "cpuManagerPolicy: static\n"
+                        "cpuManagerPolicyOptions:\n"
+                        '  full-pcpus-only: "true"\n'
+                        "cpuManagerReconcilePeriod: 5s\n"
+                        "memoryManagerPolicy: Static\n"
                         "topologyManagerPolicy: single-numa-node\n"
+                        "topologyManagerScope: pod\n"
+                        "topologyManagerPolicyOptions:\n"
+                        '  max-allowable-numa-nodes: "2"\n'
+                        "qosReserved:\n"
+                        '  memory: "50%"\n'
+                        "systemReserved:\n"
+                        "  memory: 1Gi\n"
+                        "kubeReserved:\n"
+                        "  cpu: 200m\n"
+                        "enforceNodeAllocatable:\n"
+                        "  - pods\n"
+                        "reservedMemory:\n"
+                        "  - numaNode: 0\n"
+                        "    limits:\n"
+                        "      memory: 1Gi\n"
                         "reservedSystemCPUs: 0-1\n"
                         "maxPods: 250\n"
                     ),
@@ -602,30 +621,59 @@ class TestKubeletConfigLabels:
         nodegroup.name = name
         return nodegroup
 
-    def test_get_kubelet_config_disabled(self):
-        assert utils.get_kubelet_config(self._cluster({})) == {
+    def _empty_kubelet_config(self):
+        return {
             "enabled": False,
-            "cpuManagerPolicy": "",
-            "topologyManagerPolicy": "",
-            "reservedSystemCPUs": "",
-            "maxPods": 0,
+            "configYaml": "",
         }
 
-    def test_get_kubelet_config_enabled(self):
-        assert utils.get_kubelet_config(
-            self._cluster(
-                {
-                    "kubelet_config_profile": "profile-gpu",
-                }
-            ),
-            self.api,
-        ) == {
+    def _gpu_kubelet_config(self):
+        return {
             "enabled": True,
-            "cpuManagerPolicy": "static",
-            "topologyManagerPolicy": "single-numa-node",
-            "reservedSystemCPUs": "0-1",
-            "maxPods": 250,
+            "configYaml": (
+                "cpuManagerPolicy: static\n"
+                "  cpuManagerPolicyOptions:\n"
+                "    full-pcpus-only: 'true'\n"
+                "  cpuManagerReconcilePeriod: 5s\n"
+                "  enforceNodeAllocatable:\n"
+                "  - pods\n"
+                "  kubeReserved:\n"
+                "    cpu: 200m\n"
+                "  maxPods: 250\n"
+                "  memoryManagerPolicy: Static\n"
+                "  qosReserved:\n"
+                "    memory: 50%\n"
+                "  reservedMemory:\n"
+                "  - limits:\n"
+                "      memory: 1Gi\n"
+                "    numaNode: 0\n"
+                "  reservedSystemCPUs: 0-1\n"
+                "  systemReserved:\n"
+                "    memory: 1Gi\n"
+                "  topologyManagerPolicy: single-numa-node\n"
+                "  topologyManagerPolicyOptions:\n"
+                "    max-allowable-numa-nodes: '2'\n"
+                "  topologyManagerScope: pod"
+            ),
         }
+
+    def test_get_kubelet_config_disabled(self):
+        assert (
+            utils.get_kubelet_config(self._cluster({})) == self._empty_kubelet_config()
+        )
+
+    def test_get_kubelet_config_enabled(self):
+        assert (
+            utils.get_kubelet_config(
+                self._cluster(
+                    {
+                        "kubelet_config_profile": "profile-gpu",
+                    }
+                ),
+                self.api,
+            )
+            == self._gpu_kubelet_config()
+        )
 
     def test_validate_kubelet_config_labels(self):
         cluster = self._cluster(
@@ -656,16 +704,13 @@ class TestKubeletConfigLabels:
             utils.get_kubelet_config(cluster)
 
     def test_get_kubelet_config_profile_defaults(self):
-        assert utils.get_kubelet_config(
-            self._cluster({"kubelet_config_profile": "profile-gpu"}),
-            self.api,
-        ) == {
-            "enabled": True,
-            "cpuManagerPolicy": "static",
-            "topologyManagerPolicy": "single-numa-node",
-            "reservedSystemCPUs": "0-1",
-            "maxPods": 250,
-        }
+        assert (
+            utils.get_kubelet_config(
+                self._cluster({"kubelet_config_profile": "profile-gpu"}),
+                self.api,
+            )
+            == self._gpu_kubelet_config()
+        )
 
     def test_get_kubelet_config_profile_configures_max_pods(self):
         self.config_map.obj["data"] = {
@@ -677,10 +722,7 @@ class TestKubeletConfigLabels:
             self.api,
         ) == {
             "enabled": True,
-            "cpuManagerPolicy": "",
-            "topologyManagerPolicy": "",
-            "reservedSystemCPUs": "0-1",
-            "maxPods": 500,
+            "configYaml": "maxPods: 500\n  reservedSystemCPUs: 0-1",
         }
 
     def test_get_kubelet_config_rejects_missing_profiles_configmap(self):
@@ -701,8 +743,31 @@ class TestKubeletConfigLabels:
                 self.api,
             )
 
-    def test_get_kubelet_config_profile_rejects_unsupported_field(self):
-        self.config_map.obj["data"] = {"profile-bad": "shutdownGracePeriod: 30s\n"}
+    def test_get_kubelet_config_profile_allows_dynamic_kubelet_fields(self):
+        self.config_map.obj["data"] = {
+            "profile-dynamic": (
+                "shutdownGracePeriod: 30s\n"
+                "featureGates:\n"
+                "  TopologyManagerPolicyOptions: true\n"
+                "topologyManagerScope: pod\n"
+            )
+        }
+
+        assert utils.get_kubelet_config(
+            self._cluster({"kubelet_config_profile": "profile-dynamic"}),
+            self.api,
+        ) == {
+            "enabled": True,
+            "configYaml": (
+                "featureGates:\n"
+                "    TopologyManagerPolicyOptions: true\n"
+                "  shutdownGracePeriod: 30s\n"
+                "  topologyManagerScope: pod"
+            ),
+        }
+
+    def test_get_kubelet_config_profile_rejects_reserved_field(self):
+        self.config_map.obj["data"] = {"profile-bad": "apiVersion: v1\n"}
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
@@ -710,8 +775,15 @@ class TestKubeletConfigLabels:
                 self.api,
             )
 
-    def test_get_kubelet_config_profile_rejects_invalid_config(self):
-        self.config_map.obj["data"] = {"profile-bad": "maxPods: 0\n"}
+    def test_get_kubelet_config_profile_rejects_mixed_nodegroups_field(self):
+        self.config_map.obj["data"] = {
+            "profile-bad": (
+                "nodegroups:\n"
+                "  gpu-workers:\n"
+                "    kubeletConfigProfile: profile-gpu\n"
+                "maxPods: 250\n"
+            )
+        }
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
@@ -725,13 +797,10 @@ class TestKubeletConfigLabels:
         )
         nodegroup = self._nodegroup("gpu-workers")
 
-        assert utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api) == {
-            "enabled": True,
-            "cpuManagerPolicy": "static",
-            "topologyManagerPolicy": "single-numa-node",
-            "reservedSystemCPUs": "0-1",
-            "maxPods": 250,
-        }
+        assert (
+            utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api)
+            == self._gpu_kubelet_config()
+        )
 
     def test_get_nodegroup_kubelet_config_ignores_unmapped_nodegroup(self):
         cluster = self._cluster(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -802,6 +802,52 @@ class TestConfigProfiles:
         assert profile["preKubeadmCommands"] == ["bash /etc/gpu-init.sh"]
         assert profile["postKubeadmCommands"] == ["echo done > /etc/gpu-init.done"]
 
+    @pytest.mark.parametrize(
+        ("profile_yaml", "expected"),
+        [
+            (
+                "files:\n"
+                "  - path: /etc/profile-file\n"
+                "    content: profile\n",
+                {
+                    "filesYaml": [
+                        (
+                            "path: /etc/profile-file\n"
+                            "permissions: '0644'\n"
+                            "content: cHJvZmlsZQ==\n"
+                            "encoding: base64"
+                        )
+                    ],
+                },
+            ),
+            (
+                "preKubeadmCommands:\n"
+                "  - echo pre\n",
+                {"preKubeadmCommands": ["echo pre"]},
+            ),
+            (
+                "postKubeadmCommands:\n"
+                "  - echo post\n",
+                {"postKubeadmCommands": ["echo post"]},
+            ),
+        ],
+    )
+    def test_get_config_profile_supports_solo_profile_keys(
+        self,
+        profile_yaml,
+        expected,
+    ):
+        self.config_map.obj["data"] = {"profile-gpu": profile_yaml}
+
+        profile = utils.get_config_profile(
+            self._cluster({"config_profile": "profile-gpu"}),
+            self.api,
+        )
+
+        assert profile["enabled"] is True
+        for key, value in expected.items():
+            assert profile[key] == value
+
     def test_get_config_profile_preserves_base64_file_content(self):
         self.config_map.obj["data"] = {
             "profile-gpu": (
@@ -877,6 +923,30 @@ class TestConfigProfiles:
             "enabled": True,
             "configYaml": "maxPods: 500\n  reservedSystemCPUs: 0-1",
         }
+
+    def test_get_config_profile_preserves_string_reserved_system_cpus(self):
+        self.config_map.obj["data"] = {
+            "profile-large": ("kubeletConfig:\n" '  reservedSystemCPUs: "0"\n')
+        }
+
+        assert utils.get_kubelet_config(
+            self._cluster({"config_profile": "profile-large"}),
+            self.api,
+        ) == {
+            "enabled": True,
+            "configYaml": "reservedSystemCPUs: '0'",
+        }
+
+    def test_get_config_profile_rejects_numeric_reserved_system_cpus(self):
+        self.config_map.obj["data"] = {
+            "profile-bad": "kubeletConfig:\n  reservedSystemCPUs: 0\n"
+        }
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(
+                self._cluster({"config_profile": "profile-bad"}),
+                self.api,
+            )
 
     def test_get_kubelet_config_rejects_missing_profiles_configmap(self):
         self.config_maps.get_or_none.return_value = None

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -657,9 +657,32 @@ class TestKubeletConfigLabels:
             ),
         }
 
+    def _empty_config_profile(self):
+        return {
+            "enabled": False,
+            "kubeletConfig": self._empty_kubelet_config(),
+            "filesYaml": [],
+            "preKubeadmCommands": [],
+            "postKubeadmCommands": [],
+        }
+
+    def _gpu_config_profile(self):
+        return {
+            "enabled": True,
+            "kubeletConfig": self._gpu_kubelet_config(),
+            "filesYaml": [],
+            "preKubeadmCommands": [],
+            "postKubeadmCommands": [],
+        }
+
     def test_get_kubelet_config_disabled(self):
         assert (
             utils.get_kubelet_config(self._cluster({})) == self._empty_kubelet_config()
+        )
+
+    def test_get_config_profile_disabled(self):
+        assert (
+            utils.get_config_profile(self._cluster({})) == self._empty_config_profile()
         )
 
     def test_get_kubelet_config_enabled(self):
@@ -674,6 +697,82 @@ class TestKubeletConfigLabels:
             )
             == self._gpu_kubelet_config()
         )
+
+    def test_get_config_profile_enabled(self):
+        assert (
+            utils.get_config_profile(
+                self._cluster(
+                    {
+                        "config_profile": "profile-gpu",
+                    }
+                ),
+                self.api,
+            )
+            == self._gpu_config_profile()
+        )
+
+    def test_get_config_profile_supports_files_and_commands(self):
+        self.config_map.obj["data"] = {
+            "profile-gpu": (
+                "kubeletConfig:\n"
+                "  maxPods: 250\n"
+                "files:\n"
+                "  - path: /etc/gpu-init.sh\n"
+                '    permissions: "0755"\n'
+                "    content: |\n"
+                "      #!/bin/bash\n"
+                "      echo gpu\n"
+                "preKubeadmCommands:\n"
+                "  - bash /etc/gpu-init.sh\n"
+                "postKubeadmCommands:\n"
+                "  - echo done > /etc/gpu-init.done\n"
+            ),
+        }
+
+        profile = utils.get_config_profile(
+            self._cluster({"config_profile": "profile-gpu"}),
+            self.api,
+        )
+
+        assert profile["enabled"] is True
+        assert profile["kubeletConfig"] == {
+            "enabled": True,
+            "configYaml": "maxPods: 250",
+        }
+        assert profile["filesYaml"] == [
+            (
+                "path: /etc/gpu-init.sh\n"
+                "permissions: '0755'\n"
+                "content: IyEvYmluL2Jhc2gKZWNobyBncHUK\n"
+                "encoding: base64"
+            )
+        ]
+        assert profile["preKubeadmCommands"] == ["bash /etc/gpu-init.sh"]
+        assert profile["postKubeadmCommands"] == ["echo done > /etc/gpu-init.done"]
+
+    def test_get_config_profile_preserves_base64_file_content(self):
+        self.config_map.obj["data"] = {
+            "profile-gpu": (
+                "files:\n"
+                "  - path: /etc/atmosphere/test-marker\n"
+                "    content: ZzItc21va2UtcHIxMDE1Cg==\n"
+                "    encoding: base64\n"
+            ),
+        }
+
+        profile = utils.get_config_profile(
+            self._cluster({"config_profile": "profile-gpu"}),
+            self.api,
+        )
+
+        assert profile["filesYaml"] == [
+            (
+                "path: /etc/atmosphere/test-marker\n"
+                "permissions: '0644'\n"
+                "content: ZzItc21va2UtcHIxMDE1Cg==\n"
+                "encoding: base64"
+            )
+        ]
 
     def test_validate_kubelet_config_labels(self):
         cluster = self._cluster(
@@ -802,6 +901,57 @@ class TestKubeletConfigLabels:
             == self._gpu_kubelet_config()
         )
 
+    def test_get_nodegroup_config_profile(self):
+        self.config_map.obj["data"]["profile-layout"] = (
+            "nodegroups:\n" "  gpu-workers:\n" "    profile: profile-gpu\n"
+        )
+        cluster = self._cluster({"nodegroup_config_profile_set": "profile-layout"})
+        nodegroup = self._nodegroup("gpu-workers")
+
+        assert (
+            utils.get_nodegroup_config_profile(cluster, nodegroup, self.api)
+            == self._gpu_config_profile()
+        )
+
+    def test_get_nodegroup_config_profile_supports_distinct_files(self):
+        self.config_map.obj["data"] = {
+            "profile-standard": (
+                "files:\n"
+                "  - path: /etc/atmosphere/role\n"
+                "    content: standard\n"
+                "preKubeadmCommands:\n"
+                "  - cat /etc/atmosphere/role\n"
+            ),
+            "profile-gpu": (
+                "files:\n"
+                "  - path: /etc/atmosphere/role\n"
+                "    content: gpu\n"
+                "preKubeadmCommands:\n"
+                "  - cat /etc/atmosphere/role\n"
+            ),
+            "profile-layout": (
+                "nodegroups:\n" "  gpu-workers:\n" "    profile: profile-gpu\n"
+            ),
+        }
+        cluster = self._cluster(
+            {
+                "config_profile": "profile-standard",
+                "nodegroup_config_profile_set": "profile-layout",
+            }
+        )
+
+        default_profile = utils.get_config_profile(cluster, self.api)
+        gpu_profile = utils.get_nodegroup_config_profile(
+            cluster,
+            self._nodegroup("gpu-workers"),
+            self.api,
+        )
+
+        assert "content: c3RhbmRhcmQ=" in default_profile["filesYaml"][0]
+        assert "content: Z3B1" in gpu_profile["filesYaml"][0]
+        assert default_profile["preKubeadmCommands"] == ["cat /etc/atmosphere/role"]
+        assert gpu_profile["preKubeadmCommands"] == ["cat /etc/atmosphere/role"]
+
     def test_get_nodegroup_kubelet_config_ignores_unmapped_nodegroup(self):
         cluster = self._cluster(
             {"kubelet_nodegroup_config_profile_set": "profile-layout"}
@@ -848,6 +998,8 @@ class TestKubeletConfigLabels:
     def test_sync_kubelet_profile_labels_from_template(self):
         cluster = self._cluster(
             {
+                "config_profile": "profile-current",
+                "nodegroup_config_profile_set": "layout-current",
                 "kubelet_config_profile": "profile-old",
                 "kubelet_nodegroup_config_profile_set": "layout-old",
                 "kube_tag": "v1.34.3",
@@ -855,13 +1007,15 @@ class TestKubeletConfigLabels:
         )
         template = mock.Mock(
             labels={
-                "kubelet_config_profile": "profile-gpu",
+                "config_profile": "profile-gpu",
             }
         )
 
         utils.sync_kubelet_profile_labels_from_template(cluster, template)
 
-        assert cluster.labels["kubelet_config_profile"] == "profile-gpu"
+        assert cluster.labels["config_profile"] == "profile-gpu"
+        assert "nodegroup_config_profile_set" not in cluster.labels
+        assert "kubelet_config_profile" not in cluster.labels
         assert "kubelet_nodegroup_config_profile_set" not in cluster.labels
         assert cluster.labels["kube_tag"] == "v1.34.3"
 
@@ -876,5 +1030,5 @@ class TestKubeletConfigLabels:
             namespace="magnum-system",
         )
         self.config_maps.get_or_none.assert_called_once_with(
-            name="mcapi-kubelet-config-profiles"
+            name="mcapi-config-profiles"
         )

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -603,7 +603,7 @@ class TestKubeletConfigLabels:
                     "profile-layout": (
                         "nodegroups:\n"
                         "  gpu-workers:\n"
-                        "    kubeletConfigProfile: profile-gpu\n"
+                        "    profile: profile-gpu\n"
                     ),
                 }
             }
@@ -690,7 +690,7 @@ class TestKubeletConfigLabels:
             utils.get_kubelet_config(
                 self._cluster(
                     {
-                        "kubelet_config_profile": "profile-gpu",
+                        "config_profile": "profile-gpu",
                     }
                 ),
                 self.api,
@@ -777,47 +777,47 @@ class TestKubeletConfigLabels:
     def test_validate_kubelet_config_labels(self):
         cluster = self._cluster(
             {
-                "kubelet_config_profile": "profile-gpu",
-                "kubelet_nodegroup_config_profile_set": "profile-layout",
+                "config_profile": "profile-gpu",
+                "nodegroup_config_profile_set": "profile-layout",
             }
         )
 
         utils.validate_kubelet_config_labels(cluster, self.api)
 
     def test_validate_kubelet_config_labels_rejects_invalid_profile(self):
-        cluster = self._cluster({"kubelet_config_profile": "exclusive"})
+        cluster = self._cluster({"config_profile": "exclusive"})
 
         with pytest.raises(exception.Invalid):
             utils.validate_kubelet_config_labels(cluster, self.api)
 
     def test_get_kubelet_config_rejects_invalid_profile(self):
-        cluster = self._cluster({"kubelet_config_profile": "missing"})
+        cluster = self._cluster({"config_profile": "missing"})
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(cluster, self.api)
 
     def test_get_kubelet_config_rejects_profile_without_api(self):
-        cluster = self._cluster({"kubelet_config_profile": "profile-gpu"})
+        cluster = self._cluster({"config_profile": "profile-gpu"})
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(cluster)
 
-    def test_get_kubelet_config_profile_defaults(self):
+    def test_get_config_profile_defaults(self):
         assert (
             utils.get_kubelet_config(
-                self._cluster({"kubelet_config_profile": "profile-gpu"}),
+                self._cluster({"config_profile": "profile-gpu"}),
                 self.api,
             )
             == self._gpu_kubelet_config()
         )
 
-    def test_get_kubelet_config_profile_configures_max_pods(self):
+    def test_get_config_profile_configures_max_pods(self):
         self.config_map.obj["data"] = {
             "profile-large": "maxPods: 500\nreservedSystemCPUs: 0-1\n"
         }
 
         assert utils.get_kubelet_config(
-            self._cluster({"kubelet_config_profile": "profile-large"}),
+            self._cluster({"config_profile": "profile-large"}),
             self.api,
         ) == {
             "enabled": True,
@@ -829,20 +829,20 @@ class TestKubeletConfigLabels:
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
-                self._cluster({"kubelet_config_profile": "profile-gpu"}),
+                self._cluster({"config_profile": "profile-gpu"}),
                 self.api,
             )
 
-    def test_get_kubelet_config_profile_rejects_invalid_yaml(self):
+    def test_get_config_profile_rejects_invalid_yaml(self):
         self.config_map.obj["data"] = {"profile-bad": "not: [valid"}
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
-                self._cluster({"kubelet_config_profile": "profile-bad"}),
+                self._cluster({"config_profile": "profile-bad"}),
                 self.api,
             )
 
-    def test_get_kubelet_config_profile_allows_dynamic_kubelet_fields(self):
+    def test_get_config_profile_allows_dynamic_kubelet_fields(self):
         self.config_map.obj["data"] = {
             "profile-dynamic": (
                 "shutdownGracePeriod: 30s\n"
@@ -853,7 +853,7 @@ class TestKubeletConfigLabels:
         }
 
         assert utils.get_kubelet_config(
-            self._cluster({"kubelet_config_profile": "profile-dynamic"}),
+            self._cluster({"config_profile": "profile-dynamic"}),
             self.api,
         ) == {
             "enabled": True,
@@ -865,34 +865,34 @@ class TestKubeletConfigLabels:
             ),
         }
 
-    def test_get_kubelet_config_profile_rejects_reserved_field(self):
+    def test_get_config_profile_rejects_reserved_field(self):
         self.config_map.obj["data"] = {"profile-bad": "apiVersion: v1\n"}
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
-                self._cluster({"kubelet_config_profile": "profile-bad"}),
+                self._cluster({"config_profile": "profile-bad"}),
                 self.api,
             )
 
-    def test_get_kubelet_config_profile_rejects_mixed_nodegroups_field(self):
+    def test_get_config_profile_rejects_mixed_nodegroups_field(self):
         self.config_map.obj["data"] = {
             "profile-bad": (
                 "nodegroups:\n"
                 "  gpu-workers:\n"
-                "    kubeletConfigProfile: profile-gpu\n"
+                "    profile: profile-gpu\n"
                 "maxPods: 250\n"
             )
         }
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
-                self._cluster({"kubelet_config_profile": "profile-bad"}),
+                self._cluster({"config_profile": "profile-bad"}),
                 self.api,
             )
 
     def test_get_nodegroup_kubelet_config(self):
         cluster = self._cluster(
-            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+            {"nodegroup_config_profile_set": "profile-layout"}
         )
         nodegroup = self._nodegroup("gpu-workers")
 
@@ -954,7 +954,7 @@ class TestKubeletConfigLabels:
 
     def test_get_nodegroup_kubelet_config_ignores_unmapped_nodegroup(self):
         cluster = self._cluster(
-            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+            {"nodegroup_config_profile_set": "profile-layout"}
         )
         nodegroup = self._nodegroup("default-worker")
 
@@ -962,7 +962,7 @@ class TestKubeletConfigLabels:
 
     def test_get_nodegroup_kubelet_config_rejects_invalid_profile_set(self):
         cluster = self._cluster(
-            {"kubelet_nodegroup_config_profile_set": "missing-layout"}
+            {"nodegroup_config_profile_set": "missing-layout"}
         )
         nodegroup = self._nodegroup("gpu-workers")
 
@@ -973,10 +973,10 @@ class TestKubeletConfigLabels:
         self.config_map.obj["data"]["profile-layout"] = (
             "nodegroups:\n"
             "  gpu-workers:\n"
-            "    kubeletConfigProfile: missing-profile\n"
+            "    profile: missing-profile\n"
         )
         cluster = self._cluster(
-            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+            {"nodegroup_config_profile_set": "profile-layout"}
         )
         nodegroup = self._nodegroup("gpu-workers")
 
@@ -988,7 +988,7 @@ class TestKubeletConfigLabels:
             "nodegroups:\n" "  gpu-workers:\n" "    maxPods: 250\n"
         )
         cluster = self._cluster(
-            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+            {"nodegroup_config_profile_set": "profile-layout"}
         )
         nodegroup = self._nodegroup("gpu-workers")
 
@@ -1000,8 +1000,6 @@ class TestKubeletConfigLabels:
             {
                 "config_profile": "profile-current",
                 "nodegroup_config_profile_set": "layout-current",
-                "kubelet_config_profile": "profile-old",
-                "kubelet_nodegroup_config_profile_set": "layout-old",
                 "kube_tag": "v1.34.3",
             }
         )
@@ -1015,13 +1013,11 @@ class TestKubeletConfigLabels:
 
         assert cluster.labels["config_profile"] == "profile-gpu"
         assert "nodegroup_config_profile_set" not in cluster.labels
-        assert "kubelet_config_profile" not in cluster.labels
-        assert "kubelet_nodegroup_config_profile_set" not in cluster.labels
         assert cluster.labels["kube_tag"] == "v1.34.3"
 
     def test_get_kubelet_config_fetches_profile_configmap(self):
         utils.get_kubelet_config(
-            self._cluster({"kubelet_config_profile": "profile-gpu"}),
+            self._cluster({"config_profile": "profile-gpu"}),
             self.api,
         )
 

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -566,3 +566,246 @@ def test_wait_for_sdk_loadbalancers_deleted_times_out(mocker):
         utils._wait_for_sdk_loadbalancers_deleted(octavia_client, {"lb-id"})
 
     sleep.assert_called_once_with(1)
+
+
+class TestKubeletConfigLabels:
+    @pytest.fixture(autouse=True)
+    def setup_profiles(self, mocker):
+        self.api = mock.Mock()
+        self.config_map = mock.Mock(
+            obj={
+                "data": {
+                    "profile-gpu": (
+                        "cpuManagerPolicy: static\n"
+                        "topologyManagerPolicy: single-numa-node\n"
+                        "reservedSystemCPUs: 0-1\n"
+                        "maxPods: 250\n"
+                    ),
+                    "profile-layout": (
+                        "nodegroups:\n"
+                        "  gpu-workers:\n"
+                        "    kubeletConfigProfile: profile-gpu\n"
+                    ),
+                }
+            }
+        )
+        self.config_maps = mocker.patch("pykube.ConfigMap.objects").return_value
+        self.config_maps.get_or_none.return_value = self.config_map
+
+    def _cluster(self, labels):
+        cluster = mock.Mock()
+        cluster.labels = dict(labels)
+        return cluster
+
+    def _nodegroup(self, name):
+        nodegroup = mock.Mock()
+        nodegroup.name = name
+        return nodegroup
+
+    def test_get_kubelet_config_disabled(self):
+        assert utils.get_kubelet_config(self._cluster({})) == {
+            "enabled": False,
+            "cpuManagerPolicy": "",
+            "topologyManagerPolicy": "",
+            "reservedSystemCPUs": "",
+            "maxPods": 0,
+        }
+
+    def test_get_kubelet_config_enabled(self):
+        assert utils.get_kubelet_config(
+            self._cluster(
+                {
+                    "kubelet_config_profile": "profile-gpu",
+                }
+            ),
+            self.api,
+        ) == {
+            "enabled": True,
+            "cpuManagerPolicy": "static",
+            "topologyManagerPolicy": "single-numa-node",
+            "reservedSystemCPUs": "0-1",
+            "maxPods": 250,
+        }
+
+    def test_validate_kubelet_config_labels(self):
+        cluster = self._cluster(
+            {
+                "kubelet_config_profile": "profile-gpu",
+                "kubelet_nodegroup_config_profile_set": "profile-layout",
+            }
+        )
+
+        utils.validate_kubelet_config_labels(cluster, self.api)
+
+    def test_validate_kubelet_config_labels_rejects_invalid_profile(self):
+        cluster = self._cluster({"kubelet_config_profile": "exclusive"})
+
+        with pytest.raises(exception.Invalid):
+            utils.validate_kubelet_config_labels(cluster, self.api)
+
+    def test_get_kubelet_config_rejects_invalid_profile(self):
+        cluster = self._cluster({"kubelet_config_profile": "missing"})
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(cluster, self.api)
+
+    def test_get_kubelet_config_rejects_profile_without_api(self):
+        cluster = self._cluster({"kubelet_config_profile": "profile-gpu"})
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(cluster)
+
+    def test_get_kubelet_config_profile_defaults(self):
+        assert utils.get_kubelet_config(
+            self._cluster({"kubelet_config_profile": "profile-gpu"}),
+            self.api,
+        ) == {
+            "enabled": True,
+            "cpuManagerPolicy": "static",
+            "topologyManagerPolicy": "single-numa-node",
+            "reservedSystemCPUs": "0-1",
+            "maxPods": 250,
+        }
+
+    def test_get_kubelet_config_profile_configures_max_pods(self):
+        self.config_map.obj["data"] = {
+            "profile-large": "maxPods: 500\nreservedSystemCPUs: 0-1\n"
+        }
+
+        assert utils.get_kubelet_config(
+            self._cluster({"kubelet_config_profile": "profile-large"}),
+            self.api,
+        ) == {
+            "enabled": True,
+            "cpuManagerPolicy": "",
+            "topologyManagerPolicy": "",
+            "reservedSystemCPUs": "0-1",
+            "maxPods": 500,
+        }
+
+    def test_get_kubelet_config_rejects_missing_profiles_configmap(self):
+        self.config_maps.get_or_none.return_value = None
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(
+                self._cluster({"kubelet_config_profile": "profile-gpu"}),
+                self.api,
+            )
+
+    def test_get_kubelet_config_profile_rejects_invalid_yaml(self):
+        self.config_map.obj["data"] = {"profile-bad": "not: [valid"}
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(
+                self._cluster({"kubelet_config_profile": "profile-bad"}),
+                self.api,
+            )
+
+    def test_get_kubelet_config_profile_rejects_unsupported_field(self):
+        self.config_map.obj["data"] = {"profile-bad": "shutdownGracePeriod: 30s\n"}
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(
+                self._cluster({"kubelet_config_profile": "profile-bad"}),
+                self.api,
+            )
+
+    def test_get_kubelet_config_profile_rejects_invalid_config(self):
+        self.config_map.obj["data"] = {"profile-bad": "maxPods: 0\n"}
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(
+                self._cluster({"kubelet_config_profile": "profile-bad"}),
+                self.api,
+            )
+
+    def test_get_nodegroup_kubelet_config(self):
+        cluster = self._cluster(
+            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+        )
+        nodegroup = self._nodegroup("gpu-workers")
+
+        assert utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api) == {
+            "enabled": True,
+            "cpuManagerPolicy": "static",
+            "topologyManagerPolicy": "single-numa-node",
+            "reservedSystemCPUs": "0-1",
+            "maxPods": 250,
+        }
+
+    def test_get_nodegroup_kubelet_config_ignores_unmapped_nodegroup(self):
+        cluster = self._cluster(
+            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+        )
+        nodegroup = self._nodegroup("default-worker")
+
+        assert utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api) is None
+
+    def test_get_nodegroup_kubelet_config_rejects_invalid_profile_set(self):
+        cluster = self._cluster(
+            {"kubelet_nodegroup_config_profile_set": "missing-layout"}
+        )
+        nodegroup = self._nodegroup("gpu-workers")
+
+        with pytest.raises(exception.Invalid):
+            utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api)
+
+    def test_get_nodegroup_kubelet_config_rejects_missing_profile_reference(self):
+        self.config_map.obj["data"]["profile-layout"] = (
+            "nodegroups:\n"
+            "  gpu-workers:\n"
+            "    kubeletConfigProfile: missing-profile\n"
+        )
+        cluster = self._cluster(
+            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+        )
+        nodegroup = self._nodegroup("gpu-workers")
+
+        with pytest.raises(exception.Invalid):
+            utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api)
+
+    def test_get_nodegroup_kubelet_config_rejects_invalid_layout_schema(self):
+        self.config_map.obj["data"]["profile-layout"] = (
+            "nodegroups:\n" "  gpu-workers:\n" "    maxPods: 250\n"
+        )
+        cluster = self._cluster(
+            {"kubelet_nodegroup_config_profile_set": "profile-layout"}
+        )
+        nodegroup = self._nodegroup("gpu-workers")
+
+        with pytest.raises(exception.Invalid):
+            utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api)
+
+    def test_sync_kubelet_profile_labels_from_template(self):
+        cluster = self._cluster(
+            {
+                "kubelet_config_profile": "profile-old",
+                "kubelet_nodegroup_config_profile_set": "layout-old",
+                "kube_tag": "v1.34.3",
+            }
+        )
+        template = mock.Mock(
+            labels={
+                "kubelet_config_profile": "profile-gpu",
+            }
+        )
+
+        utils.sync_kubelet_profile_labels_from_template(cluster, template)
+
+        assert cluster.labels["kubelet_config_profile"] == "profile-gpu"
+        assert "kubelet_nodegroup_config_profile_set" not in cluster.labels
+        assert cluster.labels["kube_tag"] == "v1.34.3"
+
+    def test_get_kubelet_config_fetches_profile_configmap(self):
+        utils.get_kubelet_config(
+            self._cluster({"kubelet_config_profile": "profile-gpu"}),
+            self.api,
+        )
+
+        pykube.ConfigMap.objects.assert_called_once_with(
+            self.api,
+            namespace="magnum-system",
+        )
+        self.config_maps.get_or_none.assert_called_once_with(
+            name="mcapi-kubelet-config-profiles"
+        )

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -655,9 +655,7 @@ class TestConfigProfiles:
                         "  maxPods: 250\n"
                     ),
                     "profile-layout": (
-                        "nodegroups:\n"
-                        "  gpu-workers:\n"
-                        "    profile: profile-gpu\n"
+                        "nodegroups:\n" "  gpu-workers:\n" "    profile: profile-gpu\n"
                     ),
                 }
             }
@@ -868,9 +866,7 @@ class TestConfigProfiles:
     def test_get_config_profile_configures_max_pods(self):
         self.config_map.obj["data"] = {
             "profile-large": (
-                "kubeletConfig:\n"
-                "  maxPods: 500\n"
-                "  reservedSystemCPUs: 0-1\n"
+                "kubeletConfig:\n" "  maxPods: 500\n" "  reservedSystemCPUs: 0-1\n"
             )
         }
 
@@ -963,9 +959,7 @@ class TestConfigProfiles:
             )
 
     def test_get_nodegroup_kubelet_config(self):
-        cluster = self._cluster(
-            {"nodegroup_config_profile_set": "profile-layout"}
-        )
+        cluster = self._cluster({"nodegroup_config_profile_set": "profile-layout"})
         nodegroup = self._nodegroup("gpu-workers")
 
         assert (
@@ -1025,17 +1019,13 @@ class TestConfigProfiles:
         assert gpu_profile["preKubeadmCommands"] == ["cat /etc/atmosphere/role"]
 
     def test_get_nodegroup_kubelet_config_ignores_unmapped_nodegroup(self):
-        cluster = self._cluster(
-            {"nodegroup_config_profile_set": "profile-layout"}
-        )
+        cluster = self._cluster({"nodegroup_config_profile_set": "profile-layout"})
         nodegroup = self._nodegroup("default-worker")
 
         assert utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api) is None
 
     def test_get_nodegroup_kubelet_config_rejects_invalid_profile_set(self):
-        cluster = self._cluster(
-            {"nodegroup_config_profile_set": "missing-layout"}
-        )
+        cluster = self._cluster({"nodegroup_config_profile_set": "missing-layout"})
         nodegroup = self._nodegroup("gpu-workers")
 
         with pytest.raises(exception.Invalid):
@@ -1043,13 +1033,9 @@ class TestConfigProfiles:
 
     def test_get_nodegroup_kubelet_config_rejects_missing_profile_reference(self):
         self.config_map.obj["data"]["profile-layout"] = (
-            "nodegroups:\n"
-            "  gpu-workers:\n"
-            "    profile: missing-profile\n"
+            "nodegroups:\n" "  gpu-workers:\n" "    profile: missing-profile\n"
         )
-        cluster = self._cluster(
-            {"nodegroup_config_profile_set": "profile-layout"}
-        )
+        cluster = self._cluster({"nodegroup_config_profile_set": "profile-layout"})
         nodegroup = self._nodegroup("gpu-workers")
 
         with pytest.raises(exception.Invalid):
@@ -1059,9 +1045,7 @@ class TestConfigProfiles:
         self.config_map.obj["data"]["profile-layout"] = (
             "nodegroups:\n" "  gpu-workers:\n" "    maxPods: 250\n"
         )
-        cluster = self._cluster(
-            {"nodegroup_config_profile_set": "profile-layout"}
-        )
+        cluster = self._cluster({"nodegroup_config_profile_set": "profile-layout"})
         nodegroup = self._nodegroup("gpu-workers")
 
         with pytest.raises(exception.Invalid):

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -383,6 +383,59 @@ class TestUtils(base.BaseTestCase):
         )
 
 
+class TestConfigProfileSelectorLabels:
+    def _cluster(self, labels, template_labels):
+        cluster = mock.Mock()
+        cluster.labels = dict(labels)
+        cluster.cluster_template = mock.Mock()
+        cluster.cluster_template.labels = dict(template_labels)
+        return cluster
+
+    def test_rejects_cluster_create_config_profile_override(self):
+        cluster = self._cluster(
+            {"config_profile": "profile-user"},
+            {"config_profile": "profile-template"},
+        )
+
+        with pytest.raises(exception.Invalid):
+            utils.reject_config_profile_label_overrides(cluster)
+
+    def test_rejects_cluster_create_config_profile_without_template_label(self):
+        cluster = self._cluster({"config_profile": "profile-user"}, {})
+
+        with pytest.raises(exception.Invalid):
+            utils.reject_config_profile_label_overrides(cluster)
+
+    def test_allows_matching_config_profile_template_label(self):
+        cluster = self._cluster(
+            {"config_profile": "profile-template"},
+            {"config_profile": "profile-template"},
+        )
+
+        utils.reject_config_profile_label_overrides(cluster)
+
+    def test_sync_config_profile_labels_from_template(self):
+        cluster = self._cluster(
+            {
+                "config_profile": "profile-current",
+                "nodegroup_config_profile_set": "layout-current",
+                "kube_tag": "v1.34.3",
+            },
+            {},
+        )
+        template = mock.Mock(
+            labels={
+                "config_profile": "profile-gpu",
+            }
+        )
+
+        utils.sync_config_profile_labels_from_template(cluster, template)
+
+        assert cluster.labels["config_profile"] == "profile-gpu"
+        assert "nodegroup_config_profile_set" not in cluster.labels
+        assert cluster.labels["kube_tag"] == "v1.34.3"
+
+
 def test_delete_loadbalancers(mocker):
     ctx = mocker.Mock()
     cluster = mocker.Mock()
@@ -568,7 +621,7 @@ def test_wait_for_sdk_loadbalancers_deleted_times_out(mocker):
     sleep.assert_called_once_with(1)
 
 
-class TestKubeletConfigLabels:
+class TestConfigProfiles:
     @pytest.fixture(autouse=True)
     def setup_profiles(self, mocker):
         self.api = mock.Mock()
@@ -576,29 +629,30 @@ class TestKubeletConfigLabels:
             obj={
                 "data": {
                     "profile-gpu": (
-                        "cpuManagerPolicy: static\n"
-                        "cpuManagerPolicyOptions:\n"
-                        '  full-pcpus-only: "true"\n'
-                        "cpuManagerReconcilePeriod: 5s\n"
-                        "memoryManagerPolicy: Static\n"
-                        "topologyManagerPolicy: single-numa-node\n"
-                        "topologyManagerScope: pod\n"
-                        "topologyManagerPolicyOptions:\n"
-                        '  max-allowable-numa-nodes: "2"\n'
-                        "qosReserved:\n"
-                        '  memory: "50%"\n'
-                        "systemReserved:\n"
-                        "  memory: 1Gi\n"
-                        "kubeReserved:\n"
-                        "  cpu: 200m\n"
-                        "enforceNodeAllocatable:\n"
-                        "  - pods\n"
-                        "reservedMemory:\n"
-                        "  - numaNode: 0\n"
-                        "    limits:\n"
-                        "      memory: 1Gi\n"
-                        "reservedSystemCPUs: 0-1\n"
-                        "maxPods: 250\n"
+                        "kubeletConfig:\n"
+                        "  cpuManagerPolicy: static\n"
+                        "  cpuManagerPolicyOptions:\n"
+                        '    full-pcpus-only: "true"\n'
+                        "  cpuManagerReconcilePeriod: 5s\n"
+                        "  memoryManagerPolicy: Static\n"
+                        "  topologyManagerPolicy: single-numa-node\n"
+                        "  topologyManagerScope: pod\n"
+                        "  topologyManagerPolicyOptions:\n"
+                        '    max-allowable-numa-nodes: "2"\n'
+                        "  qosReserved:\n"
+                        '    memory: "50%"\n'
+                        "  systemReserved:\n"
+                        "    memory: 1Gi\n"
+                        "  kubeReserved:\n"
+                        "    cpu: 200m\n"
+                        "  enforceNodeAllocatable:\n"
+                        "    - pods\n"
+                        "  reservedMemory:\n"
+                        "    - numaNode: 0\n"
+                        "      limits:\n"
+                        "        memory: 1Gi\n"
+                        "  reservedSystemCPUs: 0-1\n"
+                        "  maxPods: 250\n"
                     ),
                     "profile-layout": (
                         "nodegroups:\n"
@@ -774,7 +828,7 @@ class TestKubeletConfigLabels:
             )
         ]
 
-    def test_validate_kubelet_config_labels(self):
+    def test_validate_config_profile_labels(self):
         cluster = self._cluster(
             {
                 "config_profile": "profile-gpu",
@@ -782,13 +836,13 @@ class TestKubeletConfigLabels:
             }
         )
 
-        utils.validate_kubelet_config_labels(cluster, self.api)
+        utils.validate_config_profile_labels(cluster, self.api)
 
-    def test_validate_kubelet_config_labels_rejects_invalid_profile(self):
+    def test_validate_config_profile_labels_rejects_invalid_profile(self):
         cluster = self._cluster({"config_profile": "exclusive"})
 
         with pytest.raises(exception.Invalid):
-            utils.validate_kubelet_config_labels(cluster, self.api)
+            utils.validate_config_profile_labels(cluster, self.api)
 
     def test_get_kubelet_config_rejects_invalid_profile(self):
         cluster = self._cluster({"config_profile": "missing"})
@@ -813,7 +867,11 @@ class TestKubeletConfigLabels:
 
     def test_get_config_profile_configures_max_pods(self):
         self.config_map.obj["data"] = {
-            "profile-large": "maxPods: 500\nreservedSystemCPUs: 0-1\n"
+            "profile-large": (
+                "kubeletConfig:\n"
+                "  maxPods: 500\n"
+                "  reservedSystemCPUs: 0-1\n"
+            )
         }
 
         assert utils.get_kubelet_config(
@@ -845,10 +903,11 @@ class TestKubeletConfigLabels:
     def test_get_config_profile_allows_dynamic_kubelet_fields(self):
         self.config_map.obj["data"] = {
             "profile-dynamic": (
-                "shutdownGracePeriod: 30s\n"
-                "featureGates:\n"
-                "  TopologyManagerPolicyOptions: true\n"
-                "topologyManagerScope: pod\n"
+                "kubeletConfig:\n"
+                "  shutdownGracePeriod: 30s\n"
+                "  featureGates:\n"
+                "    TopologyManagerPolicyOptions: true\n"
+                "  topologyManagerScope: pod\n"
             )
         }
 
@@ -865,8 +924,21 @@ class TestKubeletConfigLabels:
             ),
         }
 
+    def test_get_config_profile_rejects_unwrapped_kubelet_fields(self):
+        self.config_map.obj["data"] = {
+            "profile-bad": "maxPods: 250\nreservedSystemCPUs: 0-1\n"
+        }
+
+        with pytest.raises(exception.Invalid):
+            utils.get_kubelet_config(
+                self._cluster({"config_profile": "profile-bad"}),
+                self.api,
+            )
+
     def test_get_config_profile_rejects_reserved_field(self):
-        self.config_map.obj["data"] = {"profile-bad": "apiVersion: v1\n"}
+        self.config_map.obj["data"] = {
+            "profile-bad": "kubeletConfig:\n  apiVersion: v1\n"
+        }
 
         with pytest.raises(exception.Invalid):
             utils.get_kubelet_config(
@@ -994,26 +1066,6 @@ class TestKubeletConfigLabels:
 
         with pytest.raises(exception.Invalid):
             utils.get_nodegroup_kubelet_config(cluster, nodegroup, self.api)
-
-    def test_sync_kubelet_profile_labels_from_template(self):
-        cluster = self._cluster(
-            {
-                "config_profile": "profile-current",
-                "nodegroup_config_profile_set": "layout-current",
-                "kube_tag": "v1.34.3",
-            }
-        )
-        template = mock.Mock(
-            labels={
-                "config_profile": "profile-gpu",
-            }
-        )
-
-        utils.sync_kubelet_profile_labels_from_template(cluster, template)
-
-        assert cluster.labels["config_profile"] == "profile-gpu"
-        assert "nodegroup_config_profile_set" not in cluster.labels
-        assert cluster.labels["kube_tag"] == "v1.34.3"
 
     def test_get_kubelet_config_fetches_profile_configmap(self):
         utils.get_kubelet_config(

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -453,8 +453,7 @@ def validate_config_profile(
         if field in kubelet_fields and not isinstance(kubelet_fields[field], str):
             raise exception.Invalid(
                 "Invalid kubeletConfig.%(field)s in config profile %(profile)s. "
-                "Expected a YAML string."
-                % {"field": field, "profile": profile}
+                "Expected a YAML string." % {"field": field, "profile": profile}
             )
 
     return fields

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -50,18 +50,10 @@ AVAILABLE_SERVER_GROUP_POLICIES = [
     "soft-affinity",
     "soft-anti-affinity",
 ]
-KUBELET_CPU_MANAGER_POLICIES = ["none", "static"]
-KUBELET_TOPOLOGY_MANAGER_POLICIES = [
-    "none",
-    "best-effort",
-    "restricted",
-    "single-numa-node",
-]
-KUBELET_CONFIG_PROFILE_FIELDS = {
-    "cpuManagerPolicy",
-    "topologyManagerPolicy",
-    "reservedSystemCPUs",
-    "maxPods",
+KUBELET_CONFIG_PROFILE_RESERVED_FIELDS = {
+    "apiVersion",
+    "kind",
+    "nodegroups",
 }
 KUBELET_PROFILE_SELECTOR_LABELS = {
     "kubelet_config_profile",
@@ -405,49 +397,15 @@ def validate_kubelet_config_profile(
             % {"profile": profile}
         )
 
-    config: typing.Dict[str, typing.Any] = {}
-    for key, value in fields.items():
-        if key not in KUBELET_CONFIG_PROFILE_FIELDS:
-            raise exception.Invalid(
-                "Unsupported kubelet config profile field %(field)s in "
-                "%(profile)s. Supported fields: %(supported)s."
-                % {
-                    "field": key,
-                    "profile": profile,
-                    "supported": ", ".join(sorted(KUBELET_CONFIG_PROFILE_FIELDS)),
-                }
-            )
-        config[key] = value
-
-    if "cpuManagerPolicy" in config and config["cpuManagerPolicy"] not in (
-        KUBELET_CPU_MANAGER_POLICIES
-    ):
+    reserved_fields = set(fields) & KUBELET_CONFIG_PROFILE_RESERVED_FIELDS
+    if reserved_fields:
         raise exception.Invalid(
-            "Invalid cpuManagerPolicy in kubelet config profile %(profile)s: "
-            "%(value)s." % {"profile": profile, "value": config["cpuManagerPolicy"]}
+            "Unsupported kubelet config profile field %(field)s in %(profile)s. "
+            "Magnum renders this field itself."
+            % {"field": sorted(reserved_fields)[0], "profile": profile}
         )
-    if (
-        "topologyManagerPolicy" in config
-        and config["topologyManagerPolicy"] not in KUBELET_TOPOLOGY_MANAGER_POLICIES
-    ):
-        raise exception.Invalid(
-            "Invalid topologyManagerPolicy in kubelet config profile "
-            "%(profile)s: %(value)s."
-            % {"profile": profile, "value": config["topologyManagerPolicy"]}
-        )
-    if "maxPods" in config:
-        try:
-            max_pods = strutils.validate_integer(config["maxPods"], "maxPods")
-        except ValueError as exc:
-            raise exception.Invalid(str(exc))
-        if max_pods <= 0:
-            raise exception.Invalid(
-                "maxPods in kubelet config profile %(profile)s must be a "
-                "positive integer." % {"profile": profile}
-            )
-        config["maxPods"] = max_pods
 
-    return config
+    return fields
 
 
 def get_kubelet_config_profile_data(
@@ -479,7 +437,7 @@ def get_kubelet_config_profiles(
 ) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
     profiles: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
     for name, fields in get_kubelet_config_profile_data(api, namespace).items():
-        if isinstance(fields, dict) and "nodegroups" in fields:
+        if isinstance(fields, dict) and set(fields) == {"nodegroups"}:
             continue
         profiles[name] = validate_kubelet_config_profile(name, fields)
     return profiles
@@ -636,33 +594,38 @@ def get_kubelet_nodegroup_config_profile_set(
 
 def kubelet_config_from_profile_defaults(
     profile_defaults: typing.Dict[str, typing.Any],
-) -> typing.Dict[str, typing.Union[str, bool, int]]:
-    cpu_manager_policy = profile_defaults.get("cpuManagerPolicy", "")
-    topology_manager_policy = profile_defaults.get("topologyManagerPolicy", "")
-    reserved_system_cpus = profile_defaults.get("reservedSystemCPUs", "")
-    max_pods = int(profile_defaults.get("maxPods", 0))
+) -> typing.Dict[str, typing.Any]:
+    config_yaml = _render_kubelet_config_profile_yaml(profile_defaults)
 
     return {
-        "enabled": any(
-            [
-                cpu_manager_policy,
-                topology_manager_policy,
-                reserved_system_cpus,
-                max_pods,
-            ]
-        ),
-        "cpuManagerPolicy": cpu_manager_policy,
-        "topologyManagerPolicy": topology_manager_policy,
-        "reservedSystemCPUs": reserved_system_cpus,
-        "maxPods": max_pods,
+        "enabled": bool(profile_defaults),
+        "configYaml": config_yaml,
     }
+
+
+def _render_kubelet_config_profile_yaml(
+    profile_defaults: typing.Dict[str, typing.Any],
+) -> str:
+    if not profile_defaults:
+        return ""
+
+    config_yaml = yaml.safe_dump(
+        profile_defaults,
+        default_flow_style=False,
+        sort_keys=True,
+    ).rstrip()
+    lines = config_yaml.splitlines()
+    if not lines:
+        return ""
+
+    return "\n".join([lines[0], *[f"  {line}" for line in lines[1:]]])
 
 
 def get_kubelet_config(
     cluster: magnum_objects.Cluster,
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
-) -> typing.Dict[str, typing.Union[str, bool, int]]:
+) -> typing.Dict[str, typing.Any]:
     kubelet_config_profile = cluster.labels.get("kubelet_config_profile", "")
     profile_defaults = get_kubelet_config_profile_defaults(
         kubelet_config_profile,
@@ -677,7 +640,7 @@ def get_nodegroup_kubelet_config(
     nodegroup: magnum_objects.NodeGroup,
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
-) -> typing.Dict[str, typing.Union[str, bool, int]] | None:
+) -> typing.Dict[str, typing.Any] | None:
     profile_set = get_kubelet_nodegroup_config_profile_set(
         cluster.labels.get("kubelet_nodegroup_config_profile_set", ""),
         api,

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -67,6 +67,9 @@ CONFIG_PROFILE_FIELDS = {
     "preKubeadmCommands",
     "postKubeadmCommands",
 }
+CONFIG_PROFILE_STRING_KUBELET_FIELDS = {
+    "reservedSystemCPUs",
+}
 CONFIG_PROFILE_MAX_FILES = 10
 CONFIG_PROFILE_MAX_PRE_COMMANDS = 16
 CONFIG_PROFILE_MAX_POST_COMMANDS = 16
@@ -446,6 +449,13 @@ def validate_config_profile(
             "Magnum renders this field itself."
             % {"field": sorted(reserved_fields)[0], "profile": profile}
         )
+    for field in sorted(CONFIG_PROFILE_STRING_KUBELET_FIELDS):
+        if field in kubelet_fields and not isinstance(kubelet_fields[field], str):
+            raise exception.Invalid(
+                "Invalid kubeletConfig.%(field)s in config profile %(profile)s. "
+                "Expected a YAML string."
+                % {"field": field, "profile": profile}
+            )
 
     return fields
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -50,6 +50,24 @@ AVAILABLE_SERVER_GROUP_POLICIES = [
     "soft-affinity",
     "soft-anti-affinity",
 ]
+KUBELET_CPU_MANAGER_POLICIES = ["none", "static"]
+KUBELET_TOPOLOGY_MANAGER_POLICIES = [
+    "none",
+    "best-effort",
+    "restricted",
+    "single-numa-node",
+]
+KUBELET_CONFIG_PROFILE_FIELDS = {
+    "cpuManagerPolicy",
+    "topologyManagerPolicy",
+    "reservedSystemCPUs",
+    "maxPods",
+}
+KUBELET_PROFILE_SELECTOR_LABELS = {
+    "kubelet_config_profile",
+    "kubelet_nodegroup_config_profile_set",
+}
+KUBELET_CONFIG_PROFILES_CONFIGMAP = "mcapi-kubelet-config-profiles"
 CONF = cfg.CONF
 
 
@@ -321,6 +339,363 @@ def get_cluster_label_as_bool(
     return strutils.bool_from_string(value, strict=True)
 
 
+def validate_cluster_label_in_list(
+    cluster: magnum_objects.Cluster,
+    key: str,
+    allowed_values: list[str],
+) -> None:
+    value = cluster.labels.get(key)
+    if not value:
+        return
+    if value not in allowed_values:
+        raise exception.Invalid(
+            "Invalid value for %(key)s: %(value)s. Allowed values: %(allowed)s."
+            % {
+                "key": key,
+                "value": value,
+                "allowed": ", ".join(allowed_values),
+            }
+        )
+
+
+def sync_kubelet_profile_labels_from_template(
+    cluster: magnum_objects.Cluster,
+    cluster_template: magnum_objects.ClusterTemplate,
+) -> None:
+    """Copy kubelet profile selector labels from a target template.
+
+    Magnum's cluster upgrade path is the durable user-facing API for changing
+    kubelet profiles after create.  Keep only selector labels in the cluster
+    row, and remove stale selector values when the target template omits them.
+    """
+    if cluster.labels is None:
+        cluster.labels = {}
+    template_labels = getattr(cluster_template, "labels", None) or {}
+    for label in KUBELET_PROFILE_SELECTOR_LABELS:
+        if label in template_labels:
+            cluster.labels[label] = template_labels[label]
+        else:
+            cluster.labels.pop(label, None)
+
+
+def validate_kubelet_config_labels(
+    cluster: magnum_objects.Cluster,
+    api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
+) -> None:
+    get_kubelet_config_profile_defaults(
+        cluster.labels.get("kubelet_config_profile", ""),
+        api,
+        namespace,
+    )
+    get_kubelet_nodegroup_config_profile_set(
+        cluster.labels.get("kubelet_nodegroup_config_profile_set", ""),
+        api,
+        namespace,
+    )
+
+
+def validate_kubelet_config_profile(
+    profile: str,
+    fields: typing.Any,
+) -> typing.Dict[str, typing.Any]:
+    if not isinstance(fields, dict):
+        raise exception.Invalid(
+            "Invalid kubelet config profile %(profile)s. Expected a YAML object."
+            % {"profile": profile}
+        )
+
+    config: typing.Dict[str, typing.Any] = {}
+    for key, value in fields.items():
+        if key not in KUBELET_CONFIG_PROFILE_FIELDS:
+            raise exception.Invalid(
+                "Unsupported kubelet config profile field %(field)s in "
+                "%(profile)s. Supported fields: %(supported)s."
+                % {
+                    "field": key,
+                    "profile": profile,
+                    "supported": ", ".join(sorted(KUBELET_CONFIG_PROFILE_FIELDS)),
+                }
+            )
+        config[key] = value
+
+    if "cpuManagerPolicy" in config and config["cpuManagerPolicy"] not in (
+        KUBELET_CPU_MANAGER_POLICIES
+    ):
+        raise exception.Invalid(
+            "Invalid cpuManagerPolicy in kubelet config profile %(profile)s: "
+            "%(value)s." % {"profile": profile, "value": config["cpuManagerPolicy"]}
+        )
+    if (
+        "topologyManagerPolicy" in config
+        and config["topologyManagerPolicy"] not in KUBELET_TOPOLOGY_MANAGER_POLICIES
+    ):
+        raise exception.Invalid(
+            "Invalid topologyManagerPolicy in kubelet config profile "
+            "%(profile)s: %(value)s."
+            % {"profile": profile, "value": config["topologyManagerPolicy"]}
+        )
+    if "maxPods" in config:
+        try:
+            max_pods = strutils.validate_integer(config["maxPods"], "maxPods")
+        except ValueError as exc:
+            raise exception.Invalid(str(exc))
+        if max_pods <= 0:
+            raise exception.Invalid(
+                "maxPods in kubelet config profile %(profile)s must be a "
+                "positive integer." % {"profile": profile}
+            )
+        config["maxPods"] = max_pods
+
+    return config
+
+
+def get_kubelet_config_profile_data(
+    api: pykube.HTTPClient,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Any]:
+    config_map = pykube.ConfigMap.objects(api, namespace=namespace).get_or_none(
+        name=KUBELET_CONFIG_PROFILES_CONFIGMAP
+    )
+    if config_map is None:
+        return {}
+
+    profiles: typing.Dict[str, typing.Any] = {}
+    for name, raw_profile in config_map.obj.get("data", {}).items():
+        try:
+            fields = yaml.safe_load(raw_profile) or {}
+        except yaml.YAMLError as exc:
+            raise exception.Invalid(
+                "Invalid YAML in kubelet config profile %(profile)s: %(error)s."
+                % {"profile": name, "error": exc}
+            )
+        profiles[name] = fields
+    return profiles
+
+
+def get_kubelet_config_profiles(
+    api: pykube.HTTPClient,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
+    profiles: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
+    for name, fields in get_kubelet_config_profile_data(api, namespace).items():
+        if isinstance(fields, dict) and "nodegroups" in fields:
+            continue
+        profiles[name] = validate_kubelet_config_profile(name, fields)
+    return profiles
+
+
+def get_kubelet_config_profile_defaults(
+    profile: str,
+    api: pykube.HTTPClient | None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Any]:
+    if not profile:
+        return {}
+    if api is None:
+        raise exception.Invalid(
+            "kubelet_config_profile requires access to the management Kubernetes "
+            "cluster."
+        )
+    profiles = get_kubelet_config_profiles(api, namespace)
+    if profile not in profiles:
+        if not profiles:
+            raise exception.Invalid(
+                "Invalid value for kubelet_config_profile: %(value)s. No profiles "
+                "are registered in ConfigMap %(configmap)s in namespace "
+                "%(namespace)s."
+                % {
+                    "value": profile,
+                    "configmap": KUBELET_CONFIG_PROFILES_CONFIGMAP,
+                    "namespace": namespace,
+                }
+            )
+        raise exception.Invalid(
+            "Invalid value for kubelet_config_profile: %(value)s. "
+            "Allowed values: %(allowed)s."
+            % {
+                "value": profile,
+                "allowed": ", ".join(sorted(profiles)),
+            }
+        )
+    return profiles[profile]
+
+
+def validate_kubelet_nodegroup_config_profile_set(
+    profile_set: str,
+    fields: typing.Any,
+    profiles: typing.Dict[str, typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, typing.Dict[str, str]]:
+    if not isinstance(fields, dict):
+        raise exception.Invalid(
+            "Invalid kubelet nodegroup config profile set %(profile)s. "
+            "Expected a YAML object." % {"profile": profile_set}
+        )
+
+    unsupported = set(fields) - {"nodegroups"}
+    if unsupported:
+        raise exception.Invalid(
+            "Unsupported kubelet nodegroup config profile set field %(field)s "
+            "in %(profile)s. Supported fields: nodegroups."
+            % {"field": sorted(unsupported)[0], "profile": profile_set}
+        )
+
+    nodegroups = fields.get("nodegroups", {})
+    if not isinstance(nodegroups, dict):
+        raise exception.Invalid(
+            "Invalid nodegroups in kubelet nodegroup config profile set "
+            "%(profile)s. Expected a YAML object." % {"profile": profile_set}
+        )
+
+    config: typing.Dict[str, typing.Dict[str, str]] = {}
+    for nodegroup_name, nodegroup_config in nodegroups.items():
+        if not isinstance(nodegroup_config, dict):
+            raise exception.Invalid(
+                "Invalid nodegroup %(nodegroup)s in kubelet nodegroup config "
+                "profile set %(profile)s. Expected a YAML object."
+                % {"nodegroup": nodegroup_name, "profile": profile_set}
+            )
+
+        unsupported = set(nodegroup_config) - {"kubeletConfigProfile"}
+        if unsupported:
+            raise exception.Invalid(
+                "Unsupported field %(field)s for nodegroup %(nodegroup)s in "
+                "kubelet nodegroup config profile set %(profile)s. Supported "
+                "fields: kubeletConfigProfile."
+                % {
+                    "field": sorted(unsupported)[0],
+                    "nodegroup": nodegroup_name,
+                    "profile": profile_set,
+                }
+            )
+
+        kubelet_config_profile = nodegroup_config.get("kubeletConfigProfile")
+        if not kubelet_config_profile:
+            raise exception.Invalid(
+                "Nodegroup %(nodegroup)s in kubelet nodegroup config profile "
+                "set %(profile)s must set kubeletConfigProfile."
+                % {"nodegroup": nodegroup_name, "profile": profile_set}
+            )
+        if kubelet_config_profile not in profiles:
+            raise exception.Invalid(
+                "Invalid kubeletConfigProfile %(value)s for nodegroup "
+                "%(nodegroup)s in kubelet nodegroup config profile set "
+                "%(profile)s. Allowed values: %(allowed)s."
+                % {
+                    "value": kubelet_config_profile,
+                    "nodegroup": nodegroup_name,
+                    "profile": profile_set,
+                    "allowed": ", ".join(sorted(profiles)),
+                }
+            )
+
+        config[nodegroup_name] = {"kubeletConfigProfile": kubelet_config_profile}
+
+    return config
+
+
+def get_kubelet_nodegroup_config_profile_set(
+    profile_set: str,
+    api: pykube.HTTPClient | None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Dict[str, str]]:
+    if not profile_set:
+        return {}
+    if api is None:
+        raise exception.Invalid(
+            "kubelet_nodegroup_config_profile_set requires access to the "
+            "management Kubernetes cluster."
+        )
+
+    profile_data = get_kubelet_config_profile_data(api, namespace)
+    if profile_set not in profile_data:
+        if not profile_data:
+            raise exception.Invalid(
+                "Invalid value for kubelet_nodegroup_config_profile_set: "
+                "%(value)s. No profiles are registered in ConfigMap "
+                "%(configmap)s in namespace %(namespace)s."
+                % {
+                    "value": profile_set,
+                    "configmap": KUBELET_CONFIG_PROFILES_CONFIGMAP,
+                    "namespace": namespace,
+                }
+            )
+        raise exception.Invalid(
+            "Invalid value for kubelet_nodegroup_config_profile_set: %(value)s. "
+            "Allowed values: %(allowed)s."
+            % {"value": profile_set, "allowed": ", ".join(sorted(profile_data))}
+        )
+
+    profiles = get_kubelet_config_profiles(api, namespace)
+    return validate_kubelet_nodegroup_config_profile_set(
+        profile_set,
+        profile_data[profile_set],
+        profiles,
+    )
+
+
+def kubelet_config_from_profile_defaults(
+    profile_defaults: typing.Dict[str, typing.Any],
+) -> typing.Dict[str, typing.Union[str, bool, int]]:
+    cpu_manager_policy = profile_defaults.get("cpuManagerPolicy", "")
+    topology_manager_policy = profile_defaults.get("topologyManagerPolicy", "")
+    reserved_system_cpus = profile_defaults.get("reservedSystemCPUs", "")
+    max_pods = int(profile_defaults.get("maxPods", 0))
+
+    return {
+        "enabled": any(
+            [
+                cpu_manager_policy,
+                topology_manager_policy,
+                reserved_system_cpus,
+                max_pods,
+            ]
+        ),
+        "cpuManagerPolicy": cpu_manager_policy,
+        "topologyManagerPolicy": topology_manager_policy,
+        "reservedSystemCPUs": reserved_system_cpus,
+        "maxPods": max_pods,
+    }
+
+
+def get_kubelet_config(
+    cluster: magnum_objects.Cluster,
+    api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Union[str, bool, int]]:
+    kubelet_config_profile = cluster.labels.get("kubelet_config_profile", "")
+    profile_defaults = get_kubelet_config_profile_defaults(
+        kubelet_config_profile,
+        api,
+        namespace,
+    )
+    return kubelet_config_from_profile_defaults(profile_defaults)
+
+
+def get_nodegroup_kubelet_config(
+    cluster: magnum_objects.Cluster,
+    nodegroup: magnum_objects.NodeGroup,
+    api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Union[str, bool, int]] | None:
+    profile_set = get_kubelet_nodegroup_config_profile_set(
+        cluster.labels.get("kubelet_nodegroup_config_profile_set", ""),
+        api,
+        namespace,
+    )
+    nodegroup_config = profile_set.get(nodegroup.name)
+    if nodegroup_config is None:
+        return None
+
+    return kubelet_config_from_profile_defaults(
+        get_kubelet_config_profile_defaults(
+            nodegroup_config["kubeletConfigProfile"],
+            api,
+            namespace,
+        )
+    )
+
+
 def delete_loadbalancers(ctx, cluster):
     # NOTE(mnaser): This code is duplicated from magnum.common.octavia
     #               since the original code is very Heat-specific.
@@ -458,10 +833,16 @@ def lookup_image(cli: clients.OpenStackClients, image_ref: str) -> dict:
     return attr_validator.validate_image(cli, image_ref)
 
 
-def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluster):
+def validate_cluster(
+    ctx: context.RequestContext,
+    cluster: magnum_objects.Cluster,
+    api: pykube.HTTPClient | None = None,
+):
     # Check network driver
     if cluster.cluster_template.network_driver not in ["cilium", "calico"]:
         raise mcapi_exceptions.UnsupportedCNI
+
+    validate_kubelet_config_labels(cluster, api)
 
     # Check master count
     if (cluster.master_count % 2) == 0:

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -51,7 +51,7 @@ AVAILABLE_SERVER_GROUP_POLICIES = [
     "soft-affinity",
     "soft-anti-affinity",
 ]
-KUBELET_CONFIG_PROFILE_RESERVED_FIELDS = {
+CONFIG_PROFILE_RESERVED_FIELDS = {
     "apiVersion",
     "kind",
     "nodegroups",
@@ -59,12 +59,8 @@ KUBELET_CONFIG_PROFILE_RESERVED_FIELDS = {
 CONFIG_PROFILE_SELECTOR_LABELS = {
     "config_profile",
     "nodegroup_config_profile_set",
-    "kubelet_config_profile",
-    "kubelet_nodegroup_config_profile_set",
 }
-KUBELET_PROFILE_SELECTOR_LABELS = CONFIG_PROFILE_SELECTOR_LABELS
 CONFIG_PROFILES_CONFIGMAP = "mcapi-config-profiles"
-KUBELET_CONFIG_PROFILES_CONFIGMAP = "mcapi-kubelet-config-profiles"
 CONFIG_PROFILE_FIELDS = {
     "kubeletConfig",
     "files",
@@ -384,30 +380,18 @@ def sync_kubelet_profile_labels_from_template(
             cluster.labels.pop(label, None)
 
 
-def _first_label(labels: typing.Dict[str, str], *names: str) -> str:
-    for name in names:
-        value = labels.get(name)
-        if value:
-            return value
-    return ""
-
-
 def validate_kubelet_config_labels(
     cluster: magnum_objects.Cluster,
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
 ) -> None:
     get_config_profile_defaults(
-        _first_label(cluster.labels, "config_profile", "kubelet_config_profile"),
+        cluster.labels.get("config_profile", ""),
         api,
         namespace,
     )
     get_nodegroup_config_profile_set(
-        _first_label(
-            cluster.labels,
-            "nodegroup_config_profile_set",
-            "kubelet_nodegroup_config_profile_set",
-        ),
+        cluster.labels.get("nodegroup_config_profile_set", ""),
         api,
         namespace,
     )
@@ -419,7 +403,7 @@ def validate_kubelet_config_profile(
 ) -> typing.Dict[str, typing.Any]:
     if not isinstance(fields, dict):
         raise exception.Invalid(
-            "Invalid kubelet config profile %(profile)s. Expected a YAML object."
+            "Invalid config profile %(profile)s. Expected a YAML object."
             % {"profile": profile}
         )
 
@@ -440,10 +424,10 @@ def validate_kubelet_config_profile(
             )
         reserved_fields = set(kubelet_fields) & {"apiVersion", "kind"}
     else:
-        reserved_fields = set(fields) & KUBELET_CONFIG_PROFILE_RESERVED_FIELDS
+        reserved_fields = set(fields) & CONFIG_PROFILE_RESERVED_FIELDS
     if reserved_fields:
         raise exception.Invalid(
-            "Unsupported kubelet config profile field %(field)s in %(profile)s. "
+            "Unsupported config profile field %(field)s in %(profile)s. "
             "Magnum renders this field itself."
             % {"field": sorted(reserved_fields)[0], "profile": profile}
         )
@@ -458,10 +442,6 @@ def get_config_profile_data(
     config_map = pykube.ConfigMap.objects(api, namespace=namespace).get_or_none(
         name=CONFIG_PROFILES_CONFIGMAP
     )
-    if config_map is None:
-        config_map = pykube.ConfigMap.objects(api, namespace=namespace).get_or_none(
-            name=KUBELET_CONFIG_PROFILES_CONFIGMAP
-        )
     if config_map is None:
         return {}
 
@@ -513,12 +493,10 @@ def get_config_profile_defaults(
         if not profiles:
             raise exception.Invalid(
                 "Invalid value for config_profile: %(value)s. No profiles "
-                "are registered in ConfigMap %(configmap)s or %(legacy)s in namespace "
-                "%(namespace)s."
+                "are registered in ConfigMap %(configmap)s in namespace %(namespace)s."
                 % {
                     "value": profile,
                     "configmap": CONFIG_PROFILES_CONFIGMAP,
-                    "legacy": KUBELET_CONFIG_PROFILES_CONFIGMAP,
                     "namespace": namespace,
                 }
             )
@@ -702,7 +680,7 @@ def validate_nodegroup_config_profile_set(
     nodegroups = fields.get("nodegroups", {})
     if not isinstance(nodegroups, dict):
         raise exception.Invalid(
-            "Invalid nodegroups in kubelet nodegroup config profile set "
+            "Invalid nodegroups in nodegroup config profile set "
             "%(profile)s. Expected a YAML object." % {"profile": profile_set}
         )
 
@@ -715,12 +693,12 @@ def validate_nodegroup_config_profile_set(
                 % {"nodegroup": nodegroup_name, "profile": profile_set}
             )
 
-        unsupported = set(nodegroup_config) - {"profile", "kubeletConfigProfile"}
+        unsupported = set(nodegroup_config) - {"profile"}
         if unsupported:
             raise exception.Invalid(
                 "Unsupported field %(field)s for nodegroup %(nodegroup)s in "
                 "nodegroup config profile set %(profile)s. Supported "
-                "fields: profile, kubeletConfigProfile."
+                "field: profile."
                 % {
                     "field": sorted(unsupported)[0],
                     "nodegroup": nodegroup_name,
@@ -728,19 +706,17 @@ def validate_nodegroup_config_profile_set(
                 }
             )
 
-        config_profile = nodegroup_config.get("profile") or nodegroup_config.get(
-            "kubeletConfigProfile"
-        )
+        config_profile = nodegroup_config.get("profile")
         if not config_profile:
             raise exception.Invalid(
-                "Nodegroup %(nodegroup)s in kubelet nodegroup config profile "
+                "Nodegroup %(nodegroup)s in nodegroup config profile "
                 "set %(profile)s must set profile."
                 % {"nodegroup": nodegroup_name, "profile": profile_set}
             )
         if config_profile not in profiles:
             raise exception.Invalid(
                 "Invalid profile %(value)s for nodegroup "
-                "%(nodegroup)s in kubelet nodegroup config profile set "
+                "%(nodegroup)s in nodegroup config profile set "
                 "%(profile)s. Allowed values: %(allowed)s."
                 % {
                     "value": config_profile,
@@ -891,7 +867,7 @@ def get_config_profile(
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Any]:
-    profile = _first_label(cluster.labels, "config_profile", "kubelet_config_profile")
+    profile = cluster.labels.get("config_profile", "")
     profile_defaults = get_config_profile_defaults(
         profile,
         api,
@@ -919,11 +895,7 @@ def get_nodegroup_config_profile(
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Any] | None:
     profile_set = get_nodegroup_config_profile_set(
-        _first_label(
-            cluster.labels,
-            "nodegroup_config_profile_set",
-            "kubelet_nodegroup_config_profile_set",
-        ),
+        cluster.labels.get("nodegroup_config_profile_set", ""),
         api,
         namespace,
     )

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import base64 as stdlib_base64
 import json
 import re
 import string
@@ -55,11 +56,24 @@ KUBELET_CONFIG_PROFILE_RESERVED_FIELDS = {
     "kind",
     "nodegroups",
 }
-KUBELET_PROFILE_SELECTOR_LABELS = {
+CONFIG_PROFILE_SELECTOR_LABELS = {
+    "config_profile",
+    "nodegroup_config_profile_set",
     "kubelet_config_profile",
     "kubelet_nodegroup_config_profile_set",
 }
+KUBELET_PROFILE_SELECTOR_LABELS = CONFIG_PROFILE_SELECTOR_LABELS
+CONFIG_PROFILES_CONFIGMAP = "mcapi-config-profiles"
 KUBELET_CONFIG_PROFILES_CONFIGMAP = "mcapi-kubelet-config-profiles"
+CONFIG_PROFILE_FIELDS = {
+    "kubeletConfig",
+    "files",
+    "preKubeadmCommands",
+    "postKubeadmCommands",
+}
+CONFIG_PROFILE_MAX_FILES = 10
+CONFIG_PROFILE_MAX_PRE_COMMANDS = 16
+CONFIG_PROFILE_MAX_POST_COMMANDS = 16
 CONF = cfg.CONF
 
 
@@ -363,11 +377,19 @@ def sync_kubelet_profile_labels_from_template(
     if cluster.labels is None:
         cluster.labels = {}
     template_labels = getattr(cluster_template, "labels", None) or {}
-    for label in KUBELET_PROFILE_SELECTOR_LABELS:
+    for label in CONFIG_PROFILE_SELECTOR_LABELS:
         if label in template_labels:
             cluster.labels[label] = template_labels[label]
         else:
             cluster.labels.pop(label, None)
+
+
+def _first_label(labels: typing.Dict[str, str], *names: str) -> str:
+    for name in names:
+        value = labels.get(name)
+        if value:
+            return value
+    return ""
 
 
 def validate_kubelet_config_labels(
@@ -375,13 +397,17 @@ def validate_kubelet_config_labels(
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
 ) -> None:
-    get_kubelet_config_profile_defaults(
-        cluster.labels.get("kubelet_config_profile", ""),
+    get_config_profile_defaults(
+        _first_label(cluster.labels, "config_profile", "kubelet_config_profile"),
         api,
         namespace,
     )
-    get_kubelet_nodegroup_config_profile_set(
-        cluster.labels.get("kubelet_nodegroup_config_profile_set", ""),
+    get_nodegroup_config_profile_set(
+        _first_label(
+            cluster.labels,
+            "nodegroup_config_profile_set",
+            "kubelet_nodegroup_config_profile_set",
+        ),
         api,
         namespace,
     )
@@ -397,7 +423,24 @@ def validate_kubelet_config_profile(
             % {"profile": profile}
         )
 
-    reserved_fields = set(fields) & KUBELET_CONFIG_PROFILE_RESERVED_FIELDS
+    if CONFIG_PROFILE_FIELDS & set(fields):
+        unsupported = set(fields) - CONFIG_PROFILE_FIELDS
+        if unsupported:
+            raise exception.Invalid(
+                "Unsupported config profile field %(field)s in %(profile)s."
+                % {"field": sorted(unsupported)[0], "profile": profile}
+            )
+        kubelet_fields = fields.get("kubeletConfig", {})
+        if kubelet_fields is None:
+            kubelet_fields = {}
+        if not isinstance(kubelet_fields, dict):
+            raise exception.Invalid(
+                "Invalid kubeletConfig in config profile %(profile)s. "
+                "Expected a YAML object." % {"profile": profile}
+            )
+        reserved_fields = set(kubelet_fields) & {"apiVersion", "kind"}
+    else:
+        reserved_fields = set(fields) & KUBELET_CONFIG_PROFILE_RESERVED_FIELDS
     if reserved_fields:
         raise exception.Invalid(
             "Unsupported kubelet config profile field %(field)s in %(profile)s. "
@@ -408,13 +451,17 @@ def validate_kubelet_config_profile(
     return fields
 
 
-def get_kubelet_config_profile_data(
+def get_config_profile_data(
     api: pykube.HTTPClient,
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Any]:
     config_map = pykube.ConfigMap.objects(api, namespace=namespace).get_or_none(
-        name=KUBELET_CONFIG_PROFILES_CONFIGMAP
+        name=CONFIG_PROFILES_CONFIGMAP
     )
+    if config_map is None:
+        config_map = pykube.ConfigMap.objects(api, namespace=namespace).get_or_none(
+            name=KUBELET_CONFIG_PROFILES_CONFIGMAP
+        )
     if config_map is None:
         return {}
 
@@ -424,11 +471,18 @@ def get_kubelet_config_profile_data(
             fields = yaml.safe_load(raw_profile) or {}
         except yaml.YAMLError as exc:
             raise exception.Invalid(
-                "Invalid YAML in kubelet config profile %(profile)s: %(error)s."
+                "Invalid YAML in config profile %(profile)s: %(error)s."
                 % {"profile": name, "error": exc}
             )
         profiles[name] = fields
     return profiles
+
+
+def get_kubelet_config_profile_data(
+    api: pykube.HTTPClient,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Any]:
+    return get_config_profile_data(api, namespace)
 
 
 def get_kubelet_config_profiles(
@@ -436,14 +490,14 @@ def get_kubelet_config_profiles(
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
     profiles: typing.Dict[str, typing.Dict[str, typing.Any]] = {}
-    for name, fields in get_kubelet_config_profile_data(api, namespace).items():
+    for name, fields in get_config_profile_data(api, namespace).items():
         if isinstance(fields, dict) and set(fields) == {"nodegroups"}:
             continue
         profiles[name] = validate_kubelet_config_profile(name, fields)
     return profiles
 
 
-def get_kubelet_config_profile_defaults(
+def get_config_profile_defaults(
     profile: str,
     api: pykube.HTTPClient | None,
     namespace: str = "magnum-system",
@@ -452,24 +506,24 @@ def get_kubelet_config_profile_defaults(
         return {}
     if api is None:
         raise exception.Invalid(
-            "kubelet_config_profile requires access to the management Kubernetes "
-            "cluster."
+            "config_profile requires access to the management Kubernetes " "cluster."
         )
     profiles = get_kubelet_config_profiles(api, namespace)
     if profile not in profiles:
         if not profiles:
             raise exception.Invalid(
-                "Invalid value for kubelet_config_profile: %(value)s. No profiles "
-                "are registered in ConfigMap %(configmap)s in namespace "
+                "Invalid value for config_profile: %(value)s. No profiles "
+                "are registered in ConfigMap %(configmap)s or %(legacy)s in namespace "
                 "%(namespace)s."
                 % {
                     "value": profile,
-                    "configmap": KUBELET_CONFIG_PROFILES_CONFIGMAP,
+                    "configmap": CONFIG_PROFILES_CONFIGMAP,
+                    "legacy": KUBELET_CONFIG_PROFILES_CONFIGMAP,
                     "namespace": namespace,
                 }
             )
         raise exception.Invalid(
-            "Invalid value for kubelet_config_profile: %(value)s. "
+            "Invalid value for config_profile: %(value)s. "
             "Allowed values: %(allowed)s."
             % {
                 "value": profile,
@@ -479,21 +533,168 @@ def get_kubelet_config_profile_defaults(
     return profiles[profile]
 
 
-def validate_kubelet_nodegroup_config_profile_set(
+def get_kubelet_config_profile_defaults(
+    profile: str,
+    api: pykube.HTTPClient | None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Any]:
+    return get_config_profile_defaults(profile, api, namespace)
+
+
+def _is_structured_config_profile(fields: typing.Dict[str, typing.Any]) -> bool:
+    return bool(CONFIG_PROFILE_FIELDS & set(fields))
+
+
+def _get_config_profile_kubelet_fields(
+    fields: typing.Dict[str, typing.Any],
+) -> typing.Dict[str, typing.Any]:
+    if _is_structured_config_profile(fields):
+        kubelet_fields = fields.get("kubeletConfig") or {}
+        if not isinstance(kubelet_fields, dict):
+            raise exception.Invalid(
+                "config profile kubeletConfig must be a YAML object."
+            )
+        return kubelet_fields
+    return fields
+
+
+def _get_config_profile_list(
+    fields: typing.Dict[str, typing.Any],
+    key: str,
+    max_items: int,
+) -> list[typing.Any]:
+    if not _is_structured_config_profile(fields):
+        return []
+
+    value = fields.get(key, [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise exception.Invalid(
+            "config profile %(key)s must be a YAML list." % {"key": key}
+        )
+    if len(value) > max_items:
+        raise exception.Invalid(
+            "config profile %(key)s supports at most %(max)d entries."
+            % {"key": key, "max": max_items}
+        )
+    return value
+
+
+def _normalise_config_profile_file(
+    entry: typing.Any,
+) -> typing.Dict[str, typing.Any]:
+    if not isinstance(entry, dict):
+        raise exception.Invalid("config profile files entries must be YAML objects.")
+
+    unsupported = set(entry) - {
+        "append",
+        "content",
+        "contentFrom",
+        "encoding",
+        "owner",
+        "path",
+        "permissions",
+    }
+    if unsupported:
+        raise exception.Invalid(
+            "Unsupported config profile file field %(field)s."
+            % {"field": sorted(unsupported)[0]}
+        )
+
+    path = entry.get("path")
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise exception.Invalid(
+            "config profile files entries must set an absolute path."
+        )
+
+    has_content = "content" in entry
+    has_content_from = "contentFrom" in entry
+    if has_content == has_content_from:
+        raise exception.Invalid(
+            "config profile file %(path)s must set exactly one of content or contentFrom."
+            % {"path": path}
+        )
+
+    file_entry: typing.Dict[str, typing.Any] = {"path": path}
+
+    for key in ("append", "contentFrom", "owner"):
+        if key in entry:
+            file_entry[key] = entry[key]
+
+    permissions = entry.get("permissions", "0644")
+    if isinstance(permissions, int):
+        permissions = f"{permissions:04o}"
+    if not isinstance(permissions, str):
+        raise exception.Invalid(
+            "config profile file %(path)s permissions must be a string."
+            % {"path": path}
+        )
+    file_entry["permissions"] = permissions
+
+    if has_content:
+        content = entry["content"]
+        if not isinstance(content, str):
+            raise exception.Invalid(
+                "config profile file %(path)s content must be a string."
+                % {"path": path}
+            )
+        encoding = entry.get("encoding")
+        if encoding is None:
+            file_entry["content"] = stdlib_base64.b64encode(
+                content.encode("utf-8")
+            ).decode("ascii")
+            file_entry["encoding"] = "base64"
+        else:
+            if encoding not in {"base64", "gzip", "gzip+base64"}:
+                raise exception.Invalid(
+                    "Unsupported config profile file %(path)s encoding %(encoding)s."
+                    % {"path": path, "encoding": encoding}
+                )
+            file_entry["content"] = content
+            file_entry["encoding"] = encoding
+
+    return file_entry
+
+
+def _render_config_profile_yaml(value: typing.Dict[str, typing.Any]) -> str:
+    return yaml.safe_dump(
+        value,
+        default_flow_style=False,
+        sort_keys=False,
+    ).rstrip()
+
+
+def _get_config_profile_commands(
+    fields: typing.Dict[str, typing.Any],
+    key: str,
+    max_items: int,
+) -> list[str]:
+    commands = _get_config_profile_list(fields, key, max_items)
+    for command in commands:
+        if not isinstance(command, str) or not command:
+            raise exception.Invalid(
+                "config profile %(key)s entries must be non-empty strings."
+                % {"key": key}
+            )
+    return commands
+
+
+def validate_nodegroup_config_profile_set(
     profile_set: str,
     fields: typing.Any,
     profiles: typing.Dict[str, typing.Dict[str, typing.Any]],
 ) -> typing.Dict[str, typing.Dict[str, str]]:
     if not isinstance(fields, dict):
         raise exception.Invalid(
-            "Invalid kubelet nodegroup config profile set %(profile)s. "
+            "Invalid nodegroup config profile set %(profile)s. "
             "Expected a YAML object." % {"profile": profile_set}
         )
 
     unsupported = set(fields) - {"nodegroups"}
     if unsupported:
         raise exception.Invalid(
-            "Unsupported kubelet nodegroup config profile set field %(field)s "
+            "Unsupported nodegroup config profile set field %(field)s "
             "in %(profile)s. Supported fields: nodegroups."
             % {"field": sorted(unsupported)[0], "profile": profile_set}
         )
@@ -509,17 +710,17 @@ def validate_kubelet_nodegroup_config_profile_set(
     for nodegroup_name, nodegroup_config in nodegroups.items():
         if not isinstance(nodegroup_config, dict):
             raise exception.Invalid(
-                "Invalid nodegroup %(nodegroup)s in kubelet nodegroup config "
+                "Invalid nodegroup %(nodegroup)s in nodegroup config "
                 "profile set %(profile)s. Expected a YAML object."
                 % {"nodegroup": nodegroup_name, "profile": profile_set}
             )
 
-        unsupported = set(nodegroup_config) - {"kubeletConfigProfile"}
+        unsupported = set(nodegroup_config) - {"profile", "kubeletConfigProfile"}
         if unsupported:
             raise exception.Invalid(
                 "Unsupported field %(field)s for nodegroup %(nodegroup)s in "
-                "kubelet nodegroup config profile set %(profile)s. Supported "
-                "fields: kubeletConfigProfile."
+                "nodegroup config profile set %(profile)s. Supported "
+                "fields: profile, kubeletConfigProfile."
                 % {
                     "field": sorted(unsupported)[0],
                     "nodegroup": nodegroup_name,
@@ -527,32 +728,42 @@ def validate_kubelet_nodegroup_config_profile_set(
                 }
             )
 
-        kubelet_config_profile = nodegroup_config.get("kubeletConfigProfile")
-        if not kubelet_config_profile:
+        config_profile = nodegroup_config.get("profile") or nodegroup_config.get(
+            "kubeletConfigProfile"
+        )
+        if not config_profile:
             raise exception.Invalid(
                 "Nodegroup %(nodegroup)s in kubelet nodegroup config profile "
-                "set %(profile)s must set kubeletConfigProfile."
+                "set %(profile)s must set profile."
                 % {"nodegroup": nodegroup_name, "profile": profile_set}
             )
-        if kubelet_config_profile not in profiles:
+        if config_profile not in profiles:
             raise exception.Invalid(
-                "Invalid kubeletConfigProfile %(value)s for nodegroup "
+                "Invalid profile %(value)s for nodegroup "
                 "%(nodegroup)s in kubelet nodegroup config profile set "
                 "%(profile)s. Allowed values: %(allowed)s."
                 % {
-                    "value": kubelet_config_profile,
+                    "value": config_profile,
                     "nodegroup": nodegroup_name,
                     "profile": profile_set,
                     "allowed": ", ".join(sorted(profiles)),
                 }
             )
 
-        config[nodegroup_name] = {"kubeletConfigProfile": kubelet_config_profile}
+        config[nodegroup_name] = {"profile": config_profile}
 
     return config
 
 
-def get_kubelet_nodegroup_config_profile_set(
+def validate_kubelet_nodegroup_config_profile_set(
+    profile_set: str,
+    fields: typing.Any,
+    profiles: typing.Dict[str, typing.Dict[str, typing.Any]],
+) -> typing.Dict[str, typing.Dict[str, str]]:
+    return validate_nodegroup_config_profile_set(profile_set, fields, profiles)
+
+
+def get_nodegroup_config_profile_set(
     profile_set: str,
     api: pykube.HTTPClient | None,
     namespace: str = "magnum-system",
@@ -561,44 +772,53 @@ def get_kubelet_nodegroup_config_profile_set(
         return {}
     if api is None:
         raise exception.Invalid(
-            "kubelet_nodegroup_config_profile_set requires access to the "
+            "nodegroup_config_profile_set requires access to the "
             "management Kubernetes cluster."
         )
 
-    profile_data = get_kubelet_config_profile_data(api, namespace)
+    profile_data = get_config_profile_data(api, namespace)
     if profile_set not in profile_data:
         if not profile_data:
             raise exception.Invalid(
-                "Invalid value for kubelet_nodegroup_config_profile_set: "
+                "Invalid value for nodegroup_config_profile_set: "
                 "%(value)s. No profiles are registered in ConfigMap "
                 "%(configmap)s in namespace %(namespace)s."
                 % {
                     "value": profile_set,
-                    "configmap": KUBELET_CONFIG_PROFILES_CONFIGMAP,
+                    "configmap": CONFIG_PROFILES_CONFIGMAP,
                     "namespace": namespace,
                 }
             )
         raise exception.Invalid(
-            "Invalid value for kubelet_nodegroup_config_profile_set: %(value)s. "
+            "Invalid value for nodegroup_config_profile_set: %(value)s. "
             "Allowed values: %(allowed)s."
             % {"value": profile_set, "allowed": ", ".join(sorted(profile_data))}
         )
 
     profiles = get_kubelet_config_profiles(api, namespace)
-    return validate_kubelet_nodegroup_config_profile_set(
+    return validate_nodegroup_config_profile_set(
         profile_set,
         profile_data[profile_set],
         profiles,
     )
 
 
+def get_kubelet_nodegroup_config_profile_set(
+    profile_set: str,
+    api: pykube.HTTPClient | None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Dict[str, str]]:
+    return get_nodegroup_config_profile_set(profile_set, api, namespace)
+
+
 def kubelet_config_from_profile_defaults(
     profile_defaults: typing.Dict[str, typing.Any],
 ) -> typing.Dict[str, typing.Any]:
-    config_yaml = _render_kubelet_config_profile_yaml(profile_defaults)
+    kubelet_fields = _get_config_profile_kubelet_fields(profile_defaults)
+    config_yaml = _render_kubelet_config_profile_yaml(kubelet_fields)
 
     return {
-        "enabled": bool(profile_defaults),
+        "enabled": bool(kubelet_fields),
         "configYaml": config_yaml,
     }
 
@@ -626,13 +846,58 @@ def get_kubelet_config(
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Any]:
-    kubelet_config_profile = cluster.labels.get("kubelet_config_profile", "")
-    profile_defaults = get_kubelet_config_profile_defaults(
-        kubelet_config_profile,
+    return get_config_profile(cluster, api, namespace)["kubeletConfig"]
+
+
+def config_profile_from_profile_defaults(
+    profile_defaults: typing.Dict[str, typing.Any],
+) -> typing.Dict[str, typing.Any]:
+    kubelet_config = kubelet_config_from_profile_defaults(profile_defaults)
+    files_yaml = [
+        _render_config_profile_yaml(_normalise_config_profile_file(entry))
+        for entry in _get_config_profile_list(
+            profile_defaults,
+            "files",
+            CONFIG_PROFILE_MAX_FILES,
+        )
+    ]
+    pre_kubeadm_commands = _get_config_profile_commands(
+        profile_defaults,
+        "preKubeadmCommands",
+        CONFIG_PROFILE_MAX_PRE_COMMANDS,
+    )
+    post_kubeadm_commands = _get_config_profile_commands(
+        profile_defaults,
+        "postKubeadmCommands",
+        CONFIG_PROFILE_MAX_POST_COMMANDS,
+    )
+
+    return {
+        "enabled": bool(
+            kubelet_config["enabled"]
+            or files_yaml
+            or pre_kubeadm_commands
+            or post_kubeadm_commands
+        ),
+        "kubeletConfig": kubelet_config,
+        "filesYaml": files_yaml,
+        "preKubeadmCommands": pre_kubeadm_commands,
+        "postKubeadmCommands": post_kubeadm_commands,
+    }
+
+
+def get_config_profile(
+    cluster: magnum_objects.Cluster,
+    api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Any]:
+    profile = _first_label(cluster.labels, "config_profile", "kubelet_config_profile")
+    profile_defaults = get_config_profile_defaults(
+        profile,
         api,
         namespace,
     )
-    return kubelet_config_from_profile_defaults(profile_defaults)
+    return config_profile_from_profile_defaults(profile_defaults)
 
 
 def get_nodegroup_kubelet_config(
@@ -641,8 +906,24 @@ def get_nodegroup_kubelet_config(
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Any] | None:
-    profile_set = get_kubelet_nodegroup_config_profile_set(
-        cluster.labels.get("kubelet_nodegroup_config_profile_set", ""),
+    config_profile = get_nodegroup_config_profile(cluster, nodegroup, api, namespace)
+    if config_profile is None:
+        return None
+    return config_profile["kubeletConfig"]
+
+
+def get_nodegroup_config_profile(
+    cluster: magnum_objects.Cluster,
+    nodegroup: magnum_objects.NodeGroup,
+    api: pykube.HTTPClient | None = None,
+    namespace: str = "magnum-system",
+) -> typing.Dict[str, typing.Any] | None:
+    profile_set = get_nodegroup_config_profile_set(
+        _first_label(
+            cluster.labels,
+            "nodegroup_config_profile_set",
+            "kubelet_nodegroup_config_profile_set",
+        ),
         api,
         namespace,
     )
@@ -650,9 +931,9 @@ def get_nodegroup_kubelet_config(
     if nodegroup_config is None:
         return None
 
-    return kubelet_config_from_profile_defaults(
-        get_kubelet_config_profile_defaults(
-            nodegroup_config["kubeletConfigProfile"],
+    return config_profile_from_profile_defaults(
+        get_config_profile_defaults(
+            nodegroup_config["profile"],
             api,
             namespace,
         )

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -56,10 +56,10 @@ CONFIG_PROFILE_RESERVED_FIELDS = {
     "kind",
     "nodegroups",
 }
-CONFIG_PROFILE_SELECTOR_LABELS = {
+CONFIG_PROFILE_SELECTOR_LABELS = (
     "config_profile",
     "nodegroup_config_profile_set",
-}
+)
 CONFIG_PROFILES_CONFIGMAP = "mcapi-config-profiles"
 CONFIG_PROFILE_FIELDS = {
     "kubeletConfig",
@@ -214,6 +214,44 @@ def get_kube_tag(cluster: magnum_objects.Cluster) -> str:
     return cluster.labels.get("kube_tag", "v1.25.3")
 
 
+def reject_config_profile_label_overrides(
+    cluster: magnum_objects.Cluster,
+) -> None:
+    """Reject create-time profile selector overrides outside templates."""
+    template = getattr(cluster, "cluster_template", None)
+    template_labels = getattr(template, "labels", None) or {}
+    cluster_labels = cluster.labels or {}
+    for label in CONFIG_PROFILE_SELECTOR_LABELS:
+        if label not in cluster_labels:
+            continue
+        if cluster_labels[label] == template_labels.get(label):
+            continue
+        raise exception.Invalid(
+            "Invalid value for %(label)s: %(value)s. This label must be set "
+            "on the cluster template and cannot be overridden during cluster "
+            "creation."
+            % {
+                "label": label,
+                "value": cluster_labels[label],
+            }
+        )
+
+
+def sync_config_profile_labels_from_template(
+    cluster: magnum_objects.Cluster,
+    cluster_template: magnum_objects.ClusterTemplate,
+) -> None:
+    """Copy config profile selector labels from a target template."""
+    if cluster.labels is None:
+        cluster.labels = {}
+    template_labels = getattr(cluster_template, "labels", None) or {}
+    for label in CONFIG_PROFILE_SELECTOR_LABELS:
+        if label in template_labels:
+            cluster.labels[label] = template_labels[label]
+        else:
+            cluster.labels.pop(label, None)
+
+
 def get_auto_scaling_enabled(cluster: magnum_objects.Cluster) -> bool:
     return get_cluster_label_as_bool(cluster, "auto_scaling_enabled", False)
 
@@ -360,27 +398,7 @@ def validate_cluster_label_in_list(
         )
 
 
-def sync_kubelet_profile_labels_from_template(
-    cluster: magnum_objects.Cluster,
-    cluster_template: magnum_objects.ClusterTemplate,
-) -> None:
-    """Copy kubelet profile selector labels from a target template.
-
-    Magnum's cluster upgrade path is the durable user-facing API for changing
-    kubelet profiles after create.  Keep only selector labels in the cluster
-    row, and remove stale selector values when the target template omits them.
-    """
-    if cluster.labels is None:
-        cluster.labels = {}
-    template_labels = getattr(cluster_template, "labels", None) or {}
-    for label in CONFIG_PROFILE_SELECTOR_LABELS:
-        if label in template_labels:
-            cluster.labels[label] = template_labels[label]
-        else:
-            cluster.labels.pop(label, None)
-
-
-def validate_kubelet_config_labels(
+def validate_config_profile_labels(
     cluster: magnum_objects.Cluster,
     api: pykube.HTTPClient | None = None,
     namespace: str = "magnum-system",
@@ -397,7 +415,7 @@ def validate_kubelet_config_labels(
     )
 
 
-def validate_kubelet_config_profile(
+def validate_config_profile(
     profile: str,
     fields: typing.Any,
 ) -> typing.Dict[str, typing.Any]:
@@ -407,24 +425,21 @@ def validate_kubelet_config_profile(
             % {"profile": profile}
         )
 
-    if CONFIG_PROFILE_FIELDS & set(fields):
-        unsupported = set(fields) - CONFIG_PROFILE_FIELDS
-        if unsupported:
-            raise exception.Invalid(
-                "Unsupported config profile field %(field)s in %(profile)s."
-                % {"field": sorted(unsupported)[0], "profile": profile}
-            )
-        kubelet_fields = fields.get("kubeletConfig", {})
-        if kubelet_fields is None:
-            kubelet_fields = {}
-        if not isinstance(kubelet_fields, dict):
-            raise exception.Invalid(
-                "Invalid kubeletConfig in config profile %(profile)s. "
-                "Expected a YAML object." % {"profile": profile}
-            )
-        reserved_fields = set(kubelet_fields) & {"apiVersion", "kind"}
-    else:
-        reserved_fields = set(fields) & CONFIG_PROFILE_RESERVED_FIELDS
+    unsupported = set(fields) - CONFIG_PROFILE_FIELDS
+    if unsupported:
+        raise exception.Invalid(
+            "Unsupported config profile field %(field)s in %(profile)s."
+            % {"field": sorted(unsupported)[0], "profile": profile}
+        )
+    kubelet_fields = fields.get("kubeletConfig", {})
+    if kubelet_fields is None:
+        kubelet_fields = {}
+    if not isinstance(kubelet_fields, dict):
+        raise exception.Invalid(
+            "Invalid kubeletConfig in config profile %(profile)s. "
+            "Expected a YAML object." % {"profile": profile}
+        )
+    reserved_fields = set(kubelet_fields) & CONFIG_PROFILE_RESERVED_FIELDS
     if reserved_fields:
         raise exception.Invalid(
             "Unsupported config profile field %(field)s in %(profile)s. "
@@ -458,14 +473,7 @@ def get_config_profile_data(
     return profiles
 
 
-def get_kubelet_config_profile_data(
-    api: pykube.HTTPClient,
-    namespace: str = "magnum-system",
-) -> typing.Dict[str, typing.Any]:
-    return get_config_profile_data(api, namespace)
-
-
-def get_kubelet_config_profiles(
+def get_config_profiles(
     api: pykube.HTTPClient,
     namespace: str = "magnum-system",
 ) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
@@ -473,7 +481,7 @@ def get_kubelet_config_profiles(
     for name, fields in get_config_profile_data(api, namespace).items():
         if isinstance(fields, dict) and set(fields) == {"nodegroups"}:
             continue
-        profiles[name] = validate_kubelet_config_profile(name, fields)
+        profiles[name] = validate_config_profile(name, fields)
     return profiles
 
 
@@ -488,7 +496,7 @@ def get_config_profile_defaults(
         raise exception.Invalid(
             "config_profile requires access to the management Kubernetes " "cluster."
         )
-    profiles = get_kubelet_config_profiles(api, namespace)
+    profiles = get_config_profiles(api, namespace)
     if profile not in profiles:
         if not profiles:
             raise exception.Invalid(
@@ -511,29 +519,13 @@ def get_config_profile_defaults(
     return profiles[profile]
 
 
-def get_kubelet_config_profile_defaults(
-    profile: str,
-    api: pykube.HTTPClient | None,
-    namespace: str = "magnum-system",
-) -> typing.Dict[str, typing.Any]:
-    return get_config_profile_defaults(profile, api, namespace)
-
-
-def _is_structured_config_profile(fields: typing.Dict[str, typing.Any]) -> bool:
-    return bool(CONFIG_PROFILE_FIELDS & set(fields))
-
-
 def _get_config_profile_kubelet_fields(
     fields: typing.Dict[str, typing.Any],
 ) -> typing.Dict[str, typing.Any]:
-    if _is_structured_config_profile(fields):
-        kubelet_fields = fields.get("kubeletConfig") or {}
-        if not isinstance(kubelet_fields, dict):
-            raise exception.Invalid(
-                "config profile kubeletConfig must be a YAML object."
-            )
-        return kubelet_fields
-    return fields
+    kubelet_fields = fields.get("kubeletConfig") or {}
+    if not isinstance(kubelet_fields, dict):
+        raise exception.Invalid("config profile kubeletConfig must be a YAML object.")
+    return kubelet_fields
 
 
 def _get_config_profile_list(
@@ -541,9 +533,6 @@ def _get_config_profile_list(
     key: str,
     max_items: int,
 ) -> list[typing.Any]:
-    if not _is_structured_config_profile(fields):
-        return []
-
     value = fields.get(key, [])
     if value is None:
         return []
@@ -731,14 +720,6 @@ def validate_nodegroup_config_profile_set(
     return config
 
 
-def validate_kubelet_nodegroup_config_profile_set(
-    profile_set: str,
-    fields: typing.Any,
-    profiles: typing.Dict[str, typing.Dict[str, typing.Any]],
-) -> typing.Dict[str, typing.Dict[str, str]]:
-    return validate_nodegroup_config_profile_set(profile_set, fields, profiles)
-
-
 def get_nodegroup_config_profile_set(
     profile_set: str,
     api: pykube.HTTPClient | None,
@@ -771,7 +752,7 @@ def get_nodegroup_config_profile_set(
             % {"value": profile_set, "allowed": ", ".join(sorted(profile_data))}
         )
 
-    profiles = get_kubelet_config_profiles(api, namespace)
+    profiles = get_config_profiles(api, namespace)
     return validate_nodegroup_config_profile_set(
         profile_set,
         profile_data[profile_set],
@@ -779,19 +760,11 @@ def get_nodegroup_config_profile_set(
     )
 
 
-def get_kubelet_nodegroup_config_profile_set(
-    profile_set: str,
-    api: pykube.HTTPClient | None,
-    namespace: str = "magnum-system",
-) -> typing.Dict[str, typing.Dict[str, str]]:
-    return get_nodegroup_config_profile_set(profile_set, api, namespace)
-
-
 def kubelet_config_from_profile_defaults(
     profile_defaults: typing.Dict[str, typing.Any],
 ) -> typing.Dict[str, typing.Any]:
     kubelet_fields = _get_config_profile_kubelet_fields(profile_defaults)
-    config_yaml = _render_kubelet_config_profile_yaml(kubelet_fields)
+    config_yaml = _render_kubelet_config_yaml(kubelet_fields)
 
     return {
         "enabled": bool(kubelet_fields),
@@ -799,7 +772,7 @@ def kubelet_config_from_profile_defaults(
     }
 
 
-def _render_kubelet_config_profile_yaml(
+def _render_kubelet_config_yaml(
     profile_defaults: typing.Dict[str, typing.Any],
 ) -> str:
     if not profile_defaults:
@@ -1058,7 +1031,7 @@ def validate_cluster(
     if cluster.cluster_template.network_driver not in ["cilium", "calico"]:
         raise mcapi_exceptions.UnsupportedCNI
 
-    validate_kubelet_config_labels(cluster, api)
+    validate_config_profile_labels(cluster, api)
 
     # Check master count
     if (cluster.master_count % 2) == 0:

--- a/src/features/containerd_config.rs
+++ b/src/features/containerd_config.rs
@@ -27,6 +27,10 @@ use crate::{
 use cluster_feature_derive::ClusterFeatureValues;
 use kube::CustomResourceExt;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+pub(crate) const WORKER_PRE_KUBEADM_COMMANDS: [&str; 2] =
+    ["systemctl daemon-reload", "systemctl restart containerd"];
 
 #[derive(Serialize, Deserialize, ClusterFeatureValues)]
 #[allow(dead_code)]
@@ -118,14 +122,8 @@ impl ClusterFeaturePatches for Feature {
                             },
                             ClusterClassPatchesDefinitionsJsonPatches {
                                 op: "add".into(),
-                                path: "/spec/template/spec/preKubeadmCommands/-".into(),
-                                value: Some("systemctl daemon-reload".into()),
-                                ..Default::default()
-                            },
-                            ClusterClassPatchesDefinitionsJsonPatches {
-                                op: "add".into(),
-                                path: "/spec/template/spec/preKubeadmCommands/-".into(),
-                                value: Some("systemctl restart containerd".into()),
+                                path: "/spec/template/spec/preKubeadmCommands".into(),
+                                value: Some(json!(WORKER_PRE_KUBEADM_COMMANDS)),
                                 ..Default::default()
                             },
                         ],

--- a/src/features/containerd_config.rs
+++ b/src/features/containerd_config.rs
@@ -118,8 +118,14 @@ impl ClusterFeaturePatches for Feature {
                             },
                             ClusterClassPatchesDefinitionsJsonPatches {
                                 op: "add".into(),
-                                path: "/spec/template/spec/preKubeadmCommands".into(),
-                                value: Some(vec!["systemctl daemon-reload", "systemctl restart containerd"].into()),
+                                path: "/spec/template/spec/preKubeadmCommands/-".into(),
+                                value: Some("systemctl daemon-reload".into()),
+                                ..Default::default()
+                            },
+                            ClusterClassPatchesDefinitionsJsonPatches {
+                                op: "add".into(),
+                                path: "/spec/template/spec/preKubeadmCommands/-".into(),
+                                value: Some("systemctl restart containerd".into()),
                                 ..Default::default()
                             },
                         ],

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -125,27 +125,12 @@ fn profile_command_patch(
     kubeadm_path_segment: &str,
     patch_name_prefix: &str,
 ) -> ClusterClassPatches {
-    let template = if idx == 0 {
-        format!("- {{{{ index .configProfile.{} {} }}}}", variable_name, idx)
-    } else {
-        format!("{{{{ index .configProfile.{} {} }}}}", variable_name, idx)
-    };
-    let control_plane_path = if idx == 0 {
-        format!(
-            "/spec/template/spec/kubeadmConfigSpec/{}",
-            kubeadm_path_segment
-        )
-    } else {
-        format!(
-            "/spec/template/spec/kubeadmConfigSpec/{}/-",
-            kubeadm_path_segment
-        )
-    };
-    let worker_path = if idx == 0 {
-        format!("/spec/template/spec/{}", kubeadm_path_segment)
-    } else {
-        format!("/spec/template/spec/{}/-", kubeadm_path_segment)
-    };
+    let template = format!("{{{{ index .configProfile.{} {} }}}}", variable_name, idx);
+    let control_plane_path = format!(
+        "/spec/template/spec/kubeadmConfigSpec/{}/-",
+        kubeadm_path_segment
+    );
+    let worker_path = format!("/spec/template/spec/{}/-", kubeadm_path_segment);
     ClusterClassPatches {
         name: format!("{}{}", patch_name_prefix, idx),
         enabled_if: Some(format!(
@@ -423,14 +408,17 @@ mod tests {
         assert!(control_plane_files
             .iter()
             .any(|f| f.path == "/etc/gpu-init.sh"));
-        assert!(kubeadm_config_spec
+        let pre_commands = kubeadm_config_spec
             .pre_kubeadm_commands
-            .expect("pre commands should be set")
-            .contains(&"bash /etc/gpu-init.sh".to_string()));
-        assert!(kubeadm_config_spec
+            .expect("pre commands should be set");
+        assert!(pre_commands.contains(&"rm /var/lib/etcd/lost+found -rf".to_string()));
+        assert!(pre_commands.contains(&"bash /run/kubeadm/configure-kube-proxy.sh".to_string()));
+        assert!(pre_commands.contains(&"bash /etc/gpu-init.sh".to_string()));
+        let post_commands = kubeadm_config_spec
             .post_kubeadm_commands
-            .expect("post commands should be set")
-            .contains(&"echo done > /etc/gpu-init.done".to_string()));
+            .expect("post commands should be set");
+        assert!(post_commands.contains(&"echo PLACEHOLDER".to_string()));
+        assert!(post_commands.contains(&"echo done > /etc/gpu-init.done".to_string()));
         assert_eq!(
             kubeadm_config_spec
                 .init_configuration

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -29,37 +29,9 @@ use typed_builder::TypedBuilder;
 pub struct KubeletConfig {
     pub enabled: bool,
 
-    #[serde(
-        default,
-        skip_serializing_if = "str::is_empty",
-        rename = "cpuManagerPolicy"
-    )]
+    #[serde(default, skip_serializing_if = "str::is_empty", rename = "configYaml")]
     #[builder(default)]
-    pub cpu_manager_policy: String,
-
-    #[serde(
-        default,
-        skip_serializing_if = "str::is_empty",
-        rename = "topologyManagerPolicy"
-    )]
-    #[builder(default)]
-    pub topology_manager_policy: String,
-
-    #[serde(
-        default,
-        skip_serializing_if = "str::is_empty",
-        rename = "reservedSystemCPUs"
-    )]
-    #[builder(default)]
-    pub reserved_system_cpus: String,
-
-    #[serde(default, skip_serializing_if = "is_zero", rename = "maxPods")]
-    #[builder(default)]
-    pub max_pods: i32,
-}
-
-fn is_zero(value: &i32) -> bool {
-    *value == 0
+    pub config_yaml: String,
 }
 
 #[derive(Serialize, Deserialize, ClusterFeatureValues)]
@@ -80,11 +52,7 @@ impl ClusterFeaturePatches for Feature {
             content: |
               apiVersion: kubelet.config.k8s.io/v1beta1
               kind: KubeletConfiguration
-              {{ if .kubeletConfig.cpuManagerPolicy }}cpuManagerPolicy: {{ .kubeletConfig.cpuManagerPolicy }}
-              {{ end }}{{ if .kubeletConfig.topologyManagerPolicy }}topologyManagerPolicy: {{ .kubeletConfig.topologyManagerPolicy }}
-              {{ end }}{{ if .kubeletConfig.reservedSystemCPUs }}reservedSystemCPUs: {{ .kubeletConfig.reservedSystemCPUs }}
-              {{ end }}{{ if .kubeletConfig.maxPods }}maxPods: {{ .kubeletConfig.maxPods }}
-              {{ end }}
+              {{ .kubeletConfig.configYaml }}
         "#};
 
         vec![ClusterClassPatches {
@@ -209,10 +177,24 @@ mod tests {
         let mut values = default_values();
         values.kubelet_config = KubeletConfig::builder()
             .enabled(true)
-            .cpu_manager_policy("static".into())
-            .topology_manager_policy("single-numa-node".into())
-            .reserved_system_cpus("0-1".into())
-            .max_pods(250)
+            .config_yaml(
+                indoc! {r#"
+                    cpuManagerPolicy: static
+                      cpuManagerPolicyOptions:
+                        full-pcpus-only: 'true'
+                      memoryManagerPolicy: Static
+                      topologyManagerPolicy: single-numa-node
+                      topologyManagerScope: pod
+                      reservedMemory:
+                      - limits:
+                          memory: 1Gi
+                        numaNode: 0
+                      reservedSystemCPUs: 0-1
+                      maxPods: 250
+                "#}
+                .trim()
+                .into(),
+            )
             .build();
 
         let patches = feature.patches();
@@ -233,9 +215,17 @@ mod tests {
             .expect("kubelet config patch should be written");
         let control_plane_content = control_plane_file.content.expect("content should be set");
 
+        assert!(!control_plane_content.contains("builtin"));
         assert!(control_plane_content.contains("kind: KubeletConfiguration"));
         assert!(control_plane_content.contains("cpuManagerPolicy: static"));
+        assert!(control_plane_content.contains("cpuManagerPolicyOptions:"));
+        assert!(control_plane_content.contains("  full-pcpus-only: 'true'"));
+        assert!(control_plane_content.contains("memoryManagerPolicy: Static"));
         assert!(control_plane_content.contains("topologyManagerPolicy: single-numa-node"));
+        assert!(control_plane_content.contains("topologyManagerScope: pod"));
+        assert!(control_plane_content.contains("reservedMemory:"));
+        assert!(control_plane_content.contains("- limits:"));
+        assert!(control_plane_content.contains("numaNode: 0"));
         assert!(control_plane_content.contains("reservedSystemCPUs: 0-1"));
         assert!(control_plane_content.contains("maxPods: 250"));
         assert_eq!(

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -1,0 +1,284 @@
+use crate::{
+    cluster_api::{
+        clusterclasses::{
+            ClusterClassPatches, ClusterClassPatchesDefinitions,
+            ClusterClassPatchesDefinitionsJsonPatches,
+            ClusterClassPatchesDefinitionsJsonPatchesValueFrom,
+            ClusterClassPatchesDefinitionsSelector,
+            ClusterClassPatchesDefinitionsSelectorMatchResources,
+            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass,
+            ClusterClassVariables, ClusterClassVariablesSchema,
+        },
+        kubeadmconfigtemplates::KubeadmConfigTemplate,
+        kubeadmcontrolplanetemplates::KubeadmControlPlaneTemplate,
+    },
+    features::{
+        ClusterClassVariablesSchemaExt, ClusterFeatureEntry, ClusterFeaturePatches,
+        ClusterFeatureVariables,
+    },
+};
+use cluster_feature_derive::ClusterFeatureValues;
+use indoc::indoc;
+use kube::CustomResourceExt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use typed_builder::TypedBuilder;
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema, TypedBuilder)]
+pub struct KubeletConfig {
+    pub enabled: bool,
+
+    #[serde(
+        default,
+        skip_serializing_if = "str::is_empty",
+        rename = "cpuManagerPolicy"
+    )]
+    #[builder(default)]
+    pub cpu_manager_policy: String,
+
+    #[serde(
+        default,
+        skip_serializing_if = "str::is_empty",
+        rename = "topologyManagerPolicy"
+    )]
+    #[builder(default)]
+    pub topology_manager_policy: String,
+
+    #[serde(
+        default,
+        skip_serializing_if = "str::is_empty",
+        rename = "reservedSystemCPUs"
+    )]
+    #[builder(default)]
+    pub reserved_system_cpus: String,
+
+    #[serde(default, skip_serializing_if = "is_zero", rename = "maxPods")]
+    #[builder(default)]
+    pub max_pods: i32,
+}
+
+fn is_zero(value: &i32) -> bool {
+    *value == 0
+}
+
+#[derive(Serialize, Deserialize, ClusterFeatureValues)]
+#[allow(dead_code)]
+pub struct FeatureValues {
+    #[serde(rename = "kubeletConfig")]
+    pub kubelet_config: KubeletConfig,
+}
+
+pub struct Feature {}
+
+impl ClusterFeaturePatches for Feature {
+    fn patches(&self) -> Vec<ClusterClassPatches> {
+        let patch_file = indoc! {r#"
+            path: /etc/kubernetes/patches/kubeletconfiguration+merge.yaml
+            permissions: "0644"
+            owner: root:root
+            content: |
+              apiVersion: kubelet.config.k8s.io/v1beta1
+              kind: KubeletConfiguration
+              {{ if .kubeletConfig.cpuManagerPolicy }}cpuManagerPolicy: {{ .kubeletConfig.cpuManagerPolicy }}
+              {{ end }}{{ if .kubeletConfig.topologyManagerPolicy }}topologyManagerPolicy: {{ .kubeletConfig.topologyManagerPolicy }}
+              {{ end }}{{ if .kubeletConfig.reservedSystemCPUs }}reservedSystemCPUs: {{ .kubeletConfig.reservedSystemCPUs }}
+              {{ end }}{{ if .kubeletConfig.maxPods }}maxPods: {{ .kubeletConfig.maxPods }}
+              {{ end }}
+        "#};
+
+        vec![ClusterClassPatches {
+            name: "kubeletConfig".into(),
+            enabled_if: Some("{{ if .kubeletConfig.enabled }}true{{end}}".into()),
+            definitions: Some(vec![
+                ClusterClassPatchesDefinitions {
+                    selector: ClusterClassPatchesDefinitionsSelector {
+                        api_version: KubeadmControlPlaneTemplate::api_resource().api_version,
+                        kind: KubeadmControlPlaneTemplate::api_resource().kind,
+                        match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                            control_plane: Some(true),
+                            ..Default::default()
+                        },
+                    },
+                    json_patches: vec![
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/kubeadmConfigSpec/files/-".into(),
+                            value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                                template: Some(patch_file.into()),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/kubeadmConfigSpec/initConfiguration/patches"
+                                .into(),
+                            value: Some(json!({
+                                "directory": "/etc/kubernetes/patches"
+                            })),
+                            ..Default::default()
+                        },
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/kubeadmConfigSpec/joinConfiguration/patches"
+                                .into(),
+                            value: Some(json!({
+                                "directory": "/etc/kubernetes/patches"
+                            })),
+                            ..Default::default()
+                        },
+                    ],
+                },
+                ClusterClassPatchesDefinitions {
+                    selector: ClusterClassPatchesDefinitionsSelector {
+                        api_version: KubeadmConfigTemplate::api_resource().api_version,
+                        kind: KubeadmConfigTemplate::api_resource().kind,
+                        match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                            machine_deployment_class: Some(ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                names: Some(vec!["default-worker".to_string()])
+                            }),
+                            ..Default::default()
+                        },
+                    },
+                    json_patches: vec![
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/files/-".into(),
+                            value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                                template: Some(patch_file.into()),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        ClusterClassPatchesDefinitionsJsonPatches {
+                            op: "add".into(),
+                            path: "/spec/template/spec/joinConfiguration/patches".into(),
+                            value: Some(json!({
+                                "directory": "/etc/kubernetes/patches"
+                            })),
+                            ..Default::default()
+                        },
+                    ],
+                },
+            ]),
+            ..Default::default()
+        }]
+    }
+}
+
+inventory::submit! {
+    ClusterFeatureEntry{ feature: &Feature {} }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test::TestClusterResources;
+    use crate::resources::fixtures::default_values;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_disabled() {
+        let feature = Feature {};
+        let values = default_values();
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let control_plane_files = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .files
+            .expect("control plane files should be set");
+        assert_eq!(
+            control_plane_files
+                .iter()
+                .find(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_apply_patches() {
+        let feature = Feature {};
+        let mut values = default_values();
+        values.kubelet_config = KubeletConfig::builder()
+            .enabled(true)
+            .cpu_manager_policy("static".into())
+            .topology_manager_policy("single-numa-node".into())
+            .reserved_system_cpus("0-1".into())
+            .max_pods(250)
+            .build();
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let kubeadm_config_spec = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec;
+        let control_plane_file = kubeadm_config_spec
+            .files
+            .expect("control plane files should be set")
+            .into_iter()
+            .find(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml")
+            .expect("kubelet config patch should be written");
+        let control_plane_content = control_plane_file.content.expect("content should be set");
+
+        assert!(control_plane_content.contains("kind: KubeletConfiguration"));
+        assert!(control_plane_content.contains("cpuManagerPolicy: static"));
+        assert!(control_plane_content.contains("topologyManagerPolicy: single-numa-node"));
+        assert!(control_plane_content.contains("reservedSystemCPUs: 0-1"));
+        assert!(control_plane_content.contains("maxPods: 250"));
+        assert_eq!(
+            kubeadm_config_spec
+                .init_configuration
+                .expect("init configuration should be set")
+                .patches
+                .expect("init patches should be set")
+                .directory,
+            Some("/etc/kubernetes/patches".into())
+        );
+        assert_eq!(
+            kubeadm_config_spec
+                .join_configuration
+                .expect("join configuration should be set")
+                .patches
+                .expect("join patches should be set")
+                .directory,
+            Some("/etc/kubernetes/patches".into())
+        );
+
+        let worker_spec = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .expect("worker spec should be set");
+        let worker_file = worker_spec
+            .files
+            .expect("worker files should be set")
+            .into_iter()
+            .find(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml")
+            .expect("worker kubelet config patch should be written");
+
+        assert_eq!(worker_file.content, Some(control_plane_content));
+        assert_eq!(
+            worker_spec
+                .join_configuration
+                .expect("worker join configuration should be set")
+                .patches
+                .expect("worker join patches should be set")
+                .directory,
+            Some("/etc/kubernetes/patches".into())
+        );
+    }
+}

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -25,6 +25,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use typed_builder::TypedBuilder;
 
+pub const MAX_CONFIG_PROFILE_FILES: usize = 10;
+pub const MAX_CONFIG_PROFILE_PRE_COMMANDS: usize = 16;
+pub const MAX_CONFIG_PROFILE_POST_COMMANDS: usize = 16;
+
 #[derive(Clone, Serialize, Deserialize, JsonSchema, TypedBuilder)]
 pub struct KubeletConfig {
     pub enabled: bool,
@@ -34,14 +38,150 @@ pub struct KubeletConfig {
     pub config_yaml: String,
 }
 
+#[derive(Clone, Serialize, Deserialize, JsonSchema, TypedBuilder)]
+pub struct ConfigProfile {
+    pub enabled: bool,
+
+    #[serde(rename = "kubeletConfig")]
+    pub kubelet_config: KubeletConfig,
+
+    #[serde(rename = "filesYaml")]
+    pub files_yaml: Vec<String>,
+
+    #[serde(rename = "preKubeadmCommands")]
+    pub pre_kubeadm_commands: Vec<String>,
+
+    #[serde(rename = "postKubeadmCommands")]
+    pub post_kubeadm_commands: Vec<String>,
+}
+
 #[derive(Serialize, Deserialize, ClusterFeatureValues)]
 #[allow(dead_code)]
 pub struct FeatureValues {
-    #[serde(rename = "kubeletConfig")]
-    pub kubelet_config: KubeletConfig,
+    #[serde(rename = "configProfile")]
+    pub config_profile: ConfigProfile,
 }
 
 pub struct Feature {}
+
+fn profile_file_patch(idx: usize) -> ClusterClassPatches {
+    ClusterClassPatches {
+        name: format!("configProfileFile{}", idx),
+        enabled_if: Some(format!(
+            "{{{{ if gt (len .configProfile.filesYaml) {} }}}}true{{{{end}}}}",
+            idx
+        )),
+        definitions: Some(vec![
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmControlPlaneTemplate::api_resource().api_version,
+                    kind: KubeadmControlPlaneTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        control_plane: Some(true),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: "/spec/template/spec/kubeadmConfigSpec/files/-".into(),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(format!("{{{{ index .configProfile.filesYaml {} }}}}", idx)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmConfigTemplate::api_resource().api_version,
+                    kind: KubeadmConfigTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        machine_deployment_class: Some(
+                            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                names: Some(vec!["default-worker".to_string()]),
+                            },
+                        ),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: "/spec/template/spec/files/-".into(),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(format!("{{{{ index .configProfile.filesYaml {} }}}}", idx)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+        ]),
+        ..Default::default()
+    }
+}
+
+fn profile_command_patch(
+    idx: usize,
+    variable_name: &str,
+    kubeadm_path_segment: &str,
+    patch_name_prefix: &str,
+) -> ClusterClassPatches {
+    let template = format!("{{{{ index .configProfile.{} {} }}}}", variable_name, idx);
+    ClusterClassPatches {
+        name: format!("{}{}", patch_name_prefix, idx),
+        enabled_if: Some(format!(
+            "{{{{ if gt (len .configProfile.{}) {} }}}}true{{{{end}}}}",
+            variable_name, idx
+        )),
+        definitions: Some(vec![
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmControlPlaneTemplate::api_resource().api_version,
+                    kind: KubeadmControlPlaneTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        control_plane: Some(true),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: format!(
+                        "/spec/template/spec/kubeadmConfigSpec/{}/-",
+                        kubeadm_path_segment
+                    ),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(template.clone()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmConfigTemplate::api_resource().api_version,
+                    kind: KubeadmConfigTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        machine_deployment_class: Some(
+                            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                names: Some(vec!["default-worker".to_string()]),
+                            },
+                        ),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: format!("/spec/template/spec/{}/-", kubeadm_path_segment),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(template),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+        ]),
+        ..Default::default()
+    }
+}
 
 impl ClusterFeaturePatches for Feature {
     fn patches(&self) -> Vec<ClusterClassPatches> {
@@ -52,12 +192,12 @@ impl ClusterFeaturePatches for Feature {
             content: |
               apiVersion: kubelet.config.k8s.io/v1beta1
               kind: KubeletConfiguration
-              {{ .kubeletConfig.configYaml }}
+              {{ .configProfile.kubeletConfig.configYaml }}
         "#};
 
-        vec![ClusterClassPatches {
-            name: "kubeletConfig".into(),
-            enabled_if: Some("{{ if .kubeletConfig.enabled }}true{{end}}".into()),
+        let mut patches = vec![ClusterClassPatches {
+            name: "configProfileKubeletConfig".into(),
+            enabled_if: Some("{{ if .configProfile.kubeletConfig.enabled }}true{{end}}".into()),
             definitions: Some(vec![
                 ClusterClassPatchesDefinitions {
                     selector: ClusterClassPatchesDefinitionsSelector {
@@ -103,9 +243,11 @@ impl ClusterFeaturePatches for Feature {
                         api_version: KubeadmConfigTemplate::api_resource().api_version,
                         kind: KubeadmConfigTemplate::api_resource().kind,
                         match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
-                            machine_deployment_class: Some(ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
-                                names: Some(vec!["default-worker".to_string()])
-                            }),
+                            machine_deployment_class: Some(
+                                ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                    names: Some(vec!["default-worker".to_string()]),
+                                },
+                            ),
                             ..Default::default()
                         },
                     },
@@ -131,7 +273,29 @@ impl ClusterFeaturePatches for Feature {
                 },
             ]),
             ..Default::default()
-        }]
+        }];
+
+        for idx in 0..MAX_CONFIG_PROFILE_FILES {
+            patches.push(profile_file_patch(idx));
+        }
+        for idx in 0..MAX_CONFIG_PROFILE_PRE_COMMANDS {
+            patches.push(profile_command_patch(
+                idx,
+                "preKubeadmCommands",
+                "preKubeadmCommands",
+                "configProfilePreKubeadmCommand",
+            ));
+        }
+        for idx in 0..MAX_CONFIG_PROFILE_POST_COMMANDS {
+            patches.push(profile_command_patch(
+                idx,
+                "postKubeadmCommands",
+                "postKubeadmCommands",
+                "configProfilePostKubeadmCommand",
+            ));
+        }
+
+        patches
     }
 }
 
@@ -169,32 +333,48 @@ mod tests {
                 .find(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml"),
             None
         );
+
+        let worker_spec = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .expect("worker spec should be set");
+        assert_eq!(worker_spec.pre_kubeadm_commands, Some(vec![]));
+        assert_eq!(worker_spec.post_kubeadm_commands, Some(vec![]));
     }
 
     #[test]
     fn test_apply_patches() {
         let feature = Feature {};
         let mut values = default_values();
-        values.kubelet_config = KubeletConfig::builder()
+        values.config_profile = ConfigProfile::builder()
             .enabled(true)
-            .config_yaml(
-                indoc! {r#"
-                    cpuManagerPolicy: static
-                      cpuManagerPolicyOptions:
-                        full-pcpus-only: 'true'
-                      memoryManagerPolicy: Static
-                      topologyManagerPolicy: single-numa-node
-                      topologyManagerScope: pod
-                      reservedMemory:
-                      - limits:
-                          memory: 1Gi
-                        numaNode: 0
-                      reservedSystemCPUs: 0-1
-                      maxPods: 250
-                "#}
-                .trim()
-                .into(),
+            .kubelet_config(
+                KubeletConfig::builder()
+                    .enabled(true)
+                    .config_yaml(
+                        indoc! {r#"
+                            cpuManagerPolicy: static
+                              reservedSystemCPUs: 0-1
+                              maxPods: 250
+                        "#}
+                        .trim()
+                        .into(),
+                    )
+                    .build(),
             )
+            .files_yaml(vec![indoc! {r#"
+                path: /etc/gpu-init.sh
+                permissions: "0755"
+                owner: root:root
+                content: ZWNobyBncHU=
+                encoding: base64
+            "#}
+            .trim()
+            .into()])
+            .pre_kubeadm_commands(vec!["bash /etc/gpu-init.sh".into()])
+            .post_kubeadm_commands(vec!["echo done > /etc/gpu-init.done".into()])
             .build();
 
         let patches = feature.patches();
@@ -207,42 +387,39 @@ mod tests {
             .template
             .spec
             .kubeadm_config_spec;
-        let control_plane_file = kubeadm_config_spec
+        let control_plane_files = kubeadm_config_spec
             .files
-            .expect("control plane files should be set")
-            .into_iter()
+            .expect("control plane files should be set");
+        let kubelet_file = control_plane_files
+            .iter()
             .find(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml")
             .expect("kubelet config patch should be written");
-        let control_plane_content = control_plane_file.content.expect("content should be set");
+        let kubelet_content = kubelet_file
+            .content
+            .as_ref()
+            .expect("content should be set");
 
-        assert!(!control_plane_content.contains("builtin"));
-        assert!(control_plane_content.contains("kind: KubeletConfiguration"));
-        assert!(control_plane_content.contains("cpuManagerPolicy: static"));
-        assert!(control_plane_content.contains("cpuManagerPolicyOptions:"));
-        assert!(control_plane_content.contains("  full-pcpus-only: 'true'"));
-        assert!(control_plane_content.contains("memoryManagerPolicy: Static"));
-        assert!(control_plane_content.contains("topologyManagerPolicy: single-numa-node"));
-        assert!(control_plane_content.contains("topologyManagerScope: pod"));
-        assert!(control_plane_content.contains("reservedMemory:"));
-        assert!(control_plane_content.contains("- limits:"));
-        assert!(control_plane_content.contains("numaNode: 0"));
-        assert!(control_plane_content.contains("reservedSystemCPUs: 0-1"));
-        assert!(control_plane_content.contains("maxPods: 250"));
+        assert!(kubelet_content.contains("kind: KubeletConfiguration"));
+        assert!(kubelet_content.contains("cpuManagerPolicy: static"));
+        assert!(kubelet_content.contains("reservedSystemCPUs: 0-1"));
+        assert!(kubelet_content.contains("maxPods: 250"));
+        assert!(control_plane_files
+            .iter()
+            .any(|f| f.path == "/etc/gpu-init.sh"));
+        assert!(kubeadm_config_spec
+            .pre_kubeadm_commands
+            .expect("pre commands should be set")
+            .contains(&"bash /etc/gpu-init.sh".to_string()));
+        assert!(kubeadm_config_spec
+            .post_kubeadm_commands
+            .expect("post commands should be set")
+            .contains(&"echo done > /etc/gpu-init.done".to_string()));
         assert_eq!(
             kubeadm_config_spec
                 .init_configuration
                 .expect("init configuration should be set")
                 .patches
                 .expect("init patches should be set")
-                .directory,
-            Some("/etc/kubernetes/patches".into())
-        );
-        assert_eq!(
-            kubeadm_config_spec
-                .join_configuration
-                .expect("join configuration should be set")
-                .patches
-                .expect("join patches should be set")
                 .directory,
             Some("/etc/kubernetes/patches".into())
         );
@@ -253,22 +430,18 @@ mod tests {
             .template
             .spec
             .expect("worker spec should be set");
-        let worker_file = worker_spec
+        assert!(worker_spec
             .files
             .expect("worker files should be set")
-            .into_iter()
-            .find(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml")
-            .expect("worker kubelet config patch should be written");
-
-        assert_eq!(worker_file.content, Some(control_plane_content));
-        assert_eq!(
-            worker_spec
-                .join_configuration
-                .expect("worker join configuration should be set")
-                .patches
-                .expect("worker join patches should be set")
-                .directory,
-            Some("/etc/kubernetes/patches".into())
-        );
+            .iter()
+            .any(|f| f.path == "/etc/gpu-init.sh"));
+        assert!(worker_spec
+            .pre_kubeadm_commands
+            .expect("worker pre commands should be set")
+            .contains(&"bash /etc/gpu-init.sh".to_string()));
+        assert!(worker_spec
+            .post_kubeadm_commands
+            .expect("worker post commands should be set")
+            .contains(&"echo done > /etc/gpu-init.done".to_string()));
     }
 }

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -130,7 +130,17 @@ fn profile_command_patch(
         "/spec/template/spec/kubeadmConfigSpec/{}/-",
         kubeadm_path_segment
     );
-    let worker_path = format!("/spec/template/spec/{}/-", kubeadm_path_segment);
+    let (worker_path, worker_template) = if idx == 0 {
+        (
+            format!("/spec/template/spec/{}", kubeadm_path_segment),
+            format!("- {{{{ index .configProfile.{} 0 }}}}", variable_name),
+        )
+    } else {
+        (
+            format!("/spec/template/spec/{}/-", kubeadm_path_segment),
+            template.clone(),
+        )
+    };
     ClusterClassPatches {
         name: format!("{}{}", patch_name_prefix, idx),
         enabled_if: Some(format!(
@@ -174,7 +184,7 @@ fn profile_command_patch(
                     op: "add".into(),
                     path: worker_path,
                     value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
-                        template: Some(template),
+                        template: Some(worker_template),
                         ..Default::default()
                     }),
                     ..Default::default()
@@ -381,6 +391,17 @@ mod tests {
 
         let patches = feature.patches();
         let mut resources = TestClusterResources::new();
+        {
+            let worker_spec = resources
+                .kubeadm_config_template
+                .spec
+                .template
+                .spec
+                .as_mut()
+                .expect("worker spec should be set");
+            worker_spec.pre_kubeadm_commands = None;
+            worker_spec.post_kubeadm_commands = None;
+        }
         resources.apply_patches(&patches, &values);
 
         let kubeadm_config_spec = resources
@@ -440,13 +461,17 @@ mod tests {
             .expect("worker files should be set")
             .iter()
             .any(|f| f.path == "/etc/gpu-init.sh"));
-        assert!(worker_spec
-            .pre_kubeadm_commands
-            .expect("worker pre commands should be set")
-            .contains(&"bash /etc/gpu-init.sh".to_string()));
-        assert!(worker_spec
-            .post_kubeadm_commands
-            .expect("worker post commands should be set")
-            .contains(&"echo done > /etc/gpu-init.done".to_string()));
+        assert_eq!(
+            worker_spec
+                .pre_kubeadm_commands
+                .expect("worker pre commands should be set"),
+            vec!["bash /etc/gpu-init.sh".to_string()]
+        );
+        assert_eq!(
+            worker_spec
+                .post_kubeadm_commands
+                .expect("worker post commands should be set"),
+            vec!["echo done > /etc/gpu-init.done".to_string()]
+        );
     }
 }

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -125,7 +125,27 @@ fn profile_command_patch(
     kubeadm_path_segment: &str,
     patch_name_prefix: &str,
 ) -> ClusterClassPatches {
-    let template = format!("{{{{ index .configProfile.{} {} }}}}", variable_name, idx);
+    let template = if idx == 0 {
+        format!("- {{{{ index .configProfile.{} {} }}}}", variable_name, idx)
+    } else {
+        format!("{{{{ index .configProfile.{} {} }}}}", variable_name, idx)
+    };
+    let control_plane_path = if idx == 0 {
+        format!(
+            "/spec/template/spec/kubeadmConfigSpec/{}",
+            kubeadm_path_segment
+        )
+    } else {
+        format!(
+            "/spec/template/spec/kubeadmConfigSpec/{}/-",
+            kubeadm_path_segment
+        )
+    };
+    let worker_path = if idx == 0 {
+        format!("/spec/template/spec/{}", kubeadm_path_segment)
+    } else {
+        format!("/spec/template/spec/{}/-", kubeadm_path_segment)
+    };
     ClusterClassPatches {
         name: format!("{}{}", patch_name_prefix, idx),
         enabled_if: Some(format!(
@@ -144,10 +164,7 @@ fn profile_command_patch(
                 },
                 json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
                     op: "add".into(),
-                    path: format!(
-                        "/spec/template/spec/kubeadmConfigSpec/{}/-",
-                        kubeadm_path_segment
-                    ),
+                    path: control_plane_path,
                     value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
                         template: Some(template.clone()),
                         ..Default::default()
@@ -170,7 +187,7 @@ fn profile_command_patch(
                 },
                 json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
                     op: "add".into(),
-                    path: format!("/spec/template/spec/{}/-", kubeadm_path_segment),
+                    path: worker_path,
                     value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
                         template: Some(template),
                         ..Default::default()

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -29,8 +29,10 @@ pub const MAX_CONFIG_PROFILE_FILES: usize = 10;
 pub const MAX_CONFIG_PROFILE_PRE_COMMANDS: usize = 16;
 pub const MAX_CONFIG_PROFILE_POST_COMMANDS: usize = 16;
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema, TypedBuilder)]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, TypedBuilder)]
 pub struct KubeletConfig {
+    #[serde(default)]
+    #[builder(default)]
     pub enabled: bool,
 
     #[serde(default, skip_serializing_if = "str::is_empty", rename = "configYaml")]
@@ -38,20 +40,30 @@ pub struct KubeletConfig {
     pub config_yaml: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema, TypedBuilder)]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, TypedBuilder)]
 pub struct ConfigProfile {
+    #[serde(default)]
+    #[builder(default)]
     pub enabled: bool,
 
+    #[serde(default)]
     #[serde(rename = "kubeletConfig")]
+    #[builder(default)]
     pub kubelet_config: KubeletConfig,
 
+    #[serde(default)]
     #[serde(rename = "filesYaml")]
+    #[builder(default)]
     pub files_yaml: Vec<String>,
 
+    #[serde(default)]
     #[serde(rename = "preKubeadmCommands")]
+    #[builder(default)]
     pub pre_kubeadm_commands: Vec<String>,
 
+    #[serde(default)]
     #[serde(rename = "postKubeadmCommands")]
+    #[builder(default)]
     pub post_kubeadm_commands: Vec<String>,
 }
 
@@ -321,6 +333,7 @@ mod tests {
     use crate::features::test::TestClusterResources;
     use crate::resources::fixtures::default_values;
     use pretty_assertions::assert_eq;
+    use serde_json::json;
 
     #[test]
     fn test_disabled() {
@@ -472,6 +485,157 @@ mod tests {
                 .post_kubeadm_commands
                 .expect("worker post commands should be set"),
             vec!["echo done > /etc/gpu-init.done".to_string()]
+        );
+    }
+
+    fn resources_with_config_profile(profile: ConfigProfile) -> TestClusterResources {
+        let feature = Feature {};
+        let mut values = default_values();
+        values.config_profile = profile;
+
+        let mut resources = TestClusterResources::new();
+        {
+            let worker_spec = resources
+                .kubeadm_config_template
+                .spec
+                .template
+                .spec
+                .as_mut()
+                .expect("worker spec should be set");
+            worker_spec.pre_kubeadm_commands = None;
+            worker_spec.post_kubeadm_commands = None;
+        }
+        resources.apply_patches(&feature.patches(), &values);
+        resources
+    }
+
+    #[test]
+    fn test_config_profile_deserializes_solo_keys() {
+        let cases = vec![
+            json!({
+                "enabled": true,
+                "kubeletConfig": {
+                    "enabled": true,
+                    "configYaml": "maxPods: 250",
+                },
+            }),
+            json!({
+                "enabled": true,
+                "filesYaml": [
+                    "path: /etc/profile-file\ncontent: cHJvZmlsZQo=\nencoding: base64",
+                ],
+            }),
+            json!({
+                "enabled": true,
+                "preKubeadmCommands": ["echo pre"],
+            }),
+            json!({
+                "enabled": true,
+                "postKubeadmCommands": ["echo post"],
+            }),
+        ];
+
+        for case in cases {
+            let profile: ConfigProfile =
+                serde_json::from_value(case).expect("profile should deserialize");
+            assert!(profile.enabled);
+        }
+    }
+
+    #[test]
+    fn test_apply_patches_with_solo_kubelet_config() {
+        let resources = resources_with_config_profile(
+            ConfigProfile::builder()
+                .enabled(true)
+                .kubelet_config(
+                    KubeletConfig::builder()
+                        .enabled(true)
+                        .config_yaml("maxPods: 250".into())
+                        .build(),
+                )
+                .build(),
+        );
+
+        let control_plane_files = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .files
+            .expect("control plane files should be set");
+        assert!(control_plane_files
+            .iter()
+            .any(|f| f.path == "/etc/kubernetes/patches/kubeletconfiguration+merge.yaml"));
+    }
+
+    #[test]
+    fn test_apply_patches_with_solo_file() {
+        let resources = resources_with_config_profile(
+            ConfigProfile::builder()
+                .enabled(true)
+                .files_yaml(vec![
+                    "path: /etc/profile-file\ncontent: cHJvZmlsZQo=\nencoding: base64".into(),
+                ])
+                .build(),
+        );
+
+        let worker_spec = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .expect("worker spec should be set");
+        assert!(worker_spec
+            .files
+            .expect("worker files should be set")
+            .iter()
+            .any(|f| f.path == "/etc/profile-file"));
+    }
+
+    #[test]
+    fn test_apply_patches_with_solo_pre_kubeadm_command() {
+        let resources = resources_with_config_profile(
+            ConfigProfile::builder()
+                .enabled(true)
+                .pre_kubeadm_commands(vec!["echo pre".into()])
+                .build(),
+        );
+
+        let worker_spec = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .expect("worker spec should be set");
+        assert_eq!(
+            worker_spec
+                .pre_kubeadm_commands
+                .expect("worker pre commands should be set"),
+            vec!["echo pre".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_with_solo_post_kubeadm_command() {
+        let resources = resources_with_config_profile(
+            ConfigProfile::builder()
+                .enabled(true)
+                .post_kubeadm_commands(vec!["echo post".into()])
+                .build(),
+        );
+
+        let worker_spec = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .expect("worker spec should be set");
+        assert_eq!(
+            worker_spec
+                .post_kubeadm_commands
+                .expect("worker post commands should be set"),
+            vec!["echo post".to_string()]
         );
     }
 }

--- a/src/features/kubelet_config.rs
+++ b/src/features/kubelet_config.rs
@@ -13,8 +13,8 @@ use crate::{
         kubeadmcontrolplanetemplates::KubeadmControlPlaneTemplate,
     },
     features::{
-        ClusterClassVariablesSchemaExt, ClusterFeatureEntry, ClusterFeaturePatches,
-        ClusterFeatureVariables,
+        containerd_config::WORKER_PRE_KUBEADM_COMMANDS, ClusterClassVariablesSchemaExt,
+        ClusterFeatureEntry, ClusterFeaturePatches, ClusterFeatureVariables,
     },
 };
 use cluster_feature_derive::ClusterFeatureValues;
@@ -143,9 +143,24 @@ fn profile_command_patch(
         kubeadm_path_segment
     );
     let (worker_path, worker_template) = if idx == 0 {
+        let mut commands = Vec::new();
+
+        if kubeadm_path_segment == "preKubeadmCommands" {
+            commands.extend(
+                WORKER_PRE_KUBEADM_COMMANDS
+                    .iter()
+                    .map(|command| format!("- {}", command)),
+            );
+        }
+
+        commands.push(format!(
+            "- {{{{ index .configProfile.{} 0 }}}}",
+            variable_name
+        ));
+
         (
             format!("/spec/template/spec/{}", kubeadm_path_segment),
-            format!("- {{{{ index .configProfile.{} 0 }}}}", variable_name),
+            commands.join("\n"),
         )
     } else {
         (
@@ -478,7 +493,11 @@ mod tests {
             worker_spec
                 .pre_kubeadm_commands
                 .expect("worker pre commands should be set"),
-            vec!["bash /etc/gpu-init.sh".to_string()]
+            vec![
+                "systemctl daemon-reload".to_string(),
+                "systemctl restart containerd".to_string(),
+                "bash /etc/gpu-init.sh".to_string()
+            ]
         );
         assert_eq!(
             worker_spec
@@ -612,7 +631,56 @@ mod tests {
             worker_spec
                 .pre_kubeadm_commands
                 .expect("worker pre commands should be set"),
-            vec!["echo pre".to_string()]
+            vec![
+                "systemctl daemon-reload".to_string(),
+                "systemctl restart containerd".to_string(),
+                "echo pre".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_worker_pre_kubeadm_commands_preserve_containerd_commands() {
+        let containerd_feature = crate::features::containerd_config::Feature {};
+        let feature = Feature {};
+        let mut values = default_values();
+        values.config_profile = ConfigProfile::builder()
+            .enabled(true)
+            .pre_kubeadm_commands(vec!["echo pre".into(), "echo second".into()])
+            .build();
+
+        let mut patches = containerd_feature.patches();
+        patches.extend(feature.patches());
+
+        let mut resources = TestClusterResources::new();
+        {
+            let worker_spec = resources
+                .kubeadm_config_template
+                .spec
+                .template
+                .spec
+                .as_mut()
+                .expect("worker spec should be set");
+            worker_spec.pre_kubeadm_commands = None;
+        }
+        resources.apply_patches(&patches, &values);
+
+        let worker_spec = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .expect("worker spec should be set");
+        assert_eq!(
+            worker_spec
+                .pre_kubeadm_commands
+                .expect("worker pre commands should be set"),
+            vec![
+                "systemctl daemon-reload".to_string(),
+                "systemctl restart containerd".to_string(),
+                "echo pre".to_string(),
+                "echo second".to_string()
+            ]
         );
     }
 

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -45,7 +45,10 @@ use crate::cluster_api::{
 };
 use base64::prelude::*;
 use maplit::btreemap;
-use schemars::{generate::SchemaGenerator, JsonSchema, Schema};
+use schemars::{
+    generate::{SchemaGenerator, SchemaSettings},
+    JsonSchema, Schema,
+};
 use std::sync::LazyLock;
 
 pub mod admission_plugins;
@@ -134,8 +137,7 @@ pub fn assert_optional_string_schema_for_field<T: JsonSchema>(field: &str) {
     // JSONSchemaProps.Type is a plain string and rejects JSON arrays.
     let field_type = &v["properties"][field]["type"];
     assert_eq!(
-        field_type,
-        "string",
+        field_type, "string",
         "field `{field}` type must be a plain string (CAPI rejects arrays)"
     );
 }
@@ -168,7 +170,9 @@ pub trait ClusterClassVariablesSchemaExt {
 
 impl ClusterClassVariablesSchemaExt for ClusterClassVariablesSchema {
     fn from_object<T: JsonSchema>() -> Self {
-        let gen = SchemaGenerator::default();
+        let mut settings = SchemaSettings::default();
+        settings.inline_subschemas = true;
+        let gen = SchemaGenerator::new(settings);
         let schema = gen.into_root_schema_for::<T>();
         Self::from_root_schema(schema)
     }
@@ -330,6 +334,8 @@ pub static KUBEADM_CONFIG_TEMPLATE: LazyLock<KubeadmConfigTemplate> =
                         encoding: Some(KubeadmConfigTemplateTemplateSpecFilesEncoding::Base64),
                         ..Default::default()
                     }]),
+                    pre_kubeadm_commands: Some(vec![]),
+                    post_kubeadm_commands: Some(vec![]),
                     join_configuration: Some(KubeadmConfigTemplateTemplateSpecJoinConfiguration {
                         node_registration: Some(
                             KubeadmConfigTemplateTemplateSpecJoinConfigurationNodeRegistration {

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -63,6 +63,7 @@ pub mod flavors;
 pub mod image_repository;
 pub mod images;
 pub mod keystone_auth;
+pub mod kubelet_config;
 pub mod networks;
 pub mod openid_connect;
 pub mod operating_system;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -265,7 +265,15 @@ pub mod fixtures {
             .api_server_tls_cipher_suites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305".into())
             .api_server_sans("".into())
             .kubelet_tls_cipher_suites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305".into())
-            .kubelet_config(kubelet_config::KubeletConfig::builder().enabled(false).build())
+            .config_profile(
+                kubelet_config::ConfigProfile::builder()
+                    .enabled(false)
+                    .kubelet_config(kubelet_config::KubeletConfig::builder().enabled(false).build())
+                    .files_yaml(Vec::<String>::new())
+                    .pre_kubeadm_commands(Vec::<String>::new())
+                    .post_kubeadm_commands(Vec::<String>::new())
+                    .build(),
+            )
             .hardware_disk_bus("".into())
             .enable_docker_volume(false)
             .docker_volume_size(0)
@@ -421,8 +429,8 @@ mod tests {
                 "kubeletTLSCipherSuites" => {
                     assert_eq!(var.value, json!(default_values().kubelet_tls_cipher_suites));
                 }
-                "kubeletConfig" => {
-                    assert_eq!(var.value, json!(default_values().kubelet_config));
+                "configProfile" => {
+                    assert_eq!(var.value, json!(default_values().config_profile));
                 }
                 "apiServerSANs" => {
                     assert_eq!(var.value, json!(default_values().api_server_sans));

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -177,7 +177,8 @@ impl From<Values> for Vec<ClusterTopologyVariables> {
 pub mod fixtures {
     use crate::{
         features::{
-            api_server_load_balancer, audit_log, boot_volume, openid_connect, operating_system,
+            api_server_load_balancer, audit_log, boot_volume, kubelet_config, openid_connect,
+            operating_system,
         },
         resources::Values,
     };
@@ -264,6 +265,7 @@ pub mod fixtures {
             .api_server_tls_cipher_suites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305".into())
             .api_server_sans("".into())
             .kubelet_tls_cipher_suites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305".into())
+            .kubelet_config(kubelet_config::KubeletConfig::builder().enabled(false).build())
             .hardware_disk_bus("".into())
             .enable_docker_volume(false)
             .docker_volume_size(0)
@@ -310,7 +312,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 39);
+        assert_eq!(variables.len(), 40);
 
         for var in &variables {
             match var.name.as_str() {
@@ -327,7 +329,10 @@ mod tests {
                     assert_eq!(var.value, json!(default_values().boot_volume));
                 }
                 "bootVolumeAvailabilityZone" => {
-                    assert_eq!(var.value, json!(default_values().boot_volume_availability_zone));
+                    assert_eq!(
+                        var.value,
+                        json!(default_values().boot_volume_availability_zone)
+                    );
                 }
                 "clusterIdentityRefName" => {
                     assert_eq!(var.value, json!(default_values().cluster_identity_ref_name));
@@ -415,6 +420,9 @@ mod tests {
                 }
                 "kubeletTLSCipherSuites" => {
                     assert_eq!(var.value, json!(default_values().kubelet_tls_cipher_suites));
+                }
+                "kubeletConfig" => {
+                    assert_eq!(var.value, json!(default_values().kubelet_config));
                 }
                 "apiServerSANs" => {
                     assert_eq!(var.value, json!(default_values().api_server_sans));


### PR DESCRIPTION
## Usage

Operators define reusable profiles in the management Kubernetes cluster using `ConfigMap/mcapi-config-profiles`, normally in the `magnum-system` namespace. Users select those profiles through cluster template labels.

Supported profile fields:

- `kubeletConfig`
- `files`
- `preKubeadmCommands`
- `postKubeadmCommands`

Users select predefined profiles with cluster template labels:

| Label | Example | Effect |
|---|---|---|
| `config_profile` | `profile-standard` | Selects the cluster-wide default profile rendered as the `configProfile` ClusterClass topology variable. |
| `nodegroup_config_profile_set` | `profile-bm-gpu-layout` | Selects an operator-defined nodegroup layout that renders MachineDeployment-level `configProfile` overrides. |

Passing `config_profile` or `nodegroup_config_profile_set` directly through `openstack coe cluster create --labels` is rejected unless the value exactly matches the selected cluster template.

## Updates

This PR now also includes the Issue 42 live-replay fix:

- `fix(pr1013): keep worker pre-kubeadm list initialized`

That fix keeps worker `preKubeadmCommands` initialized for the containerd reload/restart commands and preserves them when profile pre-kubeadm commands initialize the same list. It was moved here from PR B because the failure belongs to the config-profile/pre-kubeadm composition path owned by PR #1013.

## Validation

```bash
cargo test containerd_config
cargo test kubelet_config
cargo test test_convert_values_to_cluster_topology_variables
uv run pytest magnum_cluster_api/tests/unit/test_utils.py -q -k 'ConfigProfile or config_profile or kubelet_config'
uv run ruff check magnum_cluster_api/tests/unit/test_utils.py
```

Latest scoped validation after moving Issue 42 into this PR:

- `cargo test containerd_config` -> 2 passed
- `cargo test kubelet_config` -> 8 passed
- `cargo test test_convert_values_to_cluster_topology_variables` -> 1 passed
- `uv run pytest ... -k 'ConfigProfile or config_profile or kubelet_config'` -> 35 passed, 16 deselected, 8 warnings
- `uv run ruff check magnum_cluster_api/tests/unit/test_utils.py` -> passed

Signed-off-by: Rico Lin <rico@vexxhost.com>