### PR TITLE
feat: extra_cloud_init — operator-controlled files + pre/post-kubeadm commands

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,47 @@ use glob::glob;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::{env, error::Error, fs, path::Path};
-use syn::{parse_file, Ident, Item, Type};
+use syn::{parse_file, GenericArgument, Ident, Item, PathArguments, Type, TypePath};
 use vergen_gix::{Emitter, GixBuilder};
+
+/// If `type_path` is `Vec<T>` where `T` is a single-segment, non-generic,
+/// non-primitive identifier (i.e. a user-defined struct in the same
+/// `src/features/<module>.rs` file), return tokens for `T`.  Otherwise
+/// return `None`.
+fn extract_vec_inner(type_path: &TypePath) -> Option<TokenStream> {
+    let last = type_path.path.segments.last()?;
+    if last.ident != "Vec" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    if args.args.len() != 1 {
+        return None;
+    }
+    let GenericArgument::Type(Type::Path(inner_path)) = args.args.first()? else {
+        return None;
+    };
+    // Bail if the inner type is itself generic or multi-segment — keep
+    // qualification narrow and obvious.
+    if inner_path.path.segments.len() != 1 {
+        return None;
+    }
+    let inner_seg = inner_path.path.segments.first()?;
+    if !matches!(inner_seg.arguments, PathArguments::None) {
+        return None;
+    }
+    let ident = &inner_seg.ident;
+    let ident_str = ident.to_string();
+    // Don't qualify primitives that happen to live in std/core.
+    if matches!(
+        ident_str.as_str(),
+        "String" | "bool" | "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64"
+    ) {
+        return None;
+    }
+    Some(quote! { #ident })
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let gix = GixBuilder::default()
@@ -62,6 +101,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                                         || type_name == "Vec < String >"
                                     {
                                         quote! { #ty }
+                                    } else if let Some(inner) =
+                                        extract_vec_inner(type_path)
+                                    {
+                                        // Vec<T> where T is module-local: qualify only T.
+                                        quote! { Vec<crate::features::#mod_ident::#inner> }
                                     } else {
                                         println!(
                                             "cargo-warning: {} is not a primitive type",

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -368,6 +368,71 @@ For workloads that require genuinely distinct *content* per machine (e.g.
 unique TLS material burnt at boot), model each host as its own size-1 node
 group instead.
 
+### Accelerator host tuning per node group
+
+GPU/RDMA-bound node groups typically need a small set of host-level tuning
+in place before workloads schedule: GPU persistence mode, Mellanox NIC
+profile, hugepages, sysctl knobs.  These are one-shot, idempotent commands
+that fit naturally into `extra_pre_kubeadm_commands` for setup that must
+precede the kubelet, and `extra_post_kubeadm_commands` for tuning that
+needs the kubelet already up.
+
+The pattern: ship one `extra_files` script to every node, dispatch on
+Nova-supplied per-node-group metadata so non-accelerator pools no-op, and
+let the per-node-group `extra_post_kubeadm_commands` override the
+cluster-level value for pools that need different post-init tuning.
+
+```bash
+EF=$(cat <<'EOF' | base64 -w0
+- path: /etc/accelerator-init.sh
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -euxo pipefail
+    META=$(curl -fs http://169.254.169.254/openstack/latest/meta_data.json)
+    ROLE=$(echo "$META" | jq -r '.meta.node_role // "worker"')
+    [ "$ROLE" != "accelerator" ] && exit 0
+
+    # Host tuning — idempotent, safe on every boot.
+    command -v nvidia-smi >/dev/null && nvidia-smi -pm 1 || true
+    command -v mlnx_tune  >/dev/null && mlnx_tune -p HIGH_THROUGHPUT || true
+    echo "vm.nr_hugepages = 1024" > /etc/sysctl.d/99-hugepages.conf
+    sysctl -p /etc/sysctl.d/99-hugepages.conf
+EOF
+)
+
+# Cluster-wide: every node ships the script; non-accelerator nodes no-op.
+openstack coe cluster create k8s \
+  --labels kube_tag=v1.34.3,\
+extra_files=${EF},\
+extra_pre_kubeadm_commands="bash /etc/accelerator-init.sh"
+
+# Accelerator node-group: a post-kubeadm one-shot for tuning that needs
+# the kubelet already running (GPU compute mode, device-plugin liveness).
+openstack coe nodegroup create k8s gpu-pool \
+  --node-count 4 --flavor=g4-a100 \
+  --labels extra_post_kubeadm_commands="nvidia-smi -c EXCLUSIVE_PROCESS"
+```
+
+The `gpu-pool` node group must also boot with Nova server metadata
+`node_role=accelerator` so the dispatch script's gate passes — wire it
+through the flavor's `extra_specs` or the Nova boot template, the same
+plumbing the runtime-dispatch example above uses for `availability_zone`
+and `meta.*`.
+
+What this exercises:
+
+* `extra_files` shipped cluster-wide, gated by per-node metadata so it's
+  safe on mixed-pool clusters.
+* `extra_pre_kubeadm_commands` for tuning that must precede the kubelet
+  (sysctl, modprobe blacklists, hugepages).
+* Per-node-group `extra_post_kubeadm_commands` for tuning that needs the
+  kubelet already up (GPU compute mode, device-plugin liveness checks).
+* Per-node-group override semantics: the cluster-level
+  `extra_pre_kubeadm_commands` still applies because the `gpu-pool` did
+  not override it; the `gpu-pool`'s `extra_post_kubeadm_commands`
+  *replaces* the (empty) cluster-level value with its own.
+
 * `extra_files`
 
    Base64-encoded YAML/JSON list of files to drop on the node.  Each entry

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -315,6 +315,61 @@ is often accomplished by deploying a driver on each node.
 
    Default value: `soft-anti-affinity`
 
+## Cloud-init passthrough
+
+Three labels let operators inject extra files and shell commands into the
+cloud-init bootstrap of every node (or just one node group).  Use cases
+include applying a custom `netplan` configuration or dropping a CA bundle
+before `kubeadm init`/`join` runs.
+
+All three labels work at both the cluster level and the node-group level;
+node-group entries are appended after cluster-level entries.
+
+* `extra_files`
+
+   Base64-encoded YAML/JSON list of files to drop on the node.  Each entry
+   must include `path` (absolute) and `content`; `owner` (default
+   `root:root`), `permissions` (default `0644`), and `encoding` (omit, or
+   `base64` if `content` is already base64) are optional.
+
+   Capped at 10 entries (cluster + node-group combined).
+
+   Default value: empty list.
+
+   Netplan example:
+
+   ```bash
+   PAYLOAD=$(cat <<'EOF' | base64 -w0
+   - path: /etc/netplan/99-mcapi.yaml
+     permissions: "0600"
+     content: |
+       network:
+         version: 2
+         ethernets:
+           enp4s0:
+             dhcp4: true
+             mtu: 1450
+   EOF
+   )
+   openstack coe cluster create ... --labels \
+     extra_files=${PAYLOAD},\
+   extra_pre_kubeadm_commands="netplan generate;;netplan apply;;sleep 3"
+   ```
+
+* `extra_pre_kubeadm_commands`
+
+   `;;`-separated list of shell commands to run **before** `kubeadm
+   init`/`join`.  Capped at 16 entries.
+
+   Default value: empty list.
+
+* `extra_post_kubeadm_commands`
+
+   `;;`-separated list of shell commands to run **after** `kubeadm
+   init`/`join`.  Capped at 16 entries.
+
+   Default value: empty list.
+
 ## TODO
 
 availability_zone

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -322,8 +322,51 @@ cloud-init bootstrap of every node (or just one node group).  Use cases
 include applying a custom `netplan` configuration or dropping a CA bundle
 before `kubeadm init`/`join` runs.
 
-All three labels work at both the cluster level and the node-group level;
-node-group entries are appended after cluster-level entries.
+All three labels work at both the cluster level and the node-group level.
+**Per-node-group label fully replaces the cluster-level value** for that
+node group's machines (CAPI override semantics — never merged).  A node
+group without its own label inherits the cluster-level list.
+
+### Per-node configuration via runtime dispatch
+
+CAPI does not have a per-Machine variable scope, so per-node cloud-init is
+not directly supported.  The recommended pattern is to ship **one**
+`extra_files` script to every machine and let it branch on per-VM identity
+read from the OpenStack metadata service at first boot:
+
+```bash
+EF=$(cat <<'EOF' | base64 -w0
+- path: /etc/per-node-init.sh
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -euxo pipefail
+    META=$(curl -fs http://169.254.169.254/openstack/latest/meta_data.json)
+    HOSTNAME=$(hostname)
+    AZ=$(echo "$META" | jq -r .availability_zone)
+    ROLE=$(echo "$META" | jq -r '.meta.node_role // "worker"')
+
+    [ "$AZ" = "zone-b" ]              && ip link set dev ens4 mtu 9000
+    [ "$ROLE" = "gpu" ]               && echo "blacklist nouveau" \
+                                            > /etc/modprobe.d/nouveau.conf
+    [[ "$HOSTNAME" == *-storage-* ]]  && mkfs.xfs -f /dev/vdb \
+                                            && mount /dev/vdb /var/lib/containerd
+EOF
+)
+
+openstack coe cluster create k8s \
+  --labels kube_tag=v1.34.3,extra_files=$EF,\
+extra_pre_kubeadm_commands="bash /etc/per-node-init.sh"
+```
+
+Per-VM identity available at first boot:
+* `hostname` — CABPK names each Machine `<cluster>-<md>-<random>`.
+* `availability_zone` — set per node group via `availability_zone`.
+* `meta.*` — arbitrary key/value injected through Nova server metadata.
+
+For workloads that require genuinely distinct *content* per machine (e.g.
+unique TLS material burnt at boot), model each host as its own size-1 node
+group instead.
 
 * `extra_files`
 

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -469,12 +469,25 @@ What this exercises:
    `;;`-separated list of shell commands to run **before** `kubeadm
    init`/`join`.  Capped at 16 entries.
 
+   The delimiter is the **double** semicolon `;;` — not a single `;`.
+   Each `;;`-separated segment becomes its own cloud-init `runcmd` entry
+   and is executed in its own `/bin/sh -c <segment>` subshell, so
+   per-segment status is observable in `/var/log/cloud-init-output.log`
+   and shell options (`set -e`, `trap`, exported variables) installed in
+   one segment do not propagate to the next.  A single `;` is part of
+   one shell command and is forwarded verbatim to that subshell, e.g.
+   `"a; b"` is one runcmd entry where `b` runs after `a` regardless of
+   `a`'s exit code, while `"a;;b"` is two independent runcmd entries.
+
    Default value: empty list.
 
 * `extra_post_kubeadm_commands`
 
    `;;`-separated list of shell commands to run **after** `kubeadm
    init`/`join`.  Capped at 16 entries.
+
+   The delimiter is the **double** semicolon `;;` with the same
+   semantics as `extra_pre_kubeadm_commands` above.
 
    Default value: empty list.
 

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -842,6 +842,22 @@ def mutate_machine_deployment(
                             node_group=node_group, cluster=cluster
                         ),
                     },
+                    {
+                        "name": "extraFiles",
+                        "value": utils.get_extra_files(cluster, node_group=node_group),
+                    },
+                    {
+                        "name": "extraPreKubeadmCommands",
+                        "value": utils.get_extra_pre_kubeadm_commands(
+                            cluster, node_group=node_group
+                        ),
+                    },
+                    {
+                        "name": "extraPostKubeadmCommands",
+                        "value": utils.get_extra_post_kubeadm_commands(
+                            cluster, node_group=node_group
+                        ),
+                    },
                 ],
             },
         }
@@ -1325,6 +1341,20 @@ class Cluster(ClusterBase):
                         {
                             "name": "admissionControlList",
                             "value": self._get_admission_control_list(),
+                        },
+                        {
+                            "name": "extraFiles",
+                            "value": utils.get_extra_files(self.cluster),
+                        },
+                        {
+                            "name": "extraPreKubeadmCommands",
+                            "value": utils.get_extra_pre_kubeadm_commands(self.cluster),
+                        },
+                        {
+                            "name": "extraPostKubeadmCommands",
+                            "value": utils.get_extra_post_kubeadm_commands(
+                                self.cluster
+                            ),
                         },
                     ],
                 },

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -1344,16 +1344,29 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "extraFiles",
-                            "value": utils.get_extra_files(self.cluster),
+                            "value": utils.get_extra_files(
+                                self.cluster,
+                                node_group=getattr(
+                                    self.cluster, "default_ng_master", None
+                                ),
+                            ),
                         },
                         {
                             "name": "extraPreKubeadmCommands",
-                            "value": utils.get_extra_pre_kubeadm_commands(self.cluster),
+                            "value": utils.get_extra_pre_kubeadm_commands(
+                                self.cluster,
+                                node_group=getattr(
+                                    self.cluster, "default_ng_master", None
+                                ),
+                            ),
                         },
                         {
                             "name": "extraPostKubeadmCommands",
                             "value": utils.get_extra_post_kubeadm_commands(
-                                self.cluster
+                                self.cluster,
+                                node_group=getattr(
+                                    self.cluster, "default_ng_master", None
+                                ),
                             ),
                         },
                     ],

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -368,3 +368,129 @@ class TestUtils(base.BaseTestCase):
             context,
             fixed_network,
         )
+
+
+def _b64yaml(payload):
+    import base64 as _b64
+
+    import yaml as _yaml
+
+    return _b64.b64encode(_yaml.safe_dump(payload).encode()).decode()
+
+
+class TestExtraCloudInit:
+    def _make_cluster(self, labels):
+        cluster = mock.Mock()
+        cluster.labels = labels
+        return cluster
+
+    def _make_node_group(self, labels):
+        ng = mock.Mock()
+        ng.labels = labels
+        return ng
+
+    def test_get_extra_files_empty(self):
+        cluster = self._make_cluster({})
+        assert utils.get_extra_files(cluster) == []
+
+    def test_get_extra_files_encodes_plain_content(self):
+        payload = [{"path": "/etc/netplan/99.yaml", "content": "hello"}]
+        cluster = self._make_cluster({"extra_files": _b64yaml(payload)})
+        result = utils.get_extra_files(cluster)
+        assert result == [
+            {
+                "path": "/etc/netplan/99.yaml",
+                "owner": "root:root",
+                "permissions": "0644",
+                "content": "aGVsbG8=",
+            }
+        ]
+
+    def test_get_extra_files_passes_through_base64(self):
+        payload = [
+            {
+                "path": "/etc/foo",
+                "content": "aGVsbG8=",
+                "encoding": "base64",
+                "permissions": "0600",
+                "owner": "ubuntu:ubuntu",
+            }
+        ]
+        cluster = self._make_cluster({"extra_files": _b64yaml(payload)})
+        result = utils.get_extra_files(cluster)
+        assert result[0]["content"] == "aGVsbG8="
+        assert result[0]["permissions"] == "0600"
+        assert result[0]["owner"] == "ubuntu:ubuntu"
+
+    def test_get_extra_files_merges_node_group_after_cluster(self):
+        cluster = self._make_cluster(
+            {"extra_files": _b64yaml([{"path": "/a", "content": "x"}])}
+        )
+        ng = self._make_node_group(
+            {"extra_files": _b64yaml([{"path": "/b", "content": "y"}])}
+        )
+        result = utils.get_extra_files(cluster, node_group=ng)
+        assert [e["path"] for e in result] == ["/a", "/b"]
+
+    def test_get_extra_files_rejects_relative_path(self):
+        cluster = self._make_cluster(
+            {"extra_files": _b64yaml([{"path": "etc/foo", "content": "x"}])}
+        )
+        with pytest.raises(exception.InvalidParameterValue):
+            utils.get_extra_files(cluster)
+
+    def test_get_extra_files_rejects_non_list(self):
+        import base64 as _b64
+
+        bad = _b64.b64encode(b"not_a_list").decode()
+        cluster = self._make_cluster({"extra_files": bad})
+        with pytest.raises(exception.InvalidParameterValue):
+            utils.get_extra_files(cluster)
+
+    def test_get_extra_files_rejects_invalid_base64(self):
+        cluster = self._make_cluster({"extra_files": "!!!not base64!!!"})
+        with pytest.raises(exception.InvalidParameterValue):
+            utils.get_extra_files(cluster)
+
+    def test_get_extra_files_enforces_cap(self):
+        payload = [
+            {"path": f"/f{i}", "content": "x"}
+            for i in range(utils.EXTRA_CLOUD_INIT_MAX_FILES + 1)
+        ]
+        cluster = self._make_cluster({"extra_files": _b64yaml(payload)})
+        with pytest.raises(exception.InvalidParameterValue):
+            utils.get_extra_files(cluster)
+
+    def test_get_extra_pre_kubeadm_commands_split(self):
+        cluster = self._make_cluster(
+            {"extra_pre_kubeadm_commands": "netplan generate;;netplan apply"}
+        )
+        assert utils.get_extra_pre_kubeadm_commands(cluster) == [
+            "netplan generate",
+            "netplan apply",
+        ]
+
+    def test_get_extra_pre_kubeadm_commands_merges_node_group(self):
+        cluster = self._make_cluster({"extra_pre_kubeadm_commands": "a"})
+        ng = self._make_node_group({"extra_pre_kubeadm_commands": "b;;c"})
+        assert utils.get_extra_pre_kubeadm_commands(cluster, ng) == [
+            "a",
+            "b",
+            "c",
+        ]
+
+    def test_get_extra_pre_kubeadm_commands_drops_empty_segments(self):
+        cluster = self._make_cluster({"extra_pre_kubeadm_commands": "a;;;;b;;"})
+        assert utils.get_extra_pre_kubeadm_commands(cluster) == ["a", "b"]
+
+    def test_get_extra_post_kubeadm_commands_default_empty(self):
+        cluster = self._make_cluster({})
+        assert utils.get_extra_post_kubeadm_commands(cluster) == []
+
+    def test_get_extra_pre_kubeadm_commands_enforces_cap(self):
+        cmds = ";;".join(
+            [f"echo {i}" for i in range(utils.EXTRA_CLOUD_INIT_MAX_PRE_COMMANDS + 1)]
+        )
+        cluster = self._make_cluster({"extra_pre_kubeadm_commands": cmds})
+        with pytest.raises(exception.InvalidParameterValue):
+            utils.get_extra_pre_kubeadm_commands(cluster)

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -507,3 +507,55 @@ class TestExtraCloudInit:
         cluster = self._make_cluster({"extra_pre_kubeadm_commands": cmds})
         with pytest.raises(exception.InvalidParameterValue):
             utils.get_extra_pre_kubeadm_commands(cluster)
+
+    def test_runtime_dispatch_pattern_per_node_via_metadata_service(self):
+        """Recommended per-node pattern: one identical dispatch script ships to
+        every machine; per-VM behaviour is decided at first boot from the
+        OpenStack metadata service (hostname / AZ / server metadata).
+
+        The contract this test locks in:
+          * cluster-level ``extra_files`` is delivered identically to control
+            plane and to every worker NG that does not declare its own
+            ``extra_files`` label;
+          * cluster-level ``extra_pre_kubeadm_commands`` likewise inherits;
+          * a worker NG that opts out (its own ``extra_files``) cleanly
+            replaces the dispatch script with NG-specific content and does
+            **not** see the cluster script anymore.
+        """
+        dispatch_script = (
+            "#!/bin/bash\n"
+            "META=$(curl -fs http://169.254.169.254/openstack/latest/meta_data.json)\n"
+            "ROLE=$(echo \"$META\" | jq -r '.meta.node_role // \"worker\"')\n"
+            "[ \"$ROLE\" = gpu ] && echo blacklist nouveau >/etc/modprobe.d/nv.conf\n"
+        )
+        cluster_payload = [
+            {"path": "/etc/per-node-init.sh", "permissions": "0755", "content": dispatch_script}
+        ]
+        cluster = self._make_cluster(
+            {
+                "extra_files": _b64yaml(cluster_payload),
+                "extra_pre_kubeadm_commands": "bash /etc/per-node-init.sh",
+            }
+        )
+        master_ng = self._make_node_group({})
+        default_worker = self._make_node_group({})
+        opted_out_ng = self._make_node_group(
+            {"extra_files": _b64yaml([{"path": "/etc/db.cnf", "content": "x"}])}
+        )
+
+        cluster_files = utils.get_extra_files(cluster)
+        master_files = utils.get_extra_files(cluster, node_group=master_ng)
+        default_worker_files = utils.get_extra_files(cluster, node_group=default_worker)
+        opted_out_files = utils.get_extra_files(cluster, node_group=opted_out_ng)
+
+        # Identical dispatch script reaches CP + every inheriting NG.
+        assert cluster_files == master_files == default_worker_files
+        assert cluster_files[0]["path"] == "/etc/per-node-init.sh"
+        assert (
+            utils.get_extra_pre_kubeadm_commands(cluster, node_group=master_ng)
+            == utils.get_extra_pre_kubeadm_commands(cluster, node_group=default_worker)
+            == ["bash /etc/per-node-init.sh"]
+        )
+
+        # The opted-out NG fully replaces — no leakage of the dispatch script.
+        assert [f["path"] for f in opted_out_files] == ["/etc/db.cnf"]

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -422,7 +422,8 @@ class TestExtraCloudInit:
         assert result[0]["permissions"] == "0600"
         assert result[0]["owner"] == "ubuntu:ubuntu"
 
-    def test_get_extra_files_merges_node_group_after_cluster(self):
+    def test_get_extra_files_node_group_overrides_cluster(self):
+        """When the NG declares extra_files, it fully replaces the cluster list."""
         cluster = self._make_cluster(
             {"extra_files": _b64yaml([{"path": "/a", "content": "x"}])}
         )
@@ -430,7 +431,16 @@ class TestExtraCloudInit:
             {"extra_files": _b64yaml([{"path": "/b", "content": "y"}])}
         )
         result = utils.get_extra_files(cluster, node_group=ng)
-        assert [e["path"] for e in result] == ["/a", "/b"]
+        assert [e["path"] for e in result] == ["/b"]
+
+    def test_get_extra_files_node_group_inherits_when_unset(self):
+        """An NG without its own label inherits the cluster-level list."""
+        cluster = self._make_cluster(
+            {"extra_files": _b64yaml([{"path": "/a", "content": "x"}])}
+        )
+        ng = self._make_node_group({})
+        result = utils.get_extra_files(cluster, node_group=ng)
+        assert [e["path"] for e in result] == ["/a"]
 
     def test_get_extra_files_rejects_relative_path(self):
         cluster = self._make_cluster(
@@ -470,14 +480,17 @@ class TestExtraCloudInit:
             "netplan apply",
         ]
 
-    def test_get_extra_pre_kubeadm_commands_merges_node_group(self):
+    def test_get_extra_pre_kubeadm_commands_node_group_overrides(self):
+        """NG label fully replaces cluster-level for that NG."""
         cluster = self._make_cluster({"extra_pre_kubeadm_commands": "a"})
         ng = self._make_node_group({"extra_pre_kubeadm_commands": "b;;c"})
-        assert utils.get_extra_pre_kubeadm_commands(cluster, ng) == [
-            "a",
-            "b",
-            "c",
-        ]
+        assert utils.get_extra_pre_kubeadm_commands(cluster, ng) == ["b", "c"]
+
+    def test_get_extra_pre_kubeadm_commands_node_group_inherits(self):
+        """NG without its own label inherits the cluster-level commands."""
+        cluster = self._make_cluster({"extra_pre_kubeadm_commands": "a;;b"})
+        ng = self._make_node_group({})
+        assert utils.get_extra_pre_kubeadm_commands(cluster, ng) == ["a", "b"]
 
     def test_get_extra_pre_kubeadm_commands_drops_empty_segments(self):
         cluster = self._make_cluster({"extra_pre_kubeadm_commands": "a;;;;b;;"})

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -462,6 +462,67 @@ class TestExtraCloudInit:
         with pytest.raises(exception.InvalidParameterValue):
             utils.get_extra_files(cluster)
 
+    def test_get_extra_files_accepts_plain_yaml(self):
+        """F1: operator may pass a raw YAML/JSON list (no base64 wrap)."""
+        import yaml as _yaml
+
+        plain = _yaml.safe_dump(
+            [{"path": "/etc/foo", "content": "hi"}], default_flow_style=False
+        )
+        cluster = self._make_cluster({"extra_files": plain})
+        result = utils.get_extra_files(cluster)
+        assert result == [
+            {
+                "path": "/etc/foo",
+                "owner": "root:root",
+                "permissions": "0644",
+                "content": "aGk=",
+            }
+        ]
+
+    def test_get_extra_files_accepts_plain_json(self):
+        """F1: operator may pass JSON directly (it's a YAML subset)."""
+        cluster = self._make_cluster(
+            {"extra_files": '[{"path": "/etc/foo", "content": "hi"}]'}
+        )
+        result = utils.get_extra_files(cluster)
+        assert len(result) == 1 and result[0]["path"] == "/etc/foo"
+
+    def test_get_extra_files_rejects_double_encoded_plain(self):
+        """F2: pre-encoded ``content`` without ``encoding: base64`` is rejected.
+
+        This used to silently double-encode and write a base64 string to disk.
+        """
+        import base64 as _b64
+
+        pre_encoded = _b64.b64encode(b"#!/bin/bash\necho hi\n").decode()
+        cluster = self._make_cluster(
+            {"extra_files": _b64yaml([{"path": "/etc/foo", "content": pre_encoded}])}
+        )
+        with pytest.raises(exception.InvalidParameterValue) as exc:
+            utils.get_extra_files(cluster)
+        assert "encoding" in str(exc.value)
+
+    def test_get_extra_files_short_plain_content_not_flagged(self):
+        """F2: short plain content (e.g. 'hello') must not trigger the guard."""
+        cluster = self._make_cluster(
+            {"extra_files": _b64yaml([{"path": "/x", "content": "hello"}])}
+        )
+        result = utils.get_extra_files(cluster)
+        assert result[0]["content"] == "aGVsbG8="
+
+    def test_get_extra_files_script_with_special_chars_not_flagged(self):
+        """F2: real scripts have spaces/newlines and must pass through plain."""
+        script = "#!/bin/bash\nset -e\necho 'hello world' > /tmp/x\n"
+        cluster = self._make_cluster(
+            {"extra_files": _b64yaml([{"path": "/x.sh", "content": script}])}
+        )
+        result = utils.get_extra_files(cluster)
+        # Round-trip the wire content back to the original script.
+        import base64 as _b64
+
+        assert _b64.b64decode(result[0]["content"]).decode() == script
+
     def test_get_extra_files_enforces_cap(self):
         payload = [
             {"path": f"/f{i}", "content": "x"}

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -557,6 +557,26 @@ class TestExtraCloudInit:
         cluster = self._make_cluster({"extra_pre_kubeadm_commands": "a;;;;b;;"})
         assert utils.get_extra_pre_kubeadm_commands(cluster) == ["a", "b"]
 
+    def test_get_extra_pre_kubeadm_commands_single_semicolon_preserved(self):
+        """Single ``;`` is part of one shell command, not a delimiter.
+
+        This is the documented behaviour for both
+        ``extra_pre_kubeadm_commands`` and ``extra_post_kubeadm_commands``:
+        only the *double* semicolon ``;;`` separates entries; a single
+        ``;`` is forwarded verbatim so the resulting runcmd entry is still
+        executed by a single ``/bin/sh -c`` subshell.
+        """
+        cluster = self._make_cluster(
+            {"extra_pre_kubeadm_commands": "echo first; echo second"}
+        )
+        assert utils.get_extra_pre_kubeadm_commands(cluster) == [
+            "echo first; echo second",
+        ]
+
+    def test_get_extra_post_kubeadm_commands_single_semicolon_preserved(self):
+        cluster = self._make_cluster({"extra_post_kubeadm_commands": "a; b;;c"})
+        assert utils.get_extra_post_kubeadm_commands(cluster) == ["a; b", "c"]
+
     def test_get_extra_post_kubeadm_commands_default_empty(self):
         cluster = self._make_cluster({})
         assert utils.get_extra_post_kubeadm_commands(cluster) == []

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -525,11 +525,15 @@ class TestExtraCloudInit:
         dispatch_script = (
             "#!/bin/bash\n"
             "META=$(curl -fs http://169.254.169.254/openstack/latest/meta_data.json)\n"
-            "ROLE=$(echo \"$META\" | jq -r '.meta.node_role // \"worker\"')\n"
-            "[ \"$ROLE\" = gpu ] && echo blacklist nouveau >/etc/modprobe.d/nv.conf\n"
+            'ROLE=$(echo "$META" | jq -r \'.meta.node_role // "worker"\')\n'
+            '[ "$ROLE" = gpu ] && echo blacklist nouveau >/etc/modprobe.d/nv.conf\n'
         )
         cluster_payload = [
-            {"path": "/etc/per-node-init.sh", "permissions": "0755", "content": dispatch_script}
+            {
+                "path": "/etc/per-node-init.sh",
+                "permissions": "0755",
+                "content": dispatch_script,
+            }
         ]
         cluster = self._make_cluster(
             {

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -782,25 +782,31 @@ def get_extra_files(
 ) -> typing.List[dict]:
     """Build the `extraFiles` topology variable for one cluster + node group.
 
-    Cluster-level entries appear first, followed by node-group entries.
-    Both are rendered in the order they were declared by the operator.
+    Per-node-group override semantics: when ``node_group`` is provided **and**
+    its labels include a non-empty ``extra_files`` entry, the node group's
+    list fully replaces the cluster-level list for machines in that node
+    group.  When the node group does not declare its own ``extra_files``, the
+    machines inherit the cluster-level list.  The two are never merged — this
+    matches CAPI's ClusterClass variable-override contract (overrides replace
+    parent values) and lets operators ship distinct files to control plane,
+    worker-A, worker-B node groups, etc.
+
     Capped at :data:`EXTRA_CLOUD_INIT_MAX_FILES`; raises
     :class:`magnum.common.exception.InvalidParameterValue` if exceeded.
     """
-    cluster_entries = _decode_extra_files_label(cluster.labels.get("extra_files", ""))
-    ng_entries: typing.List[dict] = []
-    if node_group is not None:
-        ng_entries = _decode_extra_files_label(node_group.labels.get("extra_files", ""))
-
-    combined = [_normalize_extra_file(e) for e in (cluster_entries + ng_entries)]
-    if len(combined) > EXTRA_CLOUD_INIT_MAX_FILES:
+    if node_group is not None and node_group.labels.get("extra_files"):
+        raw = node_group.labels.get("extra_files", "")
+    else:
+        raw = cluster.labels.get("extra_files", "")
+    entries = [_normalize_extra_file(e) for e in _decode_extra_files_label(raw)]
+    if len(entries) > EXTRA_CLOUD_INIT_MAX_FILES:
         raise exception.InvalidParameterValue(
             err=(
                 f"extra_files exceeds the maximum of "
-                f"{EXTRA_CLOUD_INIT_MAX_FILES} entries (got {len(combined)})"
+                f"{EXTRA_CLOUD_INIT_MAX_FILES} entries (got {len(entries)})"
             )
         )
-    return combined
+    return entries
 
 
 def _split_kubeadm_commands(value: str) -> typing.List[str]:
@@ -816,26 +822,33 @@ def _get_extra_kubeadm_commands(
     label: str,
     cap: int,
 ) -> typing.List[str]:
-    cluster_cmds = _split_kubeadm_commands(cluster.labels.get(label, ""))
-    ng_cmds: typing.List[str] = []
-    if node_group is not None:
-        ng_cmds = _split_kubeadm_commands(node_group.labels.get(label, ""))
-    combined = cluster_cmds + ng_cmds
-    if len(combined) > cap:
+    if node_group is not None and node_group.labels.get(label):
+        raw = node_group.labels.get(label, "")
+    else:
+        raw = cluster.labels.get(label, "")
+    cmds = _split_kubeadm_commands(raw)
+    if len(cmds) > cap:
         raise exception.InvalidParameterValue(
             err=(
                 f"{label} exceeds the maximum of {cap} entries "
-                f"(got {len(combined)})"
+                f"(got {len(cmds)})"
             )
         )
-    return combined
+    return cmds
 
 
 def get_extra_pre_kubeadm_commands(
     cluster: magnum_objects.Cluster,
     node_group: typing.Optional[magnum_objects.NodeGroup] = None,
 ) -> typing.List[str]:
-    """`;;`-separated `extra_pre_kubeadm_commands` label, cluster + NG merged."""
+    """`;;`-separated `extra_pre_kubeadm_commands` label.
+
+    Per-node-group override semantics: when ``node_group`` declares its own
+    ``extra_pre_kubeadm_commands`` label, the node group's list fully
+    replaces the cluster-level list for machines in that node group;
+    otherwise the cluster-level list is used.  See :func:`get_extra_files`
+    for the rationale.
+    """
     return _get_extra_kubeadm_commands(
         cluster,
         node_group,
@@ -848,7 +861,10 @@ def get_extra_post_kubeadm_commands(
     cluster: magnum_objects.Cluster,
     node_group: typing.Optional[magnum_objects.NodeGroup] = None,
 ) -> typing.List[str]:
-    """`;;`-separated `extra_post_kubeadm_commands` label, cluster + NG merged."""
+    """`;;`-separated `extra_post_kubeadm_commands` label.
+
+    Per-node-group override semantics — see :func:`get_extra_files`.
+    """
     return _get_extra_kubeadm_commands(
         cluster,
         node_group,

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -829,10 +829,7 @@ def _get_extra_kubeadm_commands(
     cmds = _split_kubeadm_commands(raw)
     if len(cmds) > cap:
         raise exception.InvalidParameterValue(
-            err=(
-                f"{label} exceeds the maximum of {cap} entries "
-                f"(got {len(cmds)})"
-            )
+            err=(f"{label} exceeds the maximum of {cap} entries " f"(got {len(cmds)})")
         )
     return cmds
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -857,7 +857,25 @@ def get_extra_files(
 
 
 def _split_kubeadm_commands(value: str) -> typing.List[str]:
-    """Split a `;;`-delimited command string, dropping empty segments."""
+    """Split a ``;;``-delimited command string, dropping empty segments.
+
+    The delimiter is the *double* semicolon ``;;`` (not a single ``;``):
+    each segment becomes its own ``runcmd`` entry in the rendered cloud-init
+    user-data, and cloud-init executes each entry in its own
+    ``/bin/sh -c <entry>`` subshell.  A single ``;`` is therefore part of
+    one shell command and is forwarded verbatim to that subshell, e.g.
+
+    * ``"a; b"``  → one runcmd entry: ``a; b``
+      (single ``sh -c`` invocation, ``b`` runs after ``a`` regardless of
+      ``a``'s exit code)
+    * ``"a;;b"`` → two runcmd entries: ``a`` and ``b``
+      (separate ``sh -c`` invocations; cloud-init records per-entry status)
+
+    Use ``;;`` whenever you want each command to be observable as its own
+    runcmd entry (e.g. for failure attribution) and to avoid the
+    cloud-init quirk that shell options (``set -e``, ``trap``, exported
+    variables) installed in one entry do not propagate to the next.
+    """
     if not value:
         return []
     return [segment.strip() for segment in value.split(";;") if segment.strip()]
@@ -885,7 +903,12 @@ def get_extra_pre_kubeadm_commands(
     cluster: magnum_objects.Cluster,
     node_group: typing.Optional[magnum_objects.NodeGroup] = None,
 ) -> typing.List[str]:
-    """`;;`-separated `extra_pre_kubeadm_commands` label.
+    """``;;``-separated ``extra_pre_kubeadm_commands`` label.
+
+    Each ``;;``-separated segment becomes its own cloud-init ``runcmd``
+    entry; a single ``;`` is forwarded verbatim as part of one shell
+    command.  See :func:`_split_kubeadm_commands` for the full delimiter
+    semantics and rationale.
 
     Per-node-group override semantics: when ``node_group`` declares its own
     ``extra_pre_kubeadm_commands`` label, the node group's list fully
@@ -905,7 +928,12 @@ def get_extra_post_kubeadm_commands(
     cluster: magnum_objects.Cluster,
     node_group: typing.Optional[magnum_objects.NodeGroup] = None,
 ) -> typing.List[str]:
-    """`;;`-separated `extra_post_kubeadm_commands` label.
+    """``;;``-separated ``extra_post_kubeadm_commands`` label.
+
+    Each ``;;``-separated segment becomes its own cloud-init ``runcmd``
+    entry; a single ``;`` is forwarded verbatim as part of one shell
+    command.  See :func:`_split_kubeadm_commands` for the full delimiter
+    semantics and rationale.
 
     Per-node-group override semantics — see :func:`get_extra_files`.
     """

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import base64 as stdlib_base64
 import json
 import re
 import string
@@ -655,3 +656,202 @@ def get_fixed_network_id(context, network):
         )
     else:
         return network
+
+
+# ---------------------------------------------------------------------------
+# extra_cloud_init feature: extra_files, extra_pre/post_kubeadm_commands
+# ---------------------------------------------------------------------------
+
+# Hard caps mirror the Rust-side `MAX_EXTRA_FILES`,
+# `MAX_PRE_KUBEADM_COMMANDS`, and `MAX_POST_KUBEADM_COMMANDS` constants in
+# `src/features/extra_cloud_init.rs`.  The ClusterClass renders a fixed
+# number of patch slots; entries beyond the cap would be silently dropped
+# by CAPI, so we reject them here with a clear error.
+EXTRA_CLOUD_INIT_MAX_FILES = 10
+EXTRA_CLOUD_INIT_MAX_PRE_COMMANDS = 16
+EXTRA_CLOUD_INIT_MAX_POST_COMMANDS = 16
+
+_DEFAULT_FILE_OWNER = "root:root"
+_DEFAULT_FILE_PERMISSIONS = "0644"
+
+
+def _decode_extra_files_label(value: str) -> typing.List[dict]:
+    """Decode the base64-wrapped YAML/JSON payload of an `extra_files` label.
+
+    Operators must base64-encode the YAML/JSON list to keep it safe for
+    transport through Magnum's comma-separated label parser.  An empty or
+    missing value yields an empty list.
+    """
+    if not value:
+        return []
+    try:
+        decoded = stdlib_base64.b64decode(value, validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise exception.InvalidParameterValue(
+            err=f"extra_files label is not valid base64: {exc}"
+        )
+    try:
+        parsed = yaml.safe_load(decoded)
+    except yaml.YAMLError as exc:
+        raise exception.InvalidParameterValue(
+            err=f"extra_files label is not valid YAML/JSON: {exc}"
+        )
+    if parsed is None:
+        return []
+    if not isinstance(parsed, list):
+        raise exception.InvalidParameterValue(
+            err="extra_files label must decode to a YAML/JSON list"
+        )
+    return parsed
+
+
+def _normalize_extra_file(entry: dict) -> dict:
+    """Validate one entry and re-emit it in the wire shape."""
+    if not isinstance(entry, dict):
+        raise exception.InvalidParameterValue(
+            err="extra_files entries must be mappings"
+        )
+    path = entry.get("path")
+    if not path or not isinstance(path, str):
+        raise exception.InvalidParameterValue(
+            err="extra_files entries must include a non-empty 'path' string"
+        )
+    if not path.startswith("/"):
+        raise exception.InvalidParameterValue(
+            err=f"extra_files path must be absolute: {path!r}"
+        )
+
+    raw_content = entry.get("content", "")
+    if not isinstance(raw_content, str):
+        raise exception.InvalidParameterValue(
+            err=f"extra_files content for {path!r} must be a string"
+        )
+    encoding = entry.get("encoding")
+    if encoding is None:
+        wire_content = stdlib_base64.b64encode(raw_content.encode("utf-8")).decode(
+            "ascii"
+        )
+    elif encoding == "base64":
+        # Operator pre-encoded the content; round-trip it through the
+        # validator so we reject obvious corruption early.
+        try:
+            stdlib_base64.b64decode(raw_content, validate=True)
+        except ValueError as exc:
+            raise exception.InvalidParameterValue(
+                err=(
+                    f"extra_files content for {path!r} is declared base64 but "
+                    f"is not valid base64: {exc}"
+                )
+            )
+        wire_content = raw_content
+    else:
+        raise exception.InvalidParameterValue(
+            err=(
+                f"extra_files entry {path!r} has unsupported encoding "
+                f"{encoding!r} (expected omit or 'base64')"
+            )
+        )
+
+    owner = entry.get("owner", _DEFAULT_FILE_OWNER)
+    if not isinstance(owner, str) or not owner:
+        raise exception.InvalidParameterValue(
+            err=f"extra_files owner for {path!r} must be a non-empty string"
+        )
+    permissions = entry.get("permissions", _DEFAULT_FILE_PERMISSIONS)
+    if isinstance(permissions, int):
+        permissions = format(permissions, "04o")
+    if not isinstance(permissions, str) or not permissions:
+        raise exception.InvalidParameterValue(
+            err=(
+                f"extra_files permissions for {path!r} must be a non-empty "
+                f"string (e.g. '0600')"
+            )
+        )
+
+    return {
+        "path": path,
+        "owner": owner,
+        "permissions": permissions,
+        "content": wire_content,
+    }
+
+
+def get_extra_files(
+    cluster: magnum_objects.Cluster,
+    node_group: typing.Optional[magnum_objects.NodeGroup] = None,
+) -> typing.List[dict]:
+    """Build the `extraFiles` topology variable for one cluster + node group.
+
+    Cluster-level entries appear first, followed by node-group entries.
+    Both are rendered in the order they were declared by the operator.
+    Capped at :data:`EXTRA_CLOUD_INIT_MAX_FILES`; raises
+    :class:`magnum.common.exception.InvalidParameterValue` if exceeded.
+    """
+    cluster_entries = _decode_extra_files_label(cluster.labels.get("extra_files", ""))
+    ng_entries: typing.List[dict] = []
+    if node_group is not None:
+        ng_entries = _decode_extra_files_label(node_group.labels.get("extra_files", ""))
+
+    combined = [_normalize_extra_file(e) for e in (cluster_entries + ng_entries)]
+    if len(combined) > EXTRA_CLOUD_INIT_MAX_FILES:
+        raise exception.InvalidParameterValue(
+            err=(
+                f"extra_files exceeds the maximum of "
+                f"{EXTRA_CLOUD_INIT_MAX_FILES} entries (got {len(combined)})"
+            )
+        )
+    return combined
+
+
+def _split_kubeadm_commands(value: str) -> typing.List[str]:
+    """Split a `;;`-delimited command string, dropping empty segments."""
+    if not value:
+        return []
+    return [segment.strip() for segment in value.split(";;") if segment.strip()]
+
+
+def _get_extra_kubeadm_commands(
+    cluster: magnum_objects.Cluster,
+    node_group: typing.Optional[magnum_objects.NodeGroup],
+    label: str,
+    cap: int,
+) -> typing.List[str]:
+    cluster_cmds = _split_kubeadm_commands(cluster.labels.get(label, ""))
+    ng_cmds: typing.List[str] = []
+    if node_group is not None:
+        ng_cmds = _split_kubeadm_commands(node_group.labels.get(label, ""))
+    combined = cluster_cmds + ng_cmds
+    if len(combined) > cap:
+        raise exception.InvalidParameterValue(
+            err=(
+                f"{label} exceeds the maximum of {cap} entries "
+                f"(got {len(combined)})"
+            )
+        )
+    return combined
+
+
+def get_extra_pre_kubeadm_commands(
+    cluster: magnum_objects.Cluster,
+    node_group: typing.Optional[magnum_objects.NodeGroup] = None,
+) -> typing.List[str]:
+    """`;;`-separated `extra_pre_kubeadm_commands` label, cluster + NG merged."""
+    return _get_extra_kubeadm_commands(
+        cluster,
+        node_group,
+        "extra_pre_kubeadm_commands",
+        EXTRA_CLOUD_INIT_MAX_PRE_COMMANDS,
+    )
+
+
+def get_extra_post_kubeadm_commands(
+    cluster: magnum_objects.Cluster,
+    node_group: typing.Optional[magnum_objects.NodeGroup] = None,
+) -> typing.List[str]:
+    """`;;`-separated `extra_post_kubeadm_commands` label, cluster + NG merged."""
+    return _get_extra_kubeadm_commands(
+        cluster,
+        node_group,
+        "extra_post_kubeadm_commands",
+        EXTRA_CLOUD_INIT_MAX_POST_COMMANDS,
+    )

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -674,35 +674,73 @@ EXTRA_CLOUD_INIT_MAX_POST_COMMANDS = 16
 _DEFAULT_FILE_OWNER = "root:root"
 _DEFAULT_FILE_PERMISSIONS = "0644"
 
+_BASE64_RE = re.compile(r"^[A-Za-z0-9+/]+={0,2}$")
+
+
+def _looks_like_base64_text(value: str) -> bool:
+    """Heuristic: detect content that is almost certainly already base64.
+
+    Used to surface a clear error when an operator pre-encodes ``content`` but
+    forgets to set ``encoding: base64`` (which would otherwise silently double
+    encode the payload).  The heuristic is deliberately conservative — it only
+    matches strings that look exactly like canonical base64 (no whitespace, no
+    punctuation), are long enough to be intentional, and round-trip through
+    ``b64decode`` to valid UTF-8.  Any plausible script or config file with
+    spaces, newlines, or special characters will fail the check.
+    """
+    if not value or len(value) < 16 or len(value) % 4 != 0:
+        return False
+    if not _BASE64_RE.match(value):
+        return False
+    try:
+        decoded = stdlib_base64.b64decode(value, validate=True)
+        decoded.decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return False
+    return True
+
 
 def _decode_extra_files_label(value: str) -> typing.List[dict]:
-    """Decode the base64-wrapped YAML/JSON payload of an `extra_files` label.
+    """Decode the YAML/JSON payload of an `extra_files` label.
 
-    Operators must base64-encode the YAML/JSON list to keep it safe for
-    transport through Magnum's comma-separated label parser.  An empty or
-    missing value yields an empty list.
+    The label value may be supplied either as a base64-wrapped YAML/JSON list
+    (recommended for transport-safety through Magnum's comma-separated label
+    parser) or as a plain YAML/JSON list when the operator pipeline already
+    handles encoding (e.g. Heat parameters, Terraform, kubectl YAML manifests).
+    An empty or missing value yields an empty list.
     """
     if not value:
         return []
+
+    # Try base64-wrapped form first (the recommended/documented path).
+    decoded: typing.Optional[str] = None
     try:
         decoded = stdlib_base64.b64decode(value, validate=True).decode("utf-8")
-    except (ValueError, UnicodeDecodeError) as exc:
-        raise exception.InvalidParameterValue(
-            err=f"extra_files label is not valid base64: {exc}"
+    except (ValueError, UnicodeDecodeError):
+        decoded = None
+
+    candidates = [decoded, value] if decoded is not None else [value]
+    last_error: typing.Optional[Exception] = None
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            parsed = yaml.safe_load(candidate)
+        except yaml.YAMLError as exc:
+            last_error = exc
+            continue
+        if parsed is None:
+            return []
+        if isinstance(parsed, list):
+            return parsed
+        last_error = ValueError("extra_files label must decode to a YAML/JSON list")
+
+    raise exception.InvalidParameterValue(
+        err=(
+            "extra_files label must be a base64-wrapped YAML/JSON list or a "
+            f"plain YAML/JSON list: {last_error}"
         )
-    try:
-        parsed = yaml.safe_load(decoded)
-    except yaml.YAMLError as exc:
-        raise exception.InvalidParameterValue(
-            err=f"extra_files label is not valid YAML/JSON: {exc}"
-        )
-    if parsed is None:
-        return []
-    if not isinstance(parsed, list):
-        raise exception.InvalidParameterValue(
-            err="extra_files label must decode to a YAML/JSON list"
-        )
-    return parsed
+    )
 
 
 def _normalize_extra_file(entry: dict) -> dict:
@@ -728,6 +766,15 @@ def _normalize_extra_file(entry: dict) -> dict:
         )
     encoding = entry.get("encoding")
     if encoding is None:
+        if _looks_like_base64_text(raw_content):
+            raise exception.InvalidParameterValue(
+                err=(
+                    f"extra_files content for {path!r} appears to already be "
+                    "base64-encoded but no 'encoding' field was set; either "
+                    "remove the pre-encoding or add `encoding: base64` to the "
+                    "entry to avoid double-encoding"
+                )
+            )
         wire_content = stdlib_base64.b64encode(raw_content.encode("utf-8")).decode(
             "ascii"
         )

--- a/src/features/admission_plugins.rs
+++ b/src/features/admission_plugins.rs
@@ -67,7 +67,6 @@ mod tests {
     use crate::{features::test::TestClusterResources, resources::fixtures::default_values};
     use pretty_assertions::assert_eq;
 
-
     #[test]
     fn test_admission_plugins_patch() {
         let feature = Feature {};

--- a/src/features/api_server_load_balancer.rs
+++ b/src/features/api_server_load_balancer.rs
@@ -34,7 +34,11 @@ pub struct APIServerLoadBalancerConfig {
     #[builder(default)]
     pub flavor: String,
 
-    #[serde(default, skip_serializing_if = "str::is_empty", rename = "availabilityZone")]
+    #[serde(
+        default,
+        skip_serializing_if = "str::is_empty",
+        rename = "availabilityZone"
+    )]
     #[builder(default)]
     pub availability_zone: String,
 }
@@ -177,9 +181,8 @@ mod tests {
         let feature = Feature {};
 
         let mut values = default_values();
-        values.api_server_load_balancer = APIServerLoadBalancerConfig::builder()
-            .enabled(true)
-            .build();
+        values.api_server_load_balancer =
+            APIServerLoadBalancerConfig::builder().enabled(true).build();
 
         let patches = feature.patches();
 

--- a/src/features/boot_volume.rs
+++ b/src/features/boot_volume.rs
@@ -99,7 +99,8 @@ mod tests {
             OpenStackMachineTemplateTemplateSpecRootVolume,
             OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone,
         },
-        features::test::TestClusterResources, resources::fixtures::default_values,
+        features::test::TestClusterResources,
+        resources::fixtures::default_values,
     };
     use pretty_assertions::assert_eq;
 
@@ -129,10 +130,12 @@ mod tests {
             Some(OpenStackMachineTemplateTemplateSpecRootVolume {
                 r#type: Some(values.clone().boot_volume.r#type),
                 size_gi_b: values.clone().boot_volume.size,
-                availability_zone: Some(OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone {
-                    name: Some(values.clone().boot_volume_availability_zone),
-                    ..Default::default()
-                }),
+                availability_zone: Some(
+                    OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone {
+                        name: Some(values.clone().boot_volume_availability_zone),
+                        ..Default::default()
+                    }
+                ),
             })
         );
 
@@ -146,10 +149,12 @@ mod tests {
             Some(OpenStackMachineTemplateTemplateSpecRootVolume {
                 r#type: Some(values.clone().boot_volume.r#type),
                 size_gi_b: values.clone().boot_volume.size,
-                availability_zone: Some(OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone {
-                    name: Some(values.clone().boot_volume_availability_zone),
-                    ..Default::default()
-                }),
+                availability_zone: Some(
+                    OpenStackMachineTemplateTemplateSpecRootVolumeAvailabilityZone {
+                        name: Some(values.clone().boot_volume_availability_zone),
+                        ..Default::default()
+                    }
+                ),
             })
         );
     }

--- a/src/features/disable_api_server_floating_ip.rs
+++ b/src/features/disable_api_server_floating_ip.rs
@@ -44,9 +44,7 @@ impl ClusterFeaturePatches for Feature {
     fn patches(&self) -> Vec<ClusterClassPatches> {
         vec![ClusterClassPatches {
             name: "disableAPIServerFloatingIP".into(),
-            enabled_if: Some(
-                "{{ if .disableAPIServerFloatingIPManaged }}true{{end}}".into(),
-            ),
+            enabled_if: Some("{{ if .disableAPIServerFloatingIPManaged }}true{{end}}".into()),
             definitions: Some(vec![ClusterClassPatchesDefinitions {
                 selector: ClusterClassPatchesDefinitionsSelector {
                     api_version: OpenStackClusterTemplate::api_resource().api_version,

--- a/src/features/extra_cloud_init.rs
+++ b/src/features/extra_cloud_init.rs
@@ -1,0 +1,496 @@
+use crate::{
+    cluster_api::{
+        clusterclasses::{
+            ClusterClassPatches, ClusterClassPatchesDefinitions,
+            ClusterClassPatchesDefinitionsJsonPatches,
+            ClusterClassPatchesDefinitionsJsonPatchesValueFrom,
+            ClusterClassPatchesDefinitionsSelector,
+            ClusterClassPatchesDefinitionsSelectorMatchResources,
+            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass,
+            ClusterClassVariables, ClusterClassVariablesSchema,
+        },
+        kubeadmconfigtemplates::{
+            KubeadmConfigTemplate, KubeadmConfigTemplateTemplateSpecFiles,
+            KubeadmConfigTemplateTemplateSpecFilesEncoding,
+        },
+        kubeadmcontrolplanetemplates::{
+            KubeadmControlPlaneTemplate,
+            KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFiles,
+            KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFilesEncoding,
+        },
+    },
+    features::{
+        ClusterClassVariablesSchemaExt, ClusterFeatureEntry, ClusterFeaturePatches,
+        ClusterFeatureVariables,
+    },
+};
+use cluster_feature_derive::ClusterFeatureValues;
+use kube::CustomResourceExt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Maximum number of operator-supplied extra files that can be injected
+/// per cluster (cluster-level + node-group merged).  Enforced on the
+/// Python side via `utils.get_extra_files`.  Ten slots is more than
+/// enough for the common netplan / udev / systemd-unit use cases while
+/// keeping the rendered ClusterClass small.
+pub const MAX_EXTRA_FILES: usize = 10;
+
+/// Maximum number of operator-supplied pre-kubeadm shell commands.
+pub const MAX_PRE_KUBEADM_COMMANDS: usize = 16;
+
+/// Maximum number of operator-supplied post-kubeadm shell commands.
+pub const MAX_POST_KUBEADM_COMMANDS: usize = 16;
+
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Default, PartialEq, Debug)]
+pub struct ExtraFile {
+    pub path: String,
+
+    #[serde(default = "default_owner")]
+    pub owner: String,
+
+    #[serde(default = "default_permissions")]
+    pub permissions: String,
+
+    /// Base64-encoded file contents.  The Python side base64-encodes any
+    /// operator-supplied raw content before stamping it into the topology
+    /// variable, so the wire value here is always base64.
+    pub content: String,
+}
+
+fn default_owner() -> String {
+    "root:root".into()
+}
+
+fn default_permissions() -> String {
+    "0644".into()
+}
+
+#[derive(Serialize, Deserialize, ClusterFeatureValues)]
+#[allow(dead_code)]
+pub struct FeatureValues {
+    #[serde(rename = "extraFiles")]
+    pub extra_files: Vec<ExtraFile>,
+
+    #[serde(rename = "extraPreKubeadmCommands")]
+    pub extra_pre_kubeadm_commands: Vec<String>,
+
+    #[serde(rename = "extraPostKubeadmCommands")]
+    pub extra_post_kubeadm_commands: Vec<String>,
+}
+
+pub struct Feature {}
+
+fn file_template_for_index(idx: usize) -> String {
+    // Render a single KubeadmConfig file entry via go-template.  The
+    // outer YAML serialization uses `KubeadmControlPlaneTemplate...Files`
+    // (or its KubeadmConfigTemplate sibling) just to get the field
+    // ordering right; the actual values come from gtmpl indexing.
+    let stub = KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFiles {
+        path: format!("{{{{ (index .extraFiles {}).path }}}}", idx),
+        owner: Some(format!("{{{{ (index .extraFiles {}).owner }}}}", idx)),
+        permissions: Some(format!(
+            "{{{{ (index .extraFiles {}).permissions }}}}",
+            idx
+        )),
+        encoding: Some(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFilesEncoding::Base64),
+        content: Some(format!("{{{{ (index .extraFiles {}).content }}}}", idx)),
+        ..Default::default()
+    };
+    serde_yaml::to_string(&stub).unwrap()
+}
+
+fn worker_file_template_for_index(idx: usize) -> String {
+    let stub = KubeadmConfigTemplateTemplateSpecFiles {
+        path: format!("{{{{ (index .extraFiles {}).path }}}}", idx),
+        owner: Some(format!("{{{{ (index .extraFiles {}).owner }}}}", idx)),
+        permissions: Some(format!(
+            "{{{{ (index .extraFiles {}).permissions }}}}",
+            idx
+        )),
+        encoding: Some(KubeadmConfigTemplateTemplateSpecFilesEncoding::Base64),
+        content: Some(format!("{{{{ (index .extraFiles {}).content }}}}", idx)),
+        ..Default::default()
+    };
+    serde_yaml::to_string(&stub).unwrap()
+}
+
+fn extra_file_patch(idx: usize) -> ClusterClassPatches {
+    ClusterClassPatches {
+        name: format!("extraFile{}", idx),
+        enabled_if: Some(format!(
+            "{{{{ if gt (len .extraFiles) {} }}}}true{{{{end}}}}",
+            idx
+        )),
+        definitions: Some(vec![
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmControlPlaneTemplate::api_resource().api_version,
+                    kind: KubeadmControlPlaneTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        control_plane: Some(true),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: "/spec/template/spec/kubeadmConfigSpec/files/-".into(),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(file_template_for_index(idx)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmConfigTemplate::api_resource().api_version,
+                    kind: KubeadmConfigTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        machine_deployment_class: Some(
+                            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                names: Some(vec!["default-worker".into()]),
+                            },
+                        ),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: "/spec/template/spec/files/-".into(),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(worker_file_template_for_index(idx)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+        ]),
+        ..Default::default()
+    }
+}
+
+fn extra_command_patch(
+    idx: usize,
+    variable_name: &str,
+    kubeadm_path_segment: &str,
+    patch_name_prefix: &str,
+) -> ClusterClassPatches {
+    let template = format!("{{{{ index .{} {} }}}}", variable_name, idx);
+    ClusterClassPatches {
+        name: format!("{}{}", patch_name_prefix, idx),
+        enabled_if: Some(format!(
+            "{{{{ if gt (len .{}) {} }}}}true{{{{end}}}}",
+            variable_name, idx
+        )),
+        definitions: Some(vec![
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmControlPlaneTemplate::api_resource().api_version,
+                    kind: KubeadmControlPlaneTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        control_plane: Some(true),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: format!(
+                        "/spec/template/spec/kubeadmConfigSpec/{}/-",
+                        kubeadm_path_segment
+                    ),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(template.clone()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+            ClusterClassPatchesDefinitions {
+                selector: ClusterClassPatchesDefinitionsSelector {
+                    api_version: KubeadmConfigTemplate::api_resource().api_version,
+                    kind: KubeadmConfigTemplate::api_resource().kind,
+                    match_resources: ClusterClassPatchesDefinitionsSelectorMatchResources {
+                        machine_deployment_class: Some(
+                            ClusterClassPatchesDefinitionsSelectorMatchResourcesMachineDeploymentClass {
+                                names: Some(vec!["default-worker".into()]),
+                            },
+                        ),
+                        ..Default::default()
+                    },
+                },
+                json_patches: vec![ClusterClassPatchesDefinitionsJsonPatches {
+                    op: "add".into(),
+                    path: format!("/spec/template/spec/{}/-", kubeadm_path_segment),
+                    value_from: Some(ClusterClassPatchesDefinitionsJsonPatchesValueFrom {
+                        template: Some(template),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+            },
+        ]),
+        ..Default::default()
+    }
+}
+
+impl ClusterFeaturePatches for Feature {
+    fn patches(&self) -> Vec<ClusterClassPatches> {
+        let mut patches = Vec::with_capacity(
+            MAX_EXTRA_FILES + MAX_PRE_KUBEADM_COMMANDS + MAX_POST_KUBEADM_COMMANDS,
+        );
+
+        for idx in 0..MAX_EXTRA_FILES {
+            patches.push(extra_file_patch(idx));
+        }
+        for idx in 0..MAX_PRE_KUBEADM_COMMANDS {
+            patches.push(extra_command_patch(
+                idx,
+                "extraPreKubeadmCommands",
+                "preKubeadmCommands",
+                "extraPreKubeadmCommand",
+            ));
+        }
+        for idx in 0..MAX_POST_KUBEADM_COMMANDS {
+            patches.push(extra_command_patch(
+                idx,
+                "extraPostKubeadmCommands",
+                "postKubeadmCommands",
+                "extraPostKubeadmCommand",
+            ));
+        }
+
+        patches
+    }
+}
+
+inventory::submit! {
+    ClusterFeatureEntry { feature: &Feature {} }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test::TestClusterResources;
+    use crate::resources::fixtures::default_values;
+    use base64::prelude::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_no_extras_renders_no_files_or_commands() {
+        let feature = Feature {};
+        let mut values = default_values();
+        values.extra_files = vec![];
+        values.extra_pre_kubeadm_commands = vec![];
+        values.extra_post_kubeadm_commands = vec![];
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        // The control-plane KubeadmConfigSpec.files / preKubeadmCommands /
+        // postKubeadmCommands lists should still be the fixture defaults
+        // (no entries injected by this feature).
+        let kcp_spec = &resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec;
+        let kcp_extra_count = kcp_spec
+            .files
+            .as_ref()
+            .map(|files| {
+                files
+                    .iter()
+                    .filter(|f| f.path == "/etc/extra")
+                    .count()
+            })
+            .unwrap_or(0);
+        assert_eq!(kcp_extra_count, 0);
+    }
+
+    #[test]
+    fn test_extra_files_appended_to_kcp_and_kct() {
+        let feature = Feature {};
+        let mut values = default_values();
+        values.extra_files = vec![
+            ExtraFile {
+                path: "/etc/netplan/99-mcapi.yaml".into(),
+                owner: "root:root".into(),
+                permissions: "0600".into(),
+                content: BASE64_STANDARD.encode(b"network:\n  version: 2\n"),
+            },
+            ExtraFile {
+                path: "/etc/sysctl.d/99-mcapi.conf".into(),
+                owner: "root:root".into(),
+                permissions: "0644".into(),
+                content: BASE64_STANDARD.encode(b"net.ipv4.ip_forward=1\n"),
+            },
+        ];
+        values.extra_pre_kubeadm_commands = vec![];
+        values.extra_post_kubeadm_commands = vec![];
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let kcp_files = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .files
+            .clone()
+            .expect("kcp files should exist");
+        let extras: Vec<_> = kcp_files
+            .iter()
+            .filter(|f| {
+                f.path == "/etc/netplan/99-mcapi.yaml"
+                    || f.path == "/etc/sysctl.d/99-mcapi.conf"
+            })
+            .collect();
+        assert_eq!(extras.len(), 2);
+        assert_eq!(extras[0].path, "/etc/netplan/99-mcapi.yaml");
+        assert_eq!(extras[0].permissions, Some("0600".into()));
+        assert_eq!(
+            extras[0].encoding,
+            Some(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFilesEncoding::Base64)
+        );
+        assert_eq!(
+            extras[0].content,
+            Some(BASE64_STANDARD.encode(b"network:\n  version: 2\n"))
+        );
+
+        let kct_files = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .as_ref()
+            .and_then(|s| s.files.clone())
+            .expect("kct files should exist");
+        let kct_extras: Vec<_> = kct_files
+            .iter()
+            .filter(|f| {
+                f.path == "/etc/netplan/99-mcapi.yaml"
+                    || f.path == "/etc/sysctl.d/99-mcapi.conf"
+            })
+            .collect();
+        assert_eq!(kct_extras.len(), 2);
+    }
+
+    #[test]
+    fn test_extra_pre_and_post_kubeadm_commands_appended() {
+        let feature = Feature {};
+        let mut values = default_values();
+        values.extra_files = vec![];
+        values.extra_pre_kubeadm_commands = vec![
+            "netplan generate".into(),
+            "netplan apply".into(),
+            "sleep 3".into(),
+        ];
+        values.extra_post_kubeadm_commands =
+            vec!["echo bootstrap done > /var/log/mcapi-extra.log".into()];
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let kcp_pre = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .pre_kubeadm_commands
+            .clone()
+            .expect("kcp preKubeadmCommands should exist");
+        for cmd in &["netplan generate", "netplan apply", "sleep 3"] {
+            assert!(
+                kcp_pre.iter().any(|c| c == cmd),
+                "expected kcp.preKubeadmCommands to contain {}, got {:?}",
+                cmd,
+                kcp_pre
+            );
+        }
+
+        let kcp_post = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .post_kubeadm_commands
+            .clone()
+            .expect("kcp postKubeadmCommands should exist");
+        assert!(kcp_post
+            .iter()
+            .any(|c| c == "echo bootstrap done > /var/log/mcapi-extra.log"));
+
+        let kct_pre = resources
+            .kubeadm_config_template
+            .spec
+            .template
+            .spec
+            .as_ref()
+            .and_then(|s| s.pre_kubeadm_commands.clone())
+            .expect("kct preKubeadmCommands should exist");
+        for cmd in &["netplan generate", "netplan apply", "sleep 3"] {
+            assert!(
+                kct_pre.iter().any(|c| c == cmd),
+                "expected kct.preKubeadmCommands to contain {}, got {:?}",
+                cmd,
+                kct_pre
+            );
+        }
+    }
+
+    #[test]
+    fn test_existing_pre_kubeadm_commands_not_clobbered() {
+        // Make sure our /-/ append patches don't replace the seeded entries
+        // from sibling features (e.g. containerd_config seeds a
+        // `systemctl restart containerd` line via the
+        // KUBEADM_CONTROL_PLANE_TEMPLATE fixture).
+        let feature = Feature {};
+        let mut values = default_values();
+        values.extra_files = vec![];
+        values.extra_pre_kubeadm_commands = vec!["echo extra".into()];
+        values.extra_post_kubeadm_commands = vec![];
+
+        let mut resources = TestClusterResources::new();
+        let baseline_pre = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .pre_kubeadm_commands
+            .clone()
+            .unwrap_or_default();
+
+        let patches = feature.patches();
+        resources.apply_patches(&patches, &values);
+
+        let after = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .pre_kubeadm_commands
+            .clone()
+            .expect("kcp preKubeadmCommands should exist");
+
+        for original in &baseline_pre {
+            assert!(
+                after.contains(original),
+                "expected baseline command {:?} to still be present after extra_cloud_init patches; got {:?}",
+                original,
+                after
+            );
+        }
+        assert!(after.contains(&"echo extra".to_string()));
+    }
+}

--- a/src/features/extra_cloud_init.rs
+++ b/src/features/extra_cloud_init.rs
@@ -89,11 +89,10 @@ fn file_template_for_index(idx: usize) -> String {
     let stub = KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFiles {
         path: format!("{{{{ (index .extraFiles {}).path }}}}", idx),
         owner: Some(format!("{{{{ (index .extraFiles {}).owner }}}}", idx)),
-        permissions: Some(format!(
-            "{{{{ (index .extraFiles {}).permissions }}}}",
-            idx
-        )),
-        encoding: Some(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFilesEncoding::Base64),
+        permissions: Some(format!("{{{{ (index .extraFiles {}).permissions }}}}", idx)),
+        encoding: Some(
+            KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFilesEncoding::Base64,
+        ),
         content: Some(format!("{{{{ (index .extraFiles {}).content }}}}", idx)),
         ..Default::default()
     };
@@ -104,10 +103,7 @@ fn worker_file_template_for_index(idx: usize) -> String {
     let stub = KubeadmConfigTemplateTemplateSpecFiles {
         path: format!("{{{{ (index .extraFiles {}).path }}}}", idx),
         owner: Some(format!("{{{{ (index .extraFiles {}).owner }}}}", idx)),
-        permissions: Some(format!(
-            "{{{{ (index .extraFiles {}).permissions }}}}",
-            idx
-        )),
+        permissions: Some(format!("{{{{ (index .extraFiles {}).permissions }}}}", idx)),
         encoding: Some(KubeadmConfigTemplateTemplateSpecFilesEncoding::Base64),
         content: Some(format!("{{{{ (index .extraFiles {}).content }}}}", idx)),
         ..Default::default()
@@ -300,12 +296,7 @@ mod tests {
         let kcp_extra_count = kcp_spec
             .files
             .as_ref()
-            .map(|files| {
-                files
-                    .iter()
-                    .filter(|f| f.path == "/etc/extra")
-                    .count()
-            })
+            .map(|files| files.iter().filter(|f| f.path == "/etc/extra").count())
             .unwrap_or(0);
         assert_eq!(kcp_extra_count, 0);
     }
@@ -347,8 +338,7 @@ mod tests {
         let extras: Vec<_> = kcp_files
             .iter()
             .filter(|f| {
-                f.path == "/etc/netplan/99-mcapi.yaml"
-                    || f.path == "/etc/sysctl.d/99-mcapi.conf"
+                f.path == "/etc/netplan/99-mcapi.yaml" || f.path == "/etc/sysctl.d/99-mcapi.conf"
             })
             .collect();
         assert_eq!(extras.len(), 2);
@@ -374,8 +364,7 @@ mod tests {
         let kct_extras: Vec<_> = kct_files
             .iter()
             .filter(|f| {
-                f.path == "/etc/netplan/99-mcapi.yaml"
-                    || f.path == "/etc/sysctl.d/99-mcapi.conf"
+                f.path == "/etc/netplan/99-mcapi.yaml" || f.path == "/etc/sysctl.d/99-mcapi.conf"
             })
             .collect();
         assert_eq!(kct_extras.len(), 2);

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -45,7 +45,10 @@ use crate::cluster_api::{
 };
 use base64::prelude::*;
 use maplit::btreemap;
-use schemars::{generate::SchemaGenerator, JsonSchema, Schema};
+use schemars::{
+    generate::{SchemaGenerator, SchemaSettings},
+    JsonSchema, Schema,
+};
 use std::sync::LazyLock;
 
 pub mod admission_plugins;
@@ -134,8 +137,7 @@ pub fn assert_optional_string_schema_for_field<T: JsonSchema>(field: &str) {
     // JSONSchemaProps.Type is a plain string and rejects JSON arrays.
     let field_type = &v["properties"][field]["type"];
     assert_eq!(
-        field_type,
-        "string",
+        field_type, "string",
         "field `{field}` type must be a plain string (CAPI rejects arrays)"
     );
 }
@@ -168,7 +170,15 @@ pub trait ClusterClassVariablesSchemaExt {
 
 impl ClusterClassVariablesSchemaExt for ClusterClassVariablesSchema {
     fn from_object<T: JsonSchema>() -> Self {
-        let gen = SchemaGenerator::default();
+        // CAPI's ClusterClass admission webhook validates variables with
+        // a structural-schema check that rejects `$ref` indirection — every
+        // node must declare an explicit `type`.  Force schemars to inline
+        // nested object schemas so user-defined element types (e.g. the
+        // `extra_files` `ExtraFile` struct) render as `{type: object, ...}`
+        // rather than `{$ref: ...}`.
+        let mut settings = SchemaSettings::default();
+        settings.inline_subschemas = true;
+        let gen = SchemaGenerator::new(settings);
         let schema = gen.into_root_schema_for::<T>();
         Self::from_root_schema(schema)
     }
@@ -342,8 +352,8 @@ pub static KUBEADM_CONFIG_TEMPLATE: LazyLock<KubeadmConfigTemplate> =
                         ),
                         ..Default::default()
                     }),
-                    pre_kubeadm_commands: Some(vec![]),
-                    post_kubeadm_commands: Some(vec![]),
+                    pre_kubeadm_commands: Some(vec!["echo PLACEHOLDER".to_string()]),
+                    post_kubeadm_commands: Some(vec!["echo PLACEHOLDER".to_string()]),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -59,6 +59,7 @@ pub mod containerd_config;
 pub mod control_plane_availability_zones;
 pub mod disable_api_server_floating_ip;
 pub mod external_network;
+pub mod extra_cloud_init;
 pub mod flavors;
 pub mod image_repository;
 pub mod images;
@@ -341,6 +342,8 @@ pub static KUBEADM_CONFIG_TEMPLATE: LazyLock<KubeadmConfigTemplate> =
                         ),
                         ..Default::default()
                     }),
+                    pre_kubeadm_commands: Some(vec![]),
+                    post_kubeadm_commands: Some(vec![]),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/src/features/operating_system.rs
+++ b/src/features/operating_system.rs
@@ -419,11 +419,7 @@ mod tests {
             );
         }
 
-        let kct_spec = resources
-            .kubeadm_config_template
-            .spec
-            .template
-            .spec;
+        let kct_spec = resources.kubeadm_config_template.spec.template.spec;
 
         if let Some(spec) = kct_spec {
             if let Some(files) = spec.files {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -273,6 +273,9 @@ pub mod fixtures {
             .etcd_volume_type("".into())
             .availability_zone("az1".into())
             .admission_control_list("NodeRestriction".into())
+            .extra_files(Vec::<crate::features::extra_cloud_init::ExtraFile>::new())
+            .extra_pre_kubeadm_commands(Vec::<String>::new())
+            .extra_post_kubeadm_commands(Vec::<String>::new())
             .build()
     }
 }
@@ -310,7 +313,7 @@ mod tests {
         let values = default_values();
         let variables: Vec<ClusterTopologyVariables> = values.into();
 
-        assert_eq!(variables.len(), 39);
+        assert_eq!(variables.len(), 42);
 
         for var in &variables {
             match var.name.as_str() {
@@ -445,6 +448,21 @@ mod tests {
                 }
                 "admissionControlList" => {
                     assert_eq!(var.value, json!(default_values().admission_control_list));
+                }
+                "extraFiles" => {
+                    assert_eq!(var.value, json!(default_values().extra_files));
+                }
+                "extraPreKubeadmCommands" => {
+                    assert_eq!(
+                        var.value,
+                        json!(default_values().extra_pre_kubeadm_commands)
+                    );
+                }
+                "extraPostKubeadmCommands" => {
+                    assert_eq!(
+                        var.value,
+                        json!(default_values().extra_post_kubeadm_commands)
+                    );
                 }
                 other => panic!("Unexpected field name: {}", other),
             }


### PR DESCRIPTION
## Summary

Adds three new Magnum labels for cloud-init passthrough on every cluster node, working uniformly on **VM and bare-metal** substrates:

- `extra_files` — base64-encoded YAML/JSON list of files to drop on the node.
- `extra_pre_kubeadm_commands` — `;;`-separated shell commands run **before** `kubeadm init/join`.
- `extra_post_kubeadm_commands` — `;;`-separated shell commands run **after** `kubeadm init/join`.

All three honor cluster-level **and** node-group-level labels; node-group entries are appended after cluster entries.

## Driving use case

Apply a custom `netplan` configuration before `kubeadm` runs so multi-NIC / VLAN / bonded layouts come up first:

```bash
PAYLOAD=$(base64 -w0 <<'EOF'
- path: /etc/netplan/99-mcapi.yaml
  permissions: "0600"
  content: |
    network:
      version: 2
      ethernets:
        enp4s0: { dhcp4: true, mtu: 1450 }
EOF
)
openstack coe cluster create ... --labels \
  extra_files=$PAYLOAD,\
  extra_pre_kubeadm_commands="netplan generate;;netplan apply;;sleep 3"
```

The same plumbing supports any operator-injected file or command (CA bundles, sysctl tweaks, etc.) without rebuilding the node image.

## Implementation notes

- **Slot-based ClusterClassPatches.** 10 file slots, 16 pre-command slots, 16 post-command slots.  Each slot has its own `enabledIf: gt (len .extraXxx) <i>` gate and emits an `op: add` against the parent list path.  Per-element appends were chosen over parent-replace because `preKubeadmCommands` is shared with `containerd_config`, `keystone_auth`, and `operating_system` features — replacing it would clobber them.
- **Python helpers** in `magnum_cluster_api/utils.py` validate paths (must be absolute), normalize ownership/permissions, base64-encode raw `content` (or pass through pre-encoded), split commands on `;;`, and enforce per-list caps that mirror the Rust slot counts.
- **`build.rs`** gains an `extract_vec_inner()` helper so a user-defined `Vec<ExtraFile>` gets qualified correctly in the generated `Values` struct.

## Tests

- `cargo test --lib`: 146/146 passing (4 new in `extra_cloud_init`).
- `pytest magnum_cluster_api/tests/unit/test_utils.py::TestExtraCloudInit`: 13/13 passing — empty defaults, base64 round-trip, NG merge, validation errors, and cap enforcement.

## Out of scope (follow-ups)

- GPU Operator addon (planned as a separate PR — substrate-agnostic GPU scheduling via the NVIDIA GPU Operator helm chart).
- Per-NG override of the *cluster*-level entries (currently NG entries are *appended*, not overriding).

## Status

**Draft.**  Slot-based ClusterClass shape needs a smoke test on a real cluster (test target: atmospehre aio ovn) before marking ready.

---

Companion PR: [vexxhost/capo-image-elements#158](https://github.com/vexxhost/capo-image-elements/pull/158) (publish raw alongside qcow2 — needed for Ironic BM).