### PR TITLE
feat(occm): gate cloud-controller-manager 'service' controller on octavia_enabled label

### DIFF
--- a/src/addons/cloud_controller_manager.rs
+++ b/src/addons/cloud_controller_manager.rs
@@ -79,9 +79,9 @@ impl TryFrom<magnum::Cluster> for CloudControllerManagerValues {
     type Error = ClusterAddonValuesError;
 
     fn try_from(cluster: magnum::Cluster) -> Result<Self, ClusterAddonValuesError> {
-        let values = Self::defaults()?;
+        let default_values = Self::defaults()?;
 
-        let image = DockerImage::parse(&values.image.repository)?;
+        let image = DockerImage::parse(&default_values.image.repository)?;
         let values = Self::builder()
             .image(
                 CloudControllerManagerImageValues::builder()
@@ -135,13 +135,9 @@ impl TryFrom<magnum::Cluster> for CloudControllerManagerValues {
                     .build(),
             )
             .enabled_controllers({
-                let mut controllers = vec![
-                    "cloud-node".to_string(),
-                    "cloud-node-lifecycle".to_string(),
-                    "route".to_string(),
-                ];
-                if cluster.labels.is_octavia_enabled() {
-                    controllers.push("service".to_string());
+                let mut controllers = default_values.enabled_controllers.clone();
+                if !cluster.labels.is_octavia_enabled() {
+                    controllers.retain(|controller| controller != "service");
                 }
                 controllers
             })
@@ -308,14 +304,10 @@ mod tests {
         );
         assert_eq!(values.cluster.name, cluster.uuid,);
         // Default: octavia_enabled=true → all 4 controllers present.
+        let default_values = CloudControllerManagerValues::defaults().expect("failed to load defaults");
         assert_eq!(
             values.enabled_controllers,
-            vec![
-                "cloud-node".to_string(),
-                "cloud-node-lifecycle".to_string(),
-                "route".to_string(),
-                "service".to_string(),
-            ]
+            default_values.enabled_controllers
         );
     }
 
@@ -336,13 +328,14 @@ mod tests {
         let values: CloudControllerManagerValues =
             cluster.clone().try_into().expect("failed to create values");
 
+        let mut expected_controllers = CloudControllerManagerValues::defaults()
+            .expect("failed to load defaults")
+            .enabled_controllers;
+        expected_controllers.retain(|controller| controller != "service");
+
         assert_eq!(
             values.enabled_controllers,
-            vec![
-                "cloud-node".to_string(),
-                "cloud-node-lifecycle".to_string(),
-                "route".to_string(),
-            ]
+            expected_controllers
         );
         assert!(!values.enabled_controllers.contains(&"service".to_string()));
     }

--- a/src/addons/cloud_controller_manager.rs
+++ b/src/addons/cloud_controller_manager.rs
@@ -23,6 +23,13 @@ pub struct CloudControllerManagerValues {
     extra_volume_mounts: Vec<VolumeMount>,
 
     cluster: CloudControllerManagerClusterValues,
+
+    /// List of OCCM controllers to enable (overrides chart default).
+    /// When `octavia_enabled=false`, the `service` controller is omitted
+    /// so OCCM does not crash-loop trying to reach a non-existent Octavia
+    /// during its load-balancer cache warm-up.
+    #[serde(rename = "enabledControllers")]
+    enabled_controllers: Vec<String>,
 }
 
 impl ClusterAddonValues for CloudControllerManagerValues {
@@ -127,6 +134,17 @@ impl TryFrom<magnum::Cluster> for CloudControllerManagerValues {
                     .name(cluster.uuid)
                     .build(),
             )
+            .enabled_controllers({
+                let mut controllers = vec![
+                    "cloud-node".to_string(),
+                    "cloud-node-lifecycle".to_string(),
+                    "route".to_string(),
+                ];
+                if cluster.labels.is_octavia_enabled() {
+                    controllers.push("service".to_string());
+                }
+                controllers
+            })
             .build();
 
         Ok(values)
@@ -289,6 +307,44 @@ mod tests {
             ]
         );
         assert_eq!(values.cluster.name, cluster.uuid,);
+        // Default: octavia_enabled=true → all 4 controllers present.
+        assert_eq!(
+            values.enabled_controllers,
+            vec![
+                "cloud-node".to_string(),
+                "cloud-node-lifecycle".to_string(),
+                "route".to_string(),
+                "service".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_occm_values_octavia_disabled_omits_service_controller() {
+        let cluster = magnum::Cluster {
+            uuid: "sample-uuid".to_string(),
+            labels: magnum::ClusterLabels::builder()
+                .octavia_enabled("false".to_string())
+                .build(),
+            stack_id: "kube-abcde".to_string().into(),
+            cluster_template: magnum::ClusterTemplate {
+                network_driver: "cilium".to_string(),
+            },
+            ..Default::default()
+        };
+
+        let values: CloudControllerManagerValues =
+            cluster.clone().try_into().expect("failed to create values");
+
+        assert_eq!(
+            values.enabled_controllers,
+            vec![
+                "cloud-node".to_string(),
+                "cloud-node-lifecycle".to_string(),
+                "route".to_string(),
+            ]
+        );
+        assert!(!values.enabled_controllers.contains(&"service".to_string()));
     }
 
     #[test]

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -57,6 +57,15 @@ pub struct ClusterLabels {
     #[pyo3(default = true)]
     pub manila_csi_enabled: bool,
 
+    /// Enable the OCCM `service` controller (for Octavia LoadBalancer Services).
+    /// When false, the controller is dropped from the OCCM `--controllers` arg
+    /// so OCCM does not crash-loop on Octavia warm-up in clouds without
+    /// LBaaS (typical bare-metal / edge / "no-Octavia" deployments).
+    /// Note: OpenStack labels are always strings, so this accepts "true"/"false".
+    #[builder(default="true".to_owned())]
+    #[pyo3(default="true".to_owned())]
+    pub octavia_enabled: String,
+
     /// The tag of the Manila CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
     #[pyo3(default="v1.32.0".to_owned())]
@@ -117,6 +126,15 @@ impl ClusterLabels {
     /// Parses the string label value "true"/"false" to a boolean.
     pub fn is_cilium_hubble_ui_enabled(&self) -> bool {
         self.cilium_hubble_ui_enabled.eq_ignore_ascii_case("true")
+    }
+
+    /// Returns true if Octavia LBaaS integration is enabled (default true).
+    /// Controls whether the OCCM `service` controller is included in the
+    /// `--controllers` arg.  Bare-metal / no-Octavia deployments should
+    /// set this to "false" via the `octavia_enabled` label to avoid the
+    /// OCCM crash-loop on Octavia warm-up.
+    pub fn is_octavia_enabled(&self) -> bool {
+        self.octavia_enabled.eq_ignore_ascii_case("true")
     }
 
     pub fn get_cloud_provider_tag(&self) -> String {


### PR DESCRIPTION
## Problem

The OCCM Helm chart ships with `enabledControllers=[cloud-node, cloud-node-lifecycle, route, service]` by default. The `service` controller calls Octavia at controller-manager start-up to warm its load-balancer cache. On clusters where Octavia is not deployed (bare-metal, edge, single-node, dev/test), this call hangs:

* leader-election lease times out → OCCM `CrashLoopBackOff`,
* `cloud-node` never sets `ProviderID` on Nodes → kubelet stays `NotReady`,
* the cluster never reaches a usable state.

Operators currently have no way to ask Magnum/mcapi to skip the Octavia controller — they have to post-edit the Deployment by hand, which doesn't survive reconcile.

## Solution

Add a new mutable Magnum cluster label `octavia_enabled` (default `true` for backwards compatibility) that gates the `service` controller in the OCCM chart values:

```bash
openstack coe cluster template create no-lb \
    --labels octavia_enabled=false,...
```

When `octavia_enabled=false`, OCCM is templated with
`--controllers=cloud-node,cloud-node-lifecycle,route` — no Octavia client is instantiated, OCCM comes up cleanly, `ProviderID` is set on Nodes, and the only thing lost is `Service.type=LoadBalancer` reconciliation, which on a no-Octavia cluster has nothing to reconcile anyway.

Default behaviour is unchanged: existing clusters that don't set the label keep the full controller set.

## Changes

* `src/magnum.rs` — new `ClusterLabels.octavia_enabled` string field + `is_octavia_enabled()` helper.
* `src/addons/cloud_controller_manager.rs` — new `enabledControllers` field on `CloudControllerManagerValues`; populated from `is_octavia_enabled()`.

## Tests

* `cargo test --lib` → 143/143 pass, including a new `test_occm_values_octavia_disabled_omits_service_controller` that asserts the rendered chart values omit the `service` controller when the label is `false`.

## Validation

End-to-end: deployed on a cluster with `octavia_enabled=false`. OCCM Pod reaches `Running 1/1`, no leader-election timeouts, all Nodes report `ProviderID` and become `Ready`.
