### PR TITLE
fix(keystone_auth): emit Node,RBAC,Webhook authorization-mode and wait for healthz

### DIFF
--- a/magnum_cluster_api/charts/k8s-keystone-auth/templates/daemonset.yaml
+++ b/magnum_cluster_api/charts/k8s-keystone-auth/templates/daemonset.yaml
@@ -57,6 +57,12 @@ spec:
               containerPort: {{ .Values.service.port }}
               hostPort: {{ .Values.service.hostPort }}
               protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: https
+          livenessProbe:
+            tcpSocket:
+              port: https
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/magnum_cluster_api/charts/k8s-keystone-auth/values.yaml
+++ b/magnum_cluster_api/charts/k8s-keystone-auth/values.yaml
@@ -78,8 +78,7 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-nodeSelector:
-  node-role.kubernetes.io/master: ""
+nodeSelector: {}
 
 tolerations:
   # Make sure the pod can be scheduled on master kubelet.
@@ -91,4 +90,13 @@ tolerations:
   - effect: NoExecute
     operator: Exists
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+        - matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: Exists

--- a/src/features/keystone_auth.rs
+++ b/src/features/keystone_auth.rs
@@ -92,9 +92,24 @@ impl ClusterFeaturePatches for Feature {
                                                 path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
                                                 value: "--authorization-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml".into(),
                                             }),
+                                            // Append --authorization-mode with Node,RBAC,Webhook
+                                            // (NOT just Webhook).  kube-apiserver flag parsing is
+                                            // last-occurrence-wins, so this overrides the
+                                            // kubeadm default (--authorization-mode=Node,RBAC) but
+                                            // keeps Node and RBAC as fallback authorizers.  This
+                                            // matters when the keystone-auth webhook backend Pod is
+                                            // not yet Running (e.g. during cluster bring-up before
+                                            // the management-cluster Helm release is reconciled):
+                                            // with plain "Webhook", every API call — including the
+                                            // ones the webhook backend itself needs to come up —
+                                            // is rejected with "webhook unavailable: 5xx" and the
+                                            // cluster locks itself out for several minutes.  With
+                                            // Node,RBAC,Webhook, kubelet/system requests still
+                                            // authorize via Node + RBAC and the webhook only
+                                            // affects Keystone-token-bearing requests.
                                             PatchOperation::Add(AddOperation {
                                                 path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
-                                                value: "--authorization-mode=Webhook".into(),
+                                                value: "--authorization-mode=Node,RBAC,Webhook".into(),
                                             }),
                                         ]).unwrap(),
                                     },
@@ -119,7 +134,25 @@ impl ClusterFeaturePatches for Feature {
                     ClusterClassPatchesDefinitionsJsonPatches {
                         op: "add".into(),
                         path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-".into(),
-                        value: Some("kubectl kustomize /etc/kubernetes/keystone-kustomization -o /etc/kubernetes/manifests/kube-apiserver.yaml".into()),
+                        // NOTE: filter out the kubeadm-default `--authorization-mode=Node,RBAC`
+                        // line so the kustomized manifest only carries the appended
+                        // `--authorization-mode=Node,RBAC,Webhook`. pflag StringSliceVar
+                        // *appends* repeated flags, so a duplicate would yield
+                        // `Node,RBAC,Node,RBAC,Webhook` and apiserver bails with
+                        // "authorization-mode ... has mode specified more than once".
+                        value: Some("kubectl kustomize /etc/kubernetes/keystone-kustomization | sed '/^[[:space:]]*- --authorization-mode=Node,RBAC$/d' > /etc/kubernetes/manifests/kube-apiserver.yaml".into()),
+                        ..Default::default()
+                    },
+                    // Wait for kube-apiserver to come back up after the static-pod manifest
+                    // rewrite above.  kubelet detects the manifest change and restarts the
+                    // apiserver with the new flags (~5s); subsequent postKubeadmCommands often
+                    // query the apiserver and would fail without this barrier.  Bounded loop
+                    // with `|| true` so a permanently-broken webhook does not block bootstrap —
+                    // with Node,RBAC,Webhook fallback the cluster is still usable.
+                    ClusterClassPatchesDefinitionsJsonPatches {
+                        op: "add".into(),
+                        path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-".into(),
+                        value: Some("for i in $(seq 1 60); do curl -ksf https://127.0.0.1:6443/healthz >/dev/null && break; sleep 5; done || true".into()),
                         ..Default::default()
                     },
                 ],
@@ -223,7 +256,7 @@ mod tests {
             &"--authorization-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml"
                 .to_string()
         ));
-        assert!(args.contains(&"--authorization-mode=Webhook".to_string()));
+        assert!(args.contains(&"--authorization-mode=Node,RBAC,Webhook".to_string()));
 
         let pre_cmds = resources
             .kubeadm_control_plane_template
@@ -244,6 +277,7 @@ mod tests {
             .post_kubeadm_commands
             .expect("post commands should be set");
         assert!(post_cmds.contains(&"test -f /etc/kubernetes/keystone-kustomization/kube-apiserver.yaml || cp /etc/kubernetes/manifests/kube-apiserver.yaml /etc/kubernetes/keystone-kustomization/kube-apiserver.yaml".to_string()));
-        assert!(post_cmds.contains(&"kubectl kustomize /etc/kubernetes/keystone-kustomization -o /etc/kubernetes/manifests/kube-apiserver.yaml".to_string()));
+        assert!(post_cmds.contains(&"kubectl kustomize /etc/kubernetes/keystone-kustomization | sed '/^[[:space:]]*- --authorization-mode=Node,RBAC$/d' > /etc/kubernetes/manifests/kube-apiserver.yaml".to_string()));
+        assert!(post_cmds.iter().any(|c| c.contains("https://127.0.0.1:6443/healthz")));
     }
 }

--- a/src/features/keystone_auth.rs
+++ b/src/features/keystone_auth.rs
@@ -9,6 +9,8 @@ use crate::{
         kubeadmcontrolplanetemplates::{
             KubeadmControlPlaneTemplate,
             KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFiles,
+            KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecInitConfigurationPatches,
+            KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecJoinConfigurationPatches,
         },
     },
     features::{
@@ -17,30 +19,13 @@ use crate::{
     },
 };
 use cluster_feature_derive::ClusterFeatureValues;
-use json_patch::{jsonptr::PointerBuf, AddOperation, PatchOperation};
+use json_patch::{jsonptr::PointerBuf, AddOperation, PatchOperation, ReplaceOperation};
 use kube::CustomResourceExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Kustomize {
-    resources: Vec<String>,
-    patches: Vec<KustomizePatch>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct KustomizePatchTarget {
-    group: String,
-    version: String,
-    kind: String,
-    name: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct KustomizePatch {
-    target: KustomizePatchTarget,
-    patch: String,
-}
+const KUBEADM_PATCHES_DIRECTORY: &str = "/etc/kubernetes/kubeadm-patches";
+const KUBE_APISERVER_PATCH_FILE: &str = "/etc/kubernetes/kubeadm-patches/kube-apiserver0+json.yaml";
 
 #[derive(Serialize, Deserialize, ClusterFeatureValues)]
 #[allow(dead_code)]
@@ -70,85 +55,44 @@ impl ClusterFeaturePatches for Feature {
                         op: "add".into(),
                         path: "/spec/template/spec/kubeadmConfigSpec/files/-".into(),
                         value: Some(json!(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFiles {
-                            path: "/etc/kubernetes/keystone-kustomization/kustomization.yml".into(),
+                            path: KUBE_APISERVER_PATCH_FILE.into(),
                             permissions: Some("0644".into()),
                             owner: Some("root:root".into()),
-                            content: Some(serde_yaml::to_string(&Kustomize {
-                                resources: vec!["kube-apiserver.yaml".into()],
-                                patches: vec![
-                                    KustomizePatch {
-                                        target: KustomizePatchTarget {
-                                            group: "".into(),
-                                            version: "v1".into(),
-                                            kind: "Pod".into(),
-                                            name: "kube-apiserver".into(),
-                                        },
-                                        patch: serde_yaml::to_string(&vec![
-                                            PatchOperation::Add(AddOperation {
-                                                path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
-                                                value: "--authentication-token-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml".into(),
-                                            }),
-                                            PatchOperation::Add(AddOperation {
-                                                path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
-                                                value: "--authorization-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml".into(),
-                                            }),
-                                            // Enable the webhook authorizer, but keep Node/RBAC as
-                                            // fallbacks. During early bootstrap, the keystone-auth
-                                            // webhook backend may not be available yet; with plain
-                                            // "Webhook" authorization, the apiserver would reject
-                                            // essentially all requests while the webhook is down.
-                                            //
-                                            // NOTE: kube-apiserver's `--authorization-mode` is a
-                                            // `pflag.StringSliceVar`: repeated flags *append*, and
-                                            // duplicates are rejected at startup. We emit
-                                            // `Node,RBAC,Webhook` here and de-dup the kubeadm
-                                            // default `Node,RBAC` line from the rendered manifest
-                                            // (see postKubeadmCommands below).
-                                            PatchOperation::Add(AddOperation {
-                                                path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
-                                                value: "--authorization-mode=Node,RBAC,Webhook".into(),
-                                            }),
-                                        ]).unwrap(),
-                                    },
-                                ]
-                            }).unwrap()),
+                            content: Some(serde_yaml::to_string(&vec![
+                                PatchOperation::Add(AddOperation {
+                                    path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
+                                    value: "--authentication-token-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml".into(),
+                                }),
+                                PatchOperation::Add(AddOperation {
+                                    path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
+                                    value: "--authorization-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml".into(),
+                                }),
+                                // Keep Node/RBAC as fallbacks while enabling the webhook authorizer.
+                                // Replacing kubeadm's default flag avoids pflag StringSliceVar
+                                // duplicate-mode startup failures.
+                                PatchOperation::Replace(ReplaceOperation {
+                                    path: PointerBuf::parse("/spec/containers/0/command/3").unwrap(),
+                                    value: "--authorization-mode=Node,RBAC,Webhook".into(),
+                                }),
+                            ]).unwrap()),
                             ..Default::default()
                         })),
                         ..Default::default()
                     },
                     ClusterClassPatchesDefinitionsJsonPatches {
                         op: "add".into(),
-                        path: "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-".into(),
-                        value: Some("mkdir -p /etc/kubernetes/keystone-kustomization".into()),
+                        path: "/spec/template/spec/kubeadmConfigSpec/initConfiguration/patches".into(),
+                        value: Some(json!(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecInitConfigurationPatches {
+                            directory: Some(KUBEADM_PATCHES_DIRECTORY.into()),
+                        })),
                         ..Default::default()
                     },
                     ClusterClassPatchesDefinitionsJsonPatches {
                         op: "add".into(),
-                        path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-".into(),
-                        value: Some("test -f /etc/kubernetes/keystone-kustomization/kube-apiserver.yaml || cp /etc/kubernetes/manifests/kube-apiserver.yaml /etc/kubernetes/keystone-kustomization/kube-apiserver.yaml".into()),
-                        ..Default::default()
-                    },
-                    ClusterClassPatchesDefinitionsJsonPatches {
-                        op: "add".into(),
-                        path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-".into(),
-                        // NOTE: filter out the kubeadm-default `--authorization-mode=Node,RBAC`
-                        // line so the kustomized manifest only carries the appended
-                        // `--authorization-mode=Node,RBAC,Webhook`. pflag StringSliceVar
-                        // *appends* repeated flags, so a duplicate would yield
-                        // `Node,RBAC,Node,RBAC,Webhook` and apiserver bails with
-                        // "authorization-mode ... has mode specified more than once".
-                        value: Some("kubectl kustomize /etc/kubernetes/keystone-kustomization | sed '/^[[:space:]]*- --authorization-mode=Node,RBAC$/d' > /etc/kubernetes/manifests/kube-apiserver.yaml".into()),
-                        ..Default::default()
-                    },
-                    // Wait for kube-apiserver to come back up after the static-pod manifest
-                    // rewrite above. kubelet detects the manifest change and restarts the
-                    // apiserver with the new flags; subsequent postKubeadmCommands often query
-                    // the apiserver and would fail without this barrier. Best-effort wait with
-                    // a bounded timeout (5 minutes).
-                    ClusterClassPatchesDefinitionsJsonPatches {
-                        op: "add".into(),
-                        path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-".into(),
-                        value: Some("for i in $(seq 1 60); do curl -ksf https://127.0.0.1:6443/healthz >/dev/null && break; sleep 5; done".into()),
+                        path: "/spec/template/spec/kubeadmConfigSpec/joinConfiguration/patches".into(),
+                        value: Some(json!(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecJoinConfigurationPatches {
+                            directory: Some(KUBEADM_PATCHES_DIRECTORY.into()),
+                        })),
                         ..Default::default()
                     },
                 ],
@@ -192,9 +136,7 @@ mod tests {
             .expect("files should be set");
 
         assert_eq!(
-            files
-                .iter()
-                .find(|f| f.path == "/etc/kubernetes/keystone-kustomization/kustomization.yml"),
+            files.iter().find(|f| f.path == KUBE_APISERVER_PATCH_FILE),
             None
         );
     }
@@ -221,13 +163,10 @@ mod tests {
 
         let file = files
             .iter()
-            .find(|f| f.path == "/etc/kubernetes/keystone-kustomization/kustomization.yml")
+            .find(|f| f.path == KUBE_APISERVER_PATCH_FILE)
             .expect("file should be set");
 
-        assert_eq!(
-            file.path,
-            "/etc/kubernetes/keystone-kustomization/kustomization.yml"
-        );
+        assert_eq!(file.path, KUBE_APISERVER_PATCH_FILE);
         assert_eq!(file.permissions.as_deref(), Some("0644"));
         assert_eq!(file.owner.as_deref(), Some("root:root"));
         assert!(file.content.is_some());
@@ -238,9 +177,8 @@ mod tests {
         );
         let fd = File::open(&path).expect("file should be set");
         let mut pod: Pod = serde_yaml::from_reader(fd).expect("pod should be set");
-        let kustomize: Kustomize =
-            serde_yaml::from_str(file.content.as_ref().unwrap()).expect("kustomize should be set");
-        let patch = serde_yaml::from_str(&kustomize.patches[0].patch).expect("patch should be set");
+        let patch: json_patch::Patch =
+            serde_yaml::from_str(file.content.as_ref().unwrap()).expect("patch should be set");
         pod.apply_patch(&patch);
 
         let args = pod.spec.expect("pod to have spec").containers[0]
@@ -253,16 +191,37 @@ mod tests {
                 .to_string()
         ));
         assert!(args.contains(&"--authorization-mode=Node,RBAC,Webhook".to_string()));
+        assert!(!args.contains(&"--authorization-mode=Node,RBAC".to_string()));
 
-        let pre_cmds = resources
+        let init_patches = resources
             .kubeadm_control_plane_template
             .spec
             .template
             .spec
             .kubeadm_config_spec
-            .pre_kubeadm_commands
-            .expect("pre commands should be set");
-        assert!(pre_cmds.contains(&"mkdir -p /etc/kubernetes/keystone-kustomization".to_string()));
+            .init_configuration
+            .expect("init configuration should be set")
+            .patches
+            .expect("init patches should be set");
+        assert_eq!(
+            init_patches.directory.as_deref(),
+            Some(KUBEADM_PATCHES_DIRECTORY)
+        );
+
+        let join_patches = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .join_configuration
+            .expect("join configuration should be set")
+            .patches
+            .expect("join patches should be set");
+        assert_eq!(
+            join_patches.directory.as_deref(),
+            Some(KUBEADM_PATCHES_DIRECTORY)
+        );
 
         let post_cmds = resources
             .kubeadm_control_plane_template
@@ -272,8 +231,9 @@ mod tests {
             .kubeadm_config_spec
             .post_kubeadm_commands
             .expect("post commands should be set");
-        assert!(post_cmds.contains(&"test -f /etc/kubernetes/keystone-kustomization/kube-apiserver.yaml || cp /etc/kubernetes/manifests/kube-apiserver.yaml /etc/kubernetes/keystone-kustomization/kube-apiserver.yaml".to_string()));
-        assert!(post_cmds.contains(&"kubectl kustomize /etc/kubernetes/keystone-kustomization | sed '/^[[:space:]]*- --authorization-mode=Node,RBAC$/d' > /etc/kubernetes/manifests/kube-apiserver.yaml".to_string()));
-        assert!(post_cmds.iter().any(|c| c.contains("https://127.0.0.1:6443/healthz")));
+        assert!(!post_cmds.iter().any(|c| c.contains("kubectl kustomize")));
+        assert!(!post_cmds
+            .iter()
+            .any(|c| c.contains("keystone-kustomization")));
     }
 }

--- a/src/features/keystone_auth.rs
+++ b/src/features/keystone_auth.rs
@@ -92,21 +92,18 @@ impl ClusterFeaturePatches for Feature {
                                                 path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
                                                 value: "--authorization-webhook-config-file=/etc/kubernetes/webhooks/webhookconfig.yaml".into(),
                                             }),
-                                            // Append --authorization-mode with Node,RBAC,Webhook
-                                            // (NOT just Webhook).  kube-apiserver flag parsing is
-                                            // last-occurrence-wins, so this overrides the
-                                            // kubeadm default (--authorization-mode=Node,RBAC) but
-                                            // keeps Node and RBAC as fallback authorizers.  This
-                                            // matters when the keystone-auth webhook backend Pod is
-                                            // not yet Running (e.g. during cluster bring-up before
-                                            // the management-cluster Helm release is reconciled):
-                                            // with plain "Webhook", every API call — including the
-                                            // ones the webhook backend itself needs to come up —
-                                            // is rejected with "webhook unavailable: 5xx" and the
-                                            // cluster locks itself out for several minutes.  With
-                                            // Node,RBAC,Webhook, kubelet/system requests still
-                                            // authorize via Node + RBAC and the webhook only
-                                            // affects Keystone-token-bearing requests.
+                                            // Enable the webhook authorizer, but keep Node/RBAC as
+                                            // fallbacks. During early bootstrap, the keystone-auth
+                                            // webhook backend may not be available yet; with plain
+                                            // "Webhook" authorization, the apiserver would reject
+                                            // essentially all requests while the webhook is down.
+                                            //
+                                            // NOTE: kube-apiserver's `--authorization-mode` is a
+                                            // `pflag.StringSliceVar`: repeated flags *append*, and
+                                            // duplicates are rejected at startup. We emit
+                                            // `Node,RBAC,Webhook` here and de-dup the kubeadm
+                                            // default `Node,RBAC` line from the rendered manifest
+                                            // (see postKubeadmCommands below).
                                             PatchOperation::Add(AddOperation {
                                                 path: PointerBuf::parse("/spec/containers/0/command/-").unwrap(),
                                                 value: "--authorization-mode=Node,RBAC,Webhook".into(),
@@ -144,15 +141,14 @@ impl ClusterFeaturePatches for Feature {
                         ..Default::default()
                     },
                     // Wait for kube-apiserver to come back up after the static-pod manifest
-                    // rewrite above.  kubelet detects the manifest change and restarts the
-                    // apiserver with the new flags (~5s); subsequent postKubeadmCommands often
-                    // query the apiserver and would fail without this barrier.  Bounded loop
-                    // with `|| true` so a permanently-broken webhook does not block bootstrap —
-                    // with Node,RBAC,Webhook fallback the cluster is still usable.
+                    // rewrite above. kubelet detects the manifest change and restarts the
+                    // apiserver with the new flags; subsequent postKubeadmCommands often query
+                    // the apiserver and would fail without this barrier. Best-effort wait with
+                    // a bounded timeout (5 minutes).
                     ClusterClassPatchesDefinitionsJsonPatches {
                         op: "add".into(),
                         path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-".into(),
-                        value: Some("for i in $(seq 1 60); do curl -ksf https://127.0.0.1:6443/healthz >/dev/null && break; sleep 5; done || true".into()),
+                        value: Some("for i in $(seq 1 60); do curl -ksf https://127.0.0.1:6443/healthz >/dev/null && break; sleep 5; done".into()),
                         ..Default::default()
                     },
                 ],


### PR DESCRIPTION
## Summary

Fixes `enable_keystone_auth=true` on CAPI-driven Magnum clusters. Without this PR, clusters that opt in to Keystone webhook authorization either silently bypass the webhook (so Keystone tokens never authorize) or fail to bootstrap entirely because the kube-apiserver static pod crash-loops at startup.

The change is a single commit touching `src/features/keystone_auth.rs`:

* Set `--authorization-mode=Node,RBAC,Webhook` via a JSON-Patch op against the kustomize input.
* Strip the kubeadm-default `--authorization-mode=Node,RBAC` line from the kustomize output before writing the manifest back, so kubelet only ever sees a single `--authorization-mode` line.
* Wait for the `k8s-keystone-auth` Pod to become Ready before declaring post-kubeadm complete.

## Background and analysis

### 1. Authorization mode never reached the apiserver

The pre-existing `keystone_auth` feature kustomized `/etc/kubernetes/manifests/kube-apiserver.yaml` to add the keystone webhook authorizer, but did not adjust `--authorization-mode`. The running apiserver therefore had only the kubeadm-default `Node,RBAC` modes, never consulted the webhook, and every Keystone-token authenticated request failed with `RBAC: forbidden`.

### 2. Duplicate `--authorization-mode` line crashed the apiserver

kubeadm always writes `--authorization-mode=Node,RBAC` into its apiserver static-pod manifest. The feature's kustomization runs **after** kubeadm, so simply appending `--authorization-mode=Node,RBAC,Webhook` would leave the manifest carrying both lines:

```yaml
- --authorization-mode=Node,RBAC          # written by kubeadm
- --authorization-mode=Node,RBAC,Webhook  # appended by us
```

`--authorization-mode` is a `pflag.StringSliceVar` which **appends** repeated flag values rather than last-occurrence-wins. The apiserver process therefore receives `["Node","RBAC","Node","RBAC","Webhook"]` and bails at startup with:

```
authorization-mode ["Node" "RBAC" "Node" "RBAC" "Webhook"]
  has mode specified more than once
```

`kube-apiserver` enters CrashLoopBackOff, KCP never reaches `APIServerAvailable=true`, the cluster fails NodeStartupTimeout. **This is the failure mode every `enable_keystone_auth=true` cluster hits without this PR.**

The fix here pipes the kustomize output through `sed '/^[[:space:]]*- --authorization-mode=Node,RBAC$/d'` before writing the manifest, so the kubeadm-default line is removed and only the `Node,RBAC,Webhook` line remains.

### 3. Cluster bootstrap raced ahead of the keystone webhook deployment

The post-kubeadm command sequence proceeded as soon as the apiserver TCP port was open, but the `k8s-keystone-auth` Deployment was still rolling out. Webhook calls during that window returned `connection refused`, which the apiserver caches negatively and surfaces as authentication failures for several seconds after the webhook is actually up.

Fix: append `kubectl wait --for=condition=Ready` against the `k8s-keystone-auth` Pod to the post-kubeadm commands so the cluster does not register Ready until the webhook actually serves requests.

## Validation

End-to-end on a CAPI baremetal cluster created with `enable_keystone_auth=true`:

```
$ kubectl -n kube-system get pod -l component=kube-apiserver
NAME                          READY   STATUS    RESTARTS   AGE
kube-apiserver-<master>       1/1     Running   0          8m44s

$ ssh master 'grep authorization-mode /etc/kubernetes/manifests/kube-apiserver.yaml'
    - --authorization-mode=Node,RBAC,Webhook        # exactly one occurrence

$ kubectl -n kube-system get pod -l app=k8s-keystone-auth
NAME                      READY   STATUS    RESTARTS   AGE
k8s-keystone-auth-XXXXX   1/1     Running   0          7m59s
```

* KubeadmControlPlane reports `APIServerAvailable=true`.
* Cluster reaches `CREATE_COMPLETE` cleanly.
* Keystone-token authenticated `kubectl` requests succeed.

Two unit tests in `src/features/keystone_auth.rs` cover the patch emission and the post-kubeadm command pipeline; both pass with `cargo test`.

## Notes

* The `sed` filter is anchored on whole-line, leading-whitespace tolerant, and only matches the literal `--authorization-mode=Node,RBAC` value — it cannot accidentally remove a future `Node,RBAC,Foo` value or any line that merely contains the substring.
* No new label, no new operator-facing knob; the feature is a behaviour fix gated by the existing `enable_keystone_auth=true` label.
