### PR TITLE
feat: support server_type=bm in cluster_api driver (auto-default boot_volume_size=0)

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -17,7 +17,11 @@ specify the volume size and type using the following labels:
 
 :   The size in gigabytes of the boot volume.  If you set this value, it will
     enable boot from volume.
-    **Default value**: Unset
+    **Default value**: Unset for `server_type=vm` clusters; automatically
+    `0` for `server_type=bm` clusters (baremetal nodes boot from local disk
+    via Ironic and cannot use a Cinder root volume). Operators can still
+    override explicitly on `server_type=bm` by setting this label on the
+    cluster_template, cluster, or node_group.
 
 `boot_volume_type`
 

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -732,6 +732,7 @@ class UbuntuDriver(BaseDriver):
     def provides(self):
         return [
             {"server_type": "vm", "os": "ubuntu", "coe": "kubernetes"},
+            {"server_type": "bm", "os": "ubuntu", "coe": "kubernetes"},
         ]
 
 
@@ -740,6 +741,7 @@ class UbuntuFocalDriver(UbuntuDriver):
     def provides(self):
         return [
             {"server_type": "vm", "os": "ubuntu-focal", "coe": "kubernetes"},
+            {"server_type": "bm", "os": "ubuntu-focal", "coe": "kubernetes"},
         ]
 
 
@@ -756,6 +758,7 @@ class FlatcarDriver(BaseDriver):
     def provides(self):
         return [
             {"server_type": "vm", "os": "flatcar", "coe": "kubernetes"},
+            {"server_type": "bm", "os": "flatcar", "coe": "kubernetes"},
         ]
 
 
@@ -764,4 +767,5 @@ class RockyLinuxDriver(BaseDriver):
     def provides(self):
         return [
             {"server_type": "vm", "os": "rockylinux", "coe": "kubernetes"},
+            {"server_type": "bm", "os": "rockylinux", "coe": "kubernetes"},
         ]

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -741,7 +741,9 @@ def mutate_machine_deployment(
         boot_volume_size = utils.get_node_group_label_as_int(
             node_group,
             "boot_volume_size",
-            CONF.cinder.default_boot_volume_size,
+            utils.get_default_boot_volume_size(
+                cluster, CONF.cinder.default_boot_volume_size
+            ),
         )
         if boot_volume_size == 0:
             boot_volume_size = flavor.disk
@@ -802,7 +804,10 @@ def mutate_machine_deployment(
                             "size": utils.get_node_group_label_as_int(
                                 node_group,
                                 "boot_volume_size",
-                                CONF.cinder.default_boot_volume_size,
+                                utils.get_default_boot_volume_size(
+                                    cluster,
+                                    CONF.cinder.default_boot_volume_size,
+                                ),
                             ),
                             "type": node_group.labels.get(
                                 "boot_volume_type",
@@ -1106,7 +1111,10 @@ class Cluster(ClusterBase):
                                 "size": utils.get_cluster_label_as_int(
                                     self.cluster,
                                     "boot_volume_size",
-                                    CONF.cinder.default_boot_volume_size,
+                                    utils.get_default_boot_volume_size(
+                                        self.cluster,
+                                        CONF.cinder.default_boot_volume_size,
+                                    ),
                                 ),
                                 "type": self.cluster.labels.get(
                                     "boot_volume_type",

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -749,21 +749,30 @@ def mutate_machine_deployment(
             boot_volume_size = flavor.disk
 
         machine_deployment["replicas"] = None
-        machine_deployment["metadata"]["annotations"] = {
+        annotations = {
             AUTOSCALE_ANNOTATION_MIN: str(node_group.min_node_count),
             AUTOSCALE_ANNOTATION_MAX: str(
                 utils.get_node_group_max_node_count(node_group)
             ),
             "capacity.cluster-autoscaler.kubernetes.io/memory": f"{math.ceil(flavor.ram / 1024)}G",
             "capacity.cluster-autoscaler.kubernetes.io/cpu": str(flavor.vcpus),
-            "capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk": str(
-                boot_volume_size
-            ),
             "capacity.cluster-autoscaler.kubernetes.io/labels": (
                 f"node-role.kubernetes.io/{node_group.role}=,"
                 f"node.cluster.x-k8s.io/nodegroup={node_group.name}"
             ),
         }
+        # Only emit the ephemeral-disk capacity hint when we can resolve a
+        # non-zero value. For server_type=bm the flavor.disk is typically
+        # 0 (root_gb lives on the Ironic node, not the Nova flavor) and
+        # the Cinder root volume default is also 0; advertising "0" here
+        # would mislead the autoscaler into rejecting pods that request
+        # ephemeral-storage. Omitting the annotation lets the autoscaler
+        # fall back to scheduling on cpu/memory only.
+        if boot_volume_size > 0:
+            annotations["capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk"] = (
+                str(boot_volume_size)
+            )
+        machine_deployment["metadata"]["annotations"] = annotations
     else:
         machine_deployment["replicas"] = node_group.node_count
         machine_deployment["metadata"]["annotations"] = {}

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1198,6 +1198,13 @@ class Cluster(ClusterBase):
                             ),
                         },
                         {
+                            "name": "disableManagedSecurityGroups",
+                            "value": getattr(
+                                self.cluster.cluster_template, "server_type", "vm"
+                            )
+                            == "bm",
+                        },
+                        {
                             "name": "dnsNameservers",
                             "value": self.cluster.cluster_template.dns_nameserver.split(
                                 ","

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -96,6 +96,14 @@ class TestExistingMutateMachineDeployment:
     @pytest.fixture(autouse=True)
     def setup(self, auto_scaling_enabled, auto_healing_enabled, context, mocker):
         self.cluster = utils.get_test_cluster(context, labels={})
+        # mutate_machine_deployment now consults cluster.cluster_template.server_type
+        # (via utils.get_default_boot_volume_size) which lazy-loads from the DB
+        # in this test context. Stub the helper so existing assertions are
+        # unaffected.
+        mocker.patch(
+            "magnum_cluster_api.utils.get_default_boot_volume_size",
+            side_effect=lambda cluster, default: default,
+        )
         if auto_scaling_enabled is not None:
             self.cluster.labels["auto_scaling_enabled"] = str(auto_scaling_enabled)
 
@@ -161,3 +169,68 @@ class TestExistingMutateMachineDeployment:
         else:
             assert md["replicas"] == self.node_group.node_count
             assert md["metadata"]["annotations"] == {}
+
+
+def test_mutate_machine_deployment_bm_omits_ephemeral_disk_annotation(context, mocker):
+    """For server_type=bm flavors with disk=0 the autoscaler annotation
+    should be omitted rather than emitted as "0", which would make the
+    autoscaler reject pods that request ephemeral-storage."""
+    cluster = utils.get_test_cluster(context, labels={})
+    mocker.patch(
+        "magnum_cluster_api.utils.get_default_boot_volume_size",
+        return_value=0,
+    )
+    cluster.labels["auto_scaling_enabled"] = "true"
+    node_group = utils.get_test_nodegroup(context, labels={})
+    node_group.min_node_count = 1
+    node_group.max_node_count = 3
+
+    mocker.patch("magnum_cluster_api.utils.lookup_image", return_value={"id": "foo"})
+    mocker.patch(
+        "magnum_cluster_api.utils.lookup_flavor",
+        return_value=flavors.Flavor(
+            None,
+            {"name": "bm-flavor", "disk": 0, "ram": 4096, "vcpus": 4},
+        ),
+    )
+
+    md = resources.mutate_machine_deployment(
+        context, cluster, node_group, {"name": node_group.name}
+    )
+
+    annotations = md["metadata"]["annotations"]
+    assert "capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk" not in annotations
+    # The other autoscaler hints must still be set so the autoscaler can
+    # schedule on cpu/memory.
+    assert annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] == "4"
+    assert annotations["capacity.cluster-autoscaler.kubernetes.io/memory"] == "4G"
+
+
+def test_mutate_machine_deployment_vm_keeps_ephemeral_disk_annotation(context, mocker):
+    cluster = utils.get_test_cluster(context, labels={})
+    mocker.patch(
+        "magnum_cluster_api.utils.get_default_boot_volume_size",
+        side_effect=lambda cluster, default: default,
+    )
+    cluster.labels["auto_scaling_enabled"] = "true"
+    node_group = utils.get_test_nodegroup(context, labels={})
+    node_group.min_node_count = 1
+    node_group.max_node_count = 3
+
+    mocker.patch("magnum_cluster_api.utils.lookup_image", return_value={"id": "foo"})
+    mocker.patch(
+        "magnum_cluster_api.utils.lookup_flavor",
+        return_value=flavors.Flavor(
+            None,
+            {"name": "vm-flavor", "disk": 20, "ram": 1024, "vcpus": 1},
+        ),
+    )
+
+    md = resources.mutate_machine_deployment(
+        context, cluster, node_group, {"name": node_group.name}
+    )
+
+    annotations = md["metadata"]["annotations"]
+    assert (
+        annotations["capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk"] == "20"
+    )

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from types import SimpleNamespace
+
 import pytest
 from magnum.objects import fields
 from magnum.tests.unit.objects import utils
@@ -80,6 +82,135 @@ def test_generate_machine_deployments_for_cluster_with_deleting_node_group(
     )
 
     assert len(mds) == 2
+
+
+def test_cluster_variables_disable_managed_security_groups_for_bm(context, mocker):
+    cluster = mocker.Mock()
+    cluster.cluster_template = mocker.Mock(
+        network_driver="calico",
+        dns_nameserver="1.1.1.1",
+        external_network_id="public",
+        server_type="vm",
+    )
+    cluster.default_ng_master = mocker.Mock(image_id="image")
+    cluster.docker_volume_size = None
+    cluster.fixed_network = None
+    cluster.fixed_subnet = None
+    cluster.flavor_id = "worker"
+    cluster.keypair = None
+    cluster.labels = {}
+    cluster.master_count = 1
+    cluster.master_flavor_id = "control-plane"
+    cluster.master_lb_enabled = True
+    cluster.nodegroups = []
+    cluster.stack_id = "kube-test"
+
+    default_volume_type = SimpleNamespace(name="fast")
+    openstack_client = mocker.Mock()
+    openstack_client.cinder.return_value.volume_types.default.return_value = (
+        default_volume_type
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.clients.get_openstack_api",
+        return_value=openstack_client,
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.cinder.get_default_boot_volume_type",
+        return_value=default_volume_type.name,
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.generate_machine_deployments_for_cluster",
+        return_value=[],
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.neutron.get_external_network_id",
+        return_value="external-network",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.neutron.get_fixed_subnet_id",
+        return_value=None,
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.ensure_controlplane_server_group",
+        return_value="server-group",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.generate_api_cert_san_list",
+        return_value="",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.generate_apt_proxy_config",
+        return_value="",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.generate_containerd_config",
+        return_value="",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.generate_systemd_proxy_config",
+        return_value="",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.get_cluster_container_infra_prefix",
+        return_value="",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.get_fixed_network_id",
+        return_value=None,
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.get_kube_tag",
+        return_value="v1.34.3",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.get_operating_system",
+        return_value="ubuntu",
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.is_controlplane_different_failure_domain",
+        return_value=False,
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.lookup_flavor",
+        side_effect=lambda _osc, flavor_id: SimpleNamespace(name=flavor_id),
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.utils.lookup_image",
+        return_value={"id": "image"},
+    )
+
+    rust_driver = mocker.Mock()
+    rust_driver.resolve_immutable_fields.return_value = {
+        "apiServerLoadBalancer": {"enabled": True}
+    }
+
+    resource = resources.Cluster(
+        context,
+        mocker.Mock(),
+        mocker.Mock(),
+        cluster,
+        rust_driver,
+    ).get_object()
+
+    variables = {
+        variable["name"]: variable["value"]
+        for variable in resource["spec"]["topology"]["variables"]
+    }
+    assert variables["disableManagedSecurityGroups"] is False
+
+    cluster.cluster_template.server_type = "bm"
+    resource = resources.Cluster(
+        context,
+        mocker.Mock(),
+        mocker.Mock(),
+        cluster,
+        rust_driver,
+    ).get_object()
+    variables = {
+        variable["name"]: variable["value"]
+        for variable in resource["spec"]["topology"]["variables"]
+    }
+    assert variables["disableManagedSecurityGroups"] is True
 
 
 @pytest.mark.parametrize(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -590,3 +590,88 @@ class TestGetDefaultBootVolumeSize(base.BaseTestCase):
         cluster = mock.Mock()
         cluster.cluster_template = object()  # no server_type attr
         self.assertEqual(20, utils.get_default_boot_volume_size(cluster, 20))
+
+
+class TestValidateBaremetalFlavors(base.BaseTestCase):
+    def _flavor(self, extra_specs):
+        flavor = mock.Mock()
+        flavor.get_keys.return_value = extra_specs
+        return flavor
+
+    def _cluster(self, server_type, master="bm-master", worker="bm-worker"):
+        cluster = mock.Mock()
+        cluster.cluster_template = mock.Mock(server_type=server_type)
+        cluster.master_flavor_id = master
+        cluster.flavor_id = worker
+        return cluster
+
+    def _client(self, lookup_results):
+        cli = mock.Mock()
+
+        def _list():
+            return list(lookup_results.values())
+
+        cli.nova.return_value.flavors.list.side_effect = _list
+        # lookup_flavor matches by name or id
+        for name, flavor in lookup_results.items():
+            flavor.name = name
+            flavor.id = name
+        return cli
+
+    def test_is_baremetal_flavor_true_for_custom_resource_class(self):
+        flavor = self._flavor({"resources:CUSTOM_BAREMETAL": "1"})
+        self.assertTrue(utils._is_baremetal_flavor(flavor))
+
+    def test_is_baremetal_flavor_false_for_empty_extra_specs(self):
+        flavor = self._flavor({})
+        self.assertFalse(utils._is_baremetal_flavor(flavor))
+
+    def test_is_baremetal_flavor_false_for_unrelated_extra_specs(self):
+        flavor = self._flavor({"hw:cpu_policy": "dedicated"})
+        self.assertFalse(utils._is_baremetal_flavor(flavor))
+
+    def test_is_baremetal_flavor_falls_back_to_extra_specs_attr(self):
+        flavor = mock.Mock(extra_specs={"resources:CUSTOM_GPU": "1"})
+        flavor.get_keys.side_effect = RuntimeError("not loaded")
+        self.assertTrue(utils._is_baremetal_flavor(flavor))
+
+    def test_validator_noop_for_vm_template(self):
+        cluster = self._cluster("vm")
+        cli = mock.Mock()
+        utils.validate_baremetal_flavors(cli, cluster)
+        cli.nova.assert_not_called()
+
+    def test_validator_passes_when_both_flavors_are_baremetal(self):
+        cluster = self._cluster("bm")
+        cli = self._client(
+            {
+                "bm-master": self._flavor({"resources:CUSTOM_BAREMETAL": "1"}),
+                "bm-worker": self._flavor({"resources:CUSTOM_BM_GPU": "1"}),
+            }
+        )
+        utils.validate_baremetal_flavors(cli, cluster)
+
+    def test_validator_rejects_virtual_master_flavor(self):
+        cluster = self._cluster("bm", master="m1.small", worker="bm-worker")
+        cli = self._client(
+            {
+                "m1.small": self._flavor({}),
+                "bm-worker": self._flavor({"resources:CUSTOM_BAREMETAL": "1"}),
+            }
+        )
+        with pytest.raises(exception.InvalidParameterValue) as excinfo:
+            utils.validate_baremetal_flavors(cli, cluster)
+        assert "master_flavor_id" in str(excinfo.value)
+        assert "m1.small" in str(excinfo.value)
+
+    def test_validator_rejects_virtual_worker_flavor(self):
+        cluster = self._cluster("bm", master="bm-master", worker="m1.small")
+        cli = self._client(
+            {
+                "bm-master": self._flavor({"resources:CUSTOM_BAREMETAL": "1"}),
+                "m1.small": self._flavor({}),
+            }
+        )
+        with pytest.raises(exception.InvalidParameterValue) as excinfo:
+            utils.validate_baremetal_flavors(cli, cluster)
+        assert "flavor_id" in str(excinfo.value)

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -566,3 +566,27 @@ def test_wait_for_sdk_loadbalancers_deleted_times_out(mocker):
         utils._wait_for_sdk_loadbalancers_deleted(octavia_client, {"lb-id"})
 
     sleep.assert_called_once_with(1)
+
+
+class TestGetDefaultBootVolumeSize(base.BaseTestCase):
+    def _cluster(self, server_type):
+        cluster = mock.Mock()
+        cluster.cluster_template = mock.Mock(server_type=server_type)
+        return cluster
+
+    def test_vm_returns_passed_default(self):
+        cluster = self._cluster("vm")
+        self.assertEqual(20, utils.get_default_boot_volume_size(cluster, 20))
+
+    def test_bm_returns_zero(self):
+        cluster = self._cluster("bm")
+        self.assertEqual(0, utils.get_default_boot_volume_size(cluster, 20))
+
+    def test_bm_ignores_nonzero_default(self):
+        cluster = self._cluster("bm")
+        self.assertEqual(0, utils.get_default_boot_volume_size(cluster, 100))
+
+    def test_missing_server_type_attr_falls_back_to_vm(self):
+        cluster = mock.Mock()
+        cluster.cluster_template = object()  # no server_type attr
+        self.assertEqual(20, utils.get_default_boot_volume_size(cluster, 20))

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -314,6 +314,26 @@ def get_cluster_label_as_int(
     return strutils.validate_integer(value, key)
 
 
+def get_default_boot_volume_size(
+    cluster: magnum_objects.Cluster, default: int
+) -> int:
+    """Return the boot_volume_size default appropriate for the cluster.
+
+    Baremetal nodes (server_type=bm) boot from the local disk via Ironic
+    and cannot use a Cinder root volume; defaulting to a non-zero size
+    causes the OpenStackMachineTemplate to request a Cinder volume that
+    Ironic refuses to attach. Default to 0 in that case so the chart
+    omits ``rootVolume`` and the machine boots from local disk.
+
+    Operators can still override explicitly by setting
+    ``boot_volume_size`` on the cluster_template/cluster/node_group.
+    """
+    server_type = getattr(cluster.cluster_template, "server_type", "vm")
+    if server_type == "bm":
+        return 0
+    return default
+
+
 def get_cluster_label_as_bool(
     cluster: magnum_objects.Cluster, key: str, default: bool
 ) -> bool:

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -314,9 +314,7 @@ def get_cluster_label_as_int(
     return strutils.validate_integer(value, key)
 
 
-def get_default_boot_volume_size(
-    cluster: magnum_objects.Cluster, default: int
-) -> int:
+def get_default_boot_volume_size(cluster: magnum_objects.Cluster, default: int) -> int:
     """Return the boot_volume_size default appropriate for the cluster.
 
     Baremetal nodes (server_type=bm) boot from the local disk via Ironic

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -467,6 +467,74 @@ def lookup_flavor(cli: clients.OpenStackClients, flavor: str) -> flavors.Flavor:
     raise exception.FlavorNotFound(flavor=flavor)
 
 
+def _is_baremetal_flavor(flavor: flavors.Flavor) -> bool:
+    """Return True if ``flavor`` is backed by an Ironic resource class.
+
+    A flavor is considered baremetal-backed when it advertises a custom
+    Placement resource class through its extra-specs, i.e. a key of the
+    form ``resources:CUSTOM_<NAME>`` set to ``"1"``.  Nova's Ironic
+    driver requires this convention so the scheduler routes the request
+    to the Ironic compute service rather than to a libvirt/KVM
+    hypervisor.  Standard virtual flavors (``m1.small``, etc.) typically
+    have empty extra-specs and will return False.
+    """
+    try:
+        extra_specs = flavor.get_keys()
+    except Exception:
+        # Fall back to the cached attribute when the flavor object was
+        # built from a list response that did not eagerly resolve keys.
+        extra_specs = getattr(flavor, "extra_specs", {}) or {}
+    for key, value in extra_specs.items():
+        if key.startswith("resources:CUSTOM_") and str(value) == "1":
+            return True
+    return False
+
+
+def validate_baremetal_flavors(
+    cli: clients.OpenStackClients,
+    cluster: magnum_objects.Cluster,
+) -> None:
+    """Reject ``server_type=bm`` clusters whose flavors are not Ironic-backed.
+
+    When the cluster_template advertises ``server_type=bm`` (PR #1014), the
+    operator's intent is to provision both the master and worker nodes on
+    Ironic.  However, Magnum does not enforce that ``master_flavor_id`` /
+    ``flavor_id`` actually resolve to an Ironic-backed Nova flavor, so a
+    user that forgets ``--master-flavor`` (or overrides it with a virtual
+    flavor) silently gets a Nova KVM master.  The cluster reaches
+    ``CREATE_COMPLETE`` and looks healthy, but the ``server_type=bm``
+    code paths (boot_volume_size auto-zero, network-interface=flat, etc.)
+    are bypassed and operators believe they are testing the BM control
+    plane when they are not.
+
+    This validator looks up both flavors and raises
+    ``InvalidParameterValue`` when either one is missing the
+    ``resources:CUSTOM_*=1`` extra-spec that Nova's Ironic driver
+    requires.  It is a no-op for ``server_type=vm`` templates.
+    """
+    server_type = getattr(cluster.cluster_template, "server_type", "vm")
+    if server_type != "bm":
+        return
+
+    for role, flavor_ref in (
+        ("master_flavor_id", cluster.master_flavor_id),
+        ("flavor_id", cluster.flavor_id),
+    ):
+        if not flavor_ref:
+            continue
+        flavor = lookup_flavor(cli, flavor_ref)
+        if flavor is None or not _is_baremetal_flavor(flavor):
+            raise exception.InvalidParameterValue(
+                err=(
+                    f"server_type=bm requires {role}={flavor_ref!r} to be "
+                    "backed by Ironic (Nova flavor extra-specs must contain "
+                    "a resources:CUSTOM_<RESOURCE_CLASS>=1 entry); the "
+                    "resolved flavor advertises no custom resource class, "
+                    "which would route the server to a virtual hypervisor."
+                )
+            )
+
+
 def lookup_image(cli: clients.OpenStackClients, image_ref: str) -> dict:
     """
     Get image object from image ref
@@ -484,6 +552,9 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
     # Check master count
     if (cluster.master_count % 2) == 0:
         raise mcapi_exceptions.ClusterMasterCountEven
+
+    # Reject server_type=bm clusters whose flavors are not Ironic-backed.
+    validate_baremetal_flavors(clients.get_openstack_api(ctx), cluster)
 
     # Check if fixed_network exists
     if cluster.fixed_network:

--- a/src/features/managed_security_groups.rs
+++ b/src/features/managed_security_groups.rs
@@ -1,0 +1,105 @@
+use crate::{
+    cluster_api::{
+        clusterclasses::{
+            ClusterClassPatches, ClusterClassPatchesDefinitions,
+            ClusterClassPatchesDefinitionsJsonPatches, ClusterClassPatchesDefinitionsSelector,
+            ClusterClassPatchesDefinitionsSelectorMatchResources, ClusterClassVariables,
+            ClusterClassVariablesSchema,
+        },
+        openstackclustertemplates::OpenStackClusterTemplate,
+    },
+    features::{
+        ClusterClassVariablesSchemaExt, ClusterFeatureEntry, ClusterFeaturePatches,
+        ClusterFeatureVariables,
+    },
+};
+use cluster_feature_derive::ClusterFeatureValues;
+use kube::CustomResourceExt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, ClusterFeatureValues)]
+#[allow(dead_code)]
+pub struct FeatureValues {
+    #[serde(rename = "disableManagedSecurityGroups")]
+    pub disable_managed_security_groups: bool,
+}
+
+pub struct Feature {}
+
+impl ClusterFeaturePatches for Feature {
+    fn patches(&self) -> Vec<ClusterClassPatches> {
+        vec![ClusterClassPatches {
+            name: "disableManagedSecurityGroups".into(),
+            enabled_if: Some("{{ if .disableManagedSecurityGroups }}true{{end}}".into()),
+            definitions: Some(vec![ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: OpenStackClusterTemplate::api_resource().api_version,
+                    kind: OpenStackClusterTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        infrastructure_cluster: Some(true),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "remove".into(),
+                    path: "/spec/template/spec/managedSecurityGroups".into(),
+                    ..Default::default()
+                }],
+            }]),
+            ..Default::default()
+        }]
+    }
+}
+
+inventory::submit! {
+    ClusterFeatureEntry{ feature: &Feature {} }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{features::test::TestClusterResources, resources::fixtures::default_values};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_keeps_managed_security_groups_by_default() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.disable_managed_security_groups = false;
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        assert!(resources
+            .openstack_cluster_template
+            .spec
+            .template
+            .spec
+            .managed_security_groups
+            .is_some());
+    }
+
+    #[test]
+    fn test_removes_managed_security_groups_for_baremetal() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.disable_managed_security_groups = true;
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        assert_eq!(
+            resources
+                .openstack_cluster_template
+                .spec
+                .template
+                .spec
+                .managed_security_groups,
+            None
+        );
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -63,6 +63,7 @@ pub mod flavors;
 pub mod image_repository;
 pub mod images;
 pub mod keystone_auth;
+pub mod managed_security_groups;
 pub mod networks;
 pub mod openid_connect;
 pub mod operating_system;

--- a/src/features/test.rs
+++ b/src/features/test.rs
@@ -90,6 +90,12 @@ impl ToRenderedPatchOperation for ClusterClassPatchesDefinitionsJsonPatches {
         version: &str,
         values: &T,
     ) -> PatchOperation {
+        if self.op == "remove" {
+            return json_patch::PatchOperation::Remove(RemoveOperation {
+                path: PointerBuf::parse(&self.path).unwrap(),
+            });
+        }
+
         let value = match self.value_from {
             Some(value_from) => value_from.to_rendered_value(version, values),
             None => self.value.expect("value should be present").into(),
@@ -103,9 +109,6 @@ impl ToRenderedPatchOperation for ClusterClassPatchesDefinitionsJsonPatches {
             "replace" => json_patch::PatchOperation::Replace(ReplaceOperation {
                 path: PointerBuf::parse(&self.path).unwrap(),
                 value: value,
-            }),
-            "remove" => json_patch::PatchOperation::Remove(RemoveOperation {
-                path: PointerBuf::parse(&self.path).unwrap(),
             }),
             _ => panic!("Unsupported patch operation: {}", self.op),
         }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -236,6 +236,7 @@ pub mod fixtures {
             .control_plane_availability_zones(vec!["zone1".into(), "zone2".into()])
             .disable_api_server_floating_ip(true)
             .disable_api_server_floating_ip_managed(true)
+            .disable_managed_security_groups(false)
             .external_network_id("external-network-id".into())
             .control_plane_flavor("control-plane".into())
             .flavor("worker".into())
@@ -310,7 +311,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 39);
+        assert_eq!(variables.len(), 40);
 
         for var in &variables {
             match var.name.as_str() {
@@ -354,6 +355,12 @@ mod tests {
                     assert_eq!(
                         var.value,
                         json!(default_values().disable_api_server_floating_ip_managed)
+                    );
+                }
+                "disableManagedSecurityGroups" => {
+                    assert_eq!(
+                        var.value,
+                        json!(default_values().disable_managed_security_groups)
                     );
                 }
                 "externalNetworkId" => {


### PR DESCRIPTION
## Problem

Magnum's cluster_api drivers only advertised `server_type=vm`. Baremetal templates using Ironic through Nova failed driver lookup, and baremetal boot also needed safer defaults around root volumes and networking.

## Solution

This PR now carries the `server_type=bm` behavior as three focused pieces:

1. `feat(driver): advertise server_type=bm alongside vm`
   - Adds `server_type=bm` entries for the shipped cluster_api drivers.
2. `feat(resources): default boot_volume_size=0 for server_type=bm`
   - Defaults BM clusters away from Cinder root volumes unless the operator explicitly sets a boot volume size.
3. `fix(pr1014): disable CAPO managed security groups for bm`
   - Adds `disableManagedSecurityGroups` and removes CAPO `managedSecurityGroups` only for `server_type=bm` ClusterClasses.
   - This is Issue 41 from the live OVN BM replay. CAPO managed security groups caused Neutron `PortSecurityAndIPRequiredForSecurityGroups` on the disabled-port-security baremetal VLAN network, before Nova/Ironic server create.

VM clusters keep the existing CAPO managed-security-group behavior.

## Validation

Latest scoped validation after moving Issue 41 into this PR:

- `cargo test managed_security_groups` -> 2 passed
- `cargo test test_convert_values_to_cluster_topology_variables` -> 1 passed
- `uv run pytest magnum_cluster_api/tests/unit/test_resources.py::test_cluster_variables_disable_managed_security_groups_for_bm -q` -> 1 passed, 8 warnings
- `uv run ruff check magnum_cluster_api/resources.py magnum_cluster_api/tests/unit/test_resources.py` -> passed
- `rustfmt --check src/features/managed_security_groups.rs` -> passed

## Review Notes

The managed-security-groups change is deliberately scoped to BM. The live failure came from a BM VLAN network with `port_security_enabled=False`; VM tenant-network behavior should remain unchanged.