### PR TITLE
fix(labels): merge cluster_template labels into sparse cluster.labels

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -69,6 +69,15 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
+        # See note in delete_cluster: Magnum REPLACES template labels with the
+        # cluster's own --labels list.  Merge any missing keys back in so the
+        # Rust driver and downstream consumers see a complete label dict.
+        original_labels = dict(cluster.labels or {})
+        utils.fill_missing_labels_from_template(cluster)
+        if cluster.labels != original_labels:
+            cluster.labels = dict(cluster.labels)
+            cluster.save()
+
         self.rust_driver.create_cluster(cluster)
 
         utils.validate_cluster(context, cluster)
@@ -219,7 +228,8 @@ class BaseDriver(driver.Driver):
 
             capi_cluster.reload()
             status_map = {
-                c["type"]: c["status"] for c in capi_cluster.obj["status"]["conditions"]
+                c["type"]: c["status"]
+                for c in capi_cluster.obj.get("status", {}).get("conditions", [])
             }
 
             for condition in ("ControlPlaneReady", "InfrastructureReady", "Ready"):
@@ -438,6 +448,13 @@ class BaseDriver(driver.Driver):
         #               https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/842
         #               https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/990
         utils.delete_loadbalancers(context, cluster)
+
+        # NOTE(rlin): Magnum's `cluster create --labels` REPLACES (rather than
+        # merges) the cluster_template labels.  This means a cluster row may
+        # legitimately be missing keys (e.g. ``kube_tag``) that the Rust driver
+        # needs to deserialize ClusterLabels.  Merge template labels as a
+        # fallback so delete never trips over a sparse label dict.
+        utils.fill_missing_labels_from_template(cluster)
 
         self.rust_driver.delete_cluster(cluster)
         resources.Cluster(

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -212,6 +212,26 @@ class TestDriver:
             json=json,
         )
 
+    def _response_for_machine_sets(self, deployment_name):
+        return responses.Response(
+            responses.GET,
+            "http://localhost/apis/%s/namespaces/%s/%s"
+            % (
+                objects.MachineSet.version,
+                "magnum-system",
+                objects.MachineSet.endpoint,
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "labelSelector": "cluster.x-k8s.io/cluster-name=%s,topology.cluster.x-k8s.io/deployment-name=%s"
+                        % (self.cluster.stack_id, deployment_name)
+                    }
+                ),
+            ],
+            json={"items": []},
+        )
+
     def test_create_cluster(
         self,
         requests_mock,
@@ -339,6 +359,113 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
+    def test_create_cluster_persists_template_labels_for_sparse_cluster_labels(
+        self,
+        requests_mock,
+        context,
+        ubuntu_driver,
+        cluster_template,
+        mock_validate_cluster,
+        mock_rust_driver,
+        mocker,
+    ):
+        self.cluster.labels = {"smoke": "test"}
+        cluster_template.labels = {
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "amphorav2",
+        }
+        mocker.patch.object(ubuntu_driver, "_create_cluster")
+        mocker.patch(
+            "magnum_cluster_api.utils.generate_cluster_api_name",
+            return_value="kube-test",
+        )
+
+        ubuntu_driver.create_cluster(context, self.cluster, 60)
+
+        assert self.cluster.labels == {
+            "smoke": "test",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "amphorav2",
+        }
+        assert self.cluster.save.call_count == 2
+
+    def test_create_cluster_passes_filled_labels_to_rust_driver(
+        self,
+        requests_mock,
+        context,
+        ubuntu_driver,
+        cluster_template,
+        mock_validate_cluster,
+        mocker,
+    ):
+        captured_labels = {}
+
+        def capture_labels(cluster):
+            captured_labels.update(cluster.labels)
+
+        self.cluster.labels = {"audit_log_enabled": "true"}
+        self.cluster.labels_skipped = {
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "ovn",
+        }
+        cluster_template.labels = {"kube_tag": "v1.30.0"}
+        ubuntu_driver.rust_driver = mock.MagicMock()
+        ubuntu_driver.rust_driver.create_cluster.side_effect = capture_labels
+        mocker.patch.object(ubuntu_driver, "_create_cluster")
+        mocker.patch(
+            "magnum_cluster_api.utils.generate_cluster_api_name",
+            return_value="kube-test",
+        )
+
+        ubuntu_driver.create_cluster(context, self.cluster, 60)
+
+        ubuntu_driver.rust_driver.create_cluster.assert_called_once_with(self.cluster)
+        assert captured_labels == {
+            "audit_log_enabled": "true",
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "ovn",
+        }
+
+    def test_delete_cluster_passes_filled_labels_to_rust_driver(
+        self,
+        requests_mock,
+        context,
+        ubuntu_driver,
+        cluster_template,
+        mocker,
+    ):
+        captured_labels = {}
+
+        def capture_labels(cluster):
+            captured_labels.update(cluster.labels)
+
+        self.cluster.stack_id = "kube-test"
+        self.cluster.labels = {"audit_log_enabled": "true"}
+        self.cluster.labels_skipped = {
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "ovn",
+        }
+        cluster_template.labels = {"kube_tag": "v1.30.0"}
+        ubuntu_driver._kube_client = mock.MagicMock()
+        ubuntu_driver.rust_driver = mock.MagicMock()
+        ubuntu_driver.rust_driver.delete_cluster.side_effect = capture_labels
+        mocker.patch("magnum_cluster_api.utils.delete_loadbalancers")
+        mocker.patch("magnum_cluster_api.resources.Cluster")
+        mocker.patch("magnum_cluster_api.resources.ClusterAutoscalerHelmRelease")
+
+        ubuntu_driver.delete_cluster(context, self.cluster)
+
+        ubuntu_driver.rust_driver.delete_cluster.assert_called_once_with(self.cluster)
+        assert captured_labels == {
+            "audit_log_enabled": "true",
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "ovn",
+        }
+
     def setup_node_group_tests(self, rsps, before, after=None):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),
@@ -390,6 +517,7 @@ class TestDriver:
                     ),
                 ],
             )
+            rsps.add(self._response_for_machine_sets(self.node_group.name))
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
 
@@ -435,6 +563,7 @@ class TestDriver:
                     ),
                 ],
             )
+            rsps.add(self._response_for_machine_sets(self.node_group.name))
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
 

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -566,3 +566,58 @@ def test_wait_for_sdk_loadbalancers_deleted_times_out(mocker):
         utils._wait_for_sdk_loadbalancers_deleted(octavia_client, {"lb-id"})
 
     sleep.assert_called_once_with(1)
+
+
+class TestFillMissingLabelsFromTemplate:
+    def _cluster(self, labels, template_labels):
+        cluster = mock.Mock()
+        cluster.labels = dict(labels)
+        cluster.cluster_template = mock.Mock()
+        cluster.cluster_template.labels = dict(template_labels)
+        return cluster
+
+    def test_fills_missing_keys(self):
+        """Missing keys (e.g. kube_tag) are pulled from the template."""
+        cluster = self._cluster(
+            {"extra_files": "x"},
+            {"kube_tag": "v1.30.0", "boot_volume_size": "20"},
+        )
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels["kube_tag"] == "v1.30.0"
+        assert cluster.labels["boot_volume_size"] == "20"
+        assert cluster.labels["extra_files"] == "x"
+
+    def test_fills_missing_keys_from_labels_skipped_first(self):
+        cluster = self._cluster(
+            {"extra_files": "x"},
+            {"kube_tag": "v1.30.0", "boot_volume_size": "20"},
+        )
+        cluster.labels_skipped = {
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+        }
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels["fixed_subnet_cidr"] == "192.168.24.0/24"
+        assert cluster.labels["kube_tag"] == "v1.34.3"
+        assert cluster.labels["boot_volume_size"] == "20"
+        assert cluster.labels["extra_files"] == "x"
+
+    def test_does_not_override_cluster_values(self):
+        cluster = self._cluster({"kube_tag": "v1.34.3"}, {"kube_tag": "v1.30.0"})
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels["kube_tag"] == "v1.34.3"
+
+    def test_no_template_is_safe(self):
+        cluster = mock.Mock()
+        cluster.labels = {"a": "b"}
+        cluster.cluster_template = None
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels == {"a": "b"}
+
+    def test_none_labels_initialised(self):
+        cluster = mock.Mock()
+        cluster.labels = None
+        cluster.cluster_template = mock.Mock()
+        cluster.cluster_template.labels = {"kube_tag": "v1.30.0"}
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels == {"kube_tag": "v1.30.0"}

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import collections.abc
 import json
 import re
 import string
@@ -192,6 +193,34 @@ def generate_manila_csi_cloud_config(
 
 def get_kube_tag(cluster: magnum_objects.Cluster) -> str:
     return cluster.labels.get("kube_tag", "v1.25.3")
+
+
+def fill_missing_labels_from_template(cluster: magnum_objects.Cluster) -> None:
+    """Merge template-derived labels into ``cluster.labels`` for missing keys.
+
+    Magnum's ``cluster create --labels`` REPLACES the cluster_template labels
+    rather than merging, so a freshly-created cluster row can be missing keys
+    that downstream code (especially the Rust ClusterLabels deserialiser)
+    expects to be present (e.g. ``kube_tag``).  Magnum may expose those
+    template-derived labels through ``labels_skipped`` instead of the loaded
+    template object, so this helper checks both sources without overriding values
+    the operator explicitly set.
+
+    Mutates ``cluster.labels`` in place.  Safe to call multiple times — keys
+    already present on the cluster are left untouched.
+    """
+    if cluster.labels is None:
+        cluster.labels = {}
+    label_sources = []
+    for labels in (
+        getattr(cluster, "labels_skipped", None),
+        getattr(getattr(cluster, "cluster_template", None), "labels", None),
+    ):
+        if isinstance(labels, collections.abc.Mapping):
+            label_sources.append(labels)
+    for labels in label_sources:
+        for key, value in labels.items():
+            cluster.labels.setdefault(key, value)
 
 
 def get_auto_scaling_enabled(cluster: magnum_objects.Cluster) -> bool:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ deps =
   pytest
   pytest-mock
   responses
+  lark
+  setuptools<82
   stestr
 
 [testenv:{unit,py3,py38,py39,py310}]


### PR DESCRIPTION
## Summary

Magnum `cluster create --labels` replaces, rather than merges, cluster-template labels. When an operator creates a cluster with sparse custom labels, the stored cluster row can miss labels required by the Rust `ClusterLabels` extractor, such as `kube_tag`.

This PR fills those missing template-derived labels before the Rust create/delete paths and persists the completed label dict on create.

## Fix

- Add `utils.fill_missing_labels_from_template(cluster)` to fill missing labels without overriding user-provided cluster labels.
- Prefer `cluster.labels_skipped` before `cluster.cluster_template.labels`, matching Magnum's stored representation for template-only labels on sparse-label creates.
- Invoke the helper before Rust create/delete paths.
- Persist the filled label dict during create when it changes, so later status/health monitor reads see the completed labels from Magnum storage.
- Tolerate CAPI `Cluster` objects that do not yet have `status.conditions` during early reconciliation.

This PR is rebased on current `main`, which already includes PR #1064.

## Repro

1. Create a cluster template with labels like `kube_tag`, `fixed_subnet_cidr`, and `octavia_provider`.
2. Run `openstack coe cluster create --labels audit_log_enabled=true` while omitting those template labels.
3. The sparse cluster row can later fail Rust label extraction with `KeyError: 'kube_tag'`, especially in status/health monitor or delete paths.

## Validation

```bash
tox -e py310
# 221 passed, 58 warnings

git diff --check origin/main...HEAD
# passed
```

Previously validated on Atmosphere main and stable AIOs with the equivalent sparse-label/status-condition fixes:

- sparse labels filled from `labels_skipped` first, then template labels
- missing CAPI `status.conditions` produced an empty status map instead of `KeyError`
- fresh cluster create passed after updated mCAPI image rollout
- old/default cluster create, mCAPI update, then resize of the same existing cluster passed
- delete path passed with sparse labels present

## Notes

- PR #1064 covers string-valued bool-ish CSI labels and is complementary; it does not replace this sparse-label fallback.
- This supersedes draft PR #1051, which duplicated the same label fallback after unrelated fixes were dropped.
- Originally fixed as part of #1015 commit `1930573` alongside unrelated `extra_cloud_init` fixes; split out here so the label fallback can land independently.

Signed-off-by: Rico Lin <rlin@vexxhost.com>