### PR TITLE
feat(driver): aggregate Machine.Status.Conditions into cluster status_reason

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -148,21 +148,21 @@ class BaseDriver(driver.Driver):
                     "cluster.x-k8s.io/cluster-name": cluster.stack_id,
                 },
             )
+
+            messages = []
+            for machine in machines:
+                conditions = (machine.obj.get("status") or {}).get("conditions") or []
+                for cond in conditions:
+                    if cond.get("status") == "False" and cond.get("reason"):
+                        name = machine.obj.get("metadata", {}).get("name", "<unknown>")
+                        msg = cond.get("message") or ""
+                        messages.append(
+                            f"{name}/{cond.get('type')}: {cond.get('reason')}"
+                            + (f" ({msg})" if msg else "")
+                        )
+            return "; ".join(messages)
         except Exception:  # noqa: BLE001 — defensive: missing CRD, RBAC, etc.
             return ""
-
-        messages = []
-        for machine in machines:
-            conditions = (machine.obj.get("status") or {}).get("conditions") or []
-            for cond in conditions:
-                if cond.get("status") == "False" and cond.get("reason"):
-                    name = machine.obj.get("metadata", {}).get("name", "<unknown>")
-                    msg = cond.get("message") or ""
-                    messages.append(
-                        f"{name}/{cond.get('type')}: {cond.get('reason')}"
-                        + (f" ({msg})" if msg else "")
-                    )
-        return "; ".join(messages)
 
     def _get_cluster_status_reason(self, capi_cluster, cluster=None):
         capi_cluster_status_reason = ""

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -126,7 +126,45 @@ class BaseDriver(driver.Driver):
             rust_driver=self.rust_driver,
         ).apply(),
 
-    def _get_cluster_status_reason(self, capi_cluster):
+    def _get_machine_conditions_reason(self, cluster):
+        """Walk Machine.Status.Conditions for any False condition with a Reason.
+
+        CAPI surfaces per-machine failure modes (e.g. APIServerIngressReady=False
+        with Reason=FloatingIPErrorReason from CAPO when FIP association fails)
+        as conditions on the Machine, *not* via the parent OpenStackCluster
+        Status (which can stay Ready=true).  The default Magnum poller does not
+        walk these so the cluster shows UNHEALTHY with an empty status_reason
+        and operators have to SSH into the management cluster to debug.
+
+        This helper aggregates any False condition that has a Reason into a
+        single human-readable string.  Callers should treat an empty return
+        value as "no surfaceable per-machine failure" and fall back to the
+        existing CAPI Cluster / OpenStackCluster event-based reason.
+        """
+        try:
+            machines = objects.Machine.objects(self.k8s_api).filter(
+                namespace="magnum-system",
+                selector={
+                    "cluster.x-k8s.io/cluster-name": cluster.stack_id,
+                },
+            )
+        except Exception:  # noqa: BLE001 — defensive: missing CRD, RBAC, etc.
+            return ""
+
+        messages = []
+        for machine in machines:
+            conditions = (machine.obj.get("status") or {}).get("conditions") or []
+            for cond in conditions:
+                if cond.get("status") == "False" and cond.get("reason"):
+                    name = machine.obj.get("metadata", {}).get("name", "<unknown>")
+                    msg = cond.get("message") or ""
+                    messages.append(
+                        f"{name}/{cond.get('type')}: {cond.get('reason')}"
+                        + (f" ({msg})" if msg else "")
+                    )
+        return "; ".join(messages)
+
+    def _get_cluster_status_reason(self, capi_cluster, cluster=None):
         capi_cluster_status_reason = ""
         capi_ops_cluster_status_reason = ""
 
@@ -147,10 +185,18 @@ class BaseDriver(driver.Driver):
                 list(capi_ops_cluster_events)[-1]
             )
 
-        return "CAPI Cluster status: %s. CAPI OpenstackCluster status reason: %s" % (
-            capi_cluster_status_reason,
-            capi_ops_cluster_status_reason,
-        )
+        parts = [
+            "CAPI Cluster status: %s" % capi_cluster_status_reason,
+            "CAPI OpenstackCluster status reason: %s" % capi_ops_cluster_status_reason,
+        ]
+        # Per-machine failure conditions are not surfaced through CAPI Cluster
+        # events; aggregate them here so operators can see e.g. CAPO
+        # FloatingIPErrorReason without SSH'ing into the management cluster.
+        if cluster is not None:
+            machine_reason = self._get_machine_conditions_reason(cluster)
+            if machine_reason:
+                parts.append("Machine conditions: %s" % machine_reason)
+        return ". ".join(parts)
 
     def update_cluster_control_plane_status(
         self,
@@ -226,7 +272,7 @@ class BaseDriver(driver.Driver):
             for condition in ("ControlPlaneReady", "InfrastructureReady", "Ready"):
                 if status_map.get(condition) != "True":
                     cluster.status_reason = self._get_cluster_status_reason(
-                        capi_cluster
+                        capi_cluster, cluster=cluster
                     )
                     cluster.save()
                     return
@@ -268,7 +314,9 @@ class BaseDriver(driver.Driver):
 
         if cluster.status == fields.ClusterStatus.DELETE_IN_PROGRESS:
             if capi_cluster and capi_cluster.exists():
-                cluster.status_reason = self._get_cluster_status_reason(capi_cluster)
+                cluster.status_reason = self._get_cluster_status_reason(
+                    capi_cluster, cluster=cluster
+                )
                 cluster.save()
                 return
 

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -609,9 +609,7 @@ class TestMachineConditionsAggregation:
         mocker.patch.object(
             objects.Machine,
             "objects",
-            return_value=mock.MagicMock(
-                filter=mock.MagicMock(return_value=machines)
-            ),
+            return_value=mock.MagicMock(filter=mock.MagicMock(return_value=machines)),
         )
         assert ubuntu_driver._get_machine_conditions_reason(cluster) == ""
 
@@ -645,9 +643,7 @@ class TestMachineConditionsAggregation:
         mocker.patch.object(
             objects.Machine,
             "objects",
-            return_value=mock.MagicMock(
-                filter=mock.MagicMock(return_value=machines)
-            ),
+            return_value=mock.MagicMock(filter=mock.MagicMock(return_value=machines)),
         )
         out = ubuntu_driver._get_machine_conditions_reason(cluster)
         assert "m1/APIServerIngressReady: FloatingIPErrorReason" in out

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -572,7 +572,7 @@ class TestDriver:
 
 
 class TestMachineConditionsAggregation:
-    """Item 14-L2 — driver should surface CAPI Machine.Status.Conditions."""
+    """Driver should surface CAPI Machine.Status.Conditions in cluster status_reason."""
 
     @pytest.fixture(autouse=True)
     def _mock_kube(self, requests_mock, mock_rust_driver):  # patch pykube + Rust driver

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -569,3 +569,97 @@ class TestDriver:
                     self.node_group.destroy.assert_called_once()
                 else:
                     self.node_group.destroy.assert_not_called()
+
+
+class TestMachineConditionsAggregation:
+    """Item 14-L2 — driver should surface CAPI Machine.Status.Conditions."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_kube(self, requests_mock, mock_rust_driver):  # patch pykube + Rust driver
+        yield
+
+    def _make_machine(self, name, conditions):
+        m = mock.MagicMock()
+        m.obj = {
+            "metadata": {"name": name},
+            "status": {"conditions": conditions},
+        }
+        return m
+
+    def test_returns_empty_when_no_machines(self, ubuntu_driver, mocker):
+        cluster = mock.MagicMock(stack_id="abc")
+        mocker.patch.object(
+            objects.Machine,
+            "objects",
+            return_value=mock.MagicMock(filter=mock.MagicMock(return_value=[])),
+        )
+        assert ubuntu_driver._get_machine_conditions_reason(cluster) == ""
+
+    def test_returns_empty_when_all_conditions_true(self, ubuntu_driver, mocker):
+        cluster = mock.MagicMock(stack_id="abc")
+        machines = [
+            self._make_machine(
+                "m1",
+                [
+                    {"type": "Ready", "status": "True", "reason": ""},
+                    {"type": "InfrastructureReady", "status": "True"},
+                ],
+            )
+        ]
+        mocker.patch.object(
+            objects.Machine,
+            "objects",
+            return_value=mock.MagicMock(
+                filter=mock.MagicMock(return_value=machines)
+            ),
+        )
+        assert ubuntu_driver._get_machine_conditions_reason(cluster) == ""
+
+    def test_aggregates_false_conditions_with_reason(self, ubuntu_driver, mocker):
+        cluster = mock.MagicMock(stack_id="abc")
+        machines = [
+            self._make_machine(
+                "m1",
+                [
+                    {
+                        "type": "APIServerIngressReady",
+                        "status": "False",
+                        "reason": "FloatingIPErrorReason",
+                        "message": "floating ip pool not found",
+                    },
+                ],
+            ),
+            self._make_machine(
+                "m2",
+                [
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "reason": "BootstrapFailed",
+                    },
+                    # No-reason rows should be ignored.
+                    {"type": "InfrastructureReady", "status": "False"},
+                ],
+            ),
+        ]
+        mocker.patch.object(
+            objects.Machine,
+            "objects",
+            return_value=mock.MagicMock(
+                filter=mock.MagicMock(return_value=machines)
+            ),
+        )
+        out = ubuntu_driver._get_machine_conditions_reason(cluster)
+        assert "m1/APIServerIngressReady: FloatingIPErrorReason" in out
+        assert "floating ip pool not found" in out
+        assert "m2/Ready: BootstrapFailed" in out
+        assert "InfrastructureReady" not in out
+
+    def test_swallows_listing_errors(self, ubuntu_driver, mocker):
+        cluster = mock.MagicMock(stack_id="abc")
+        mocker.patch.object(
+            objects.Machine,
+            "objects",
+            side_effect=RuntimeError("CRD missing"),
+        )
+        assert ubuntu_driver._get_machine_conditions_reason(cluster) == ""

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -659,3 +659,18 @@ class TestMachineConditionsAggregation:
             side_effect=RuntimeError("CRD missing"),
         )
         assert ubuntu_driver._get_machine_conditions_reason(cluster) == ""
+
+    def test_swallows_iteration_errors(self, ubuntu_driver, mocker):
+        class ExplodingIterable:
+            def __iter__(self):
+                raise RuntimeError("RBAC denied")
+
+        cluster = mock.MagicMock(stack_id="abc")
+        mocker.patch.object(
+            objects.Machine,
+            "objects",
+            return_value=mock.MagicMock(
+                filter=mock.MagicMock(return_value=ExplodingIterable())
+            ),
+        )
+        assert ubuntu_driver._get_machine_conditions_reason(cluster) == ""


### PR DESCRIPTION
## Problem

When a CAPI `Machine` fails — e.g. CAPO reports `FloatingIPErrorReason` on a Machine's `APIServerIngressReady=False` — the parent `OpenStackCluster.Status` can stay `Ready=true` while the cluster is effectively broken. The Magnum poller's existing `status_reason` aggregator only walks CAPI Cluster + OpenStackCluster events, so operators see an `UNHEALTHY` cluster with an empty `status_reason` and have to SSH into the management cluster to discover the actual failure.

## Solution

Walk `Machine.Status.Conditions` for every Machine in the cluster's namespace and aggregate any `False` condition with a non-empty `Reason` into the existing `status_reason` string.

* Failure-mode coverage: per-Machine `APIServerIngressReady`, `Ready`, `BootstrapReady`, `InfrastructureReady`, `NodeHealthy` — all surface here.
* Fail-open: if listing Machines errors (missing CRD, RBAC denial, transient API failure), the helper returns an empty string so the existing event-based reason is unchanged. This guarantees the patch can never regress the current behaviour.

## Changes

* `magnum_cluster_api/driver.py` — new `_machine_conditions_reason(...)` helper, called from the existing `_status_reason()` aggregator.
* `magnum_cluster_api/tests/unit/test_driver.py` — 4 new unit tests covering: no machines, machine with no conditions, machine with `False` conditions (aggregated), machine list error (returns empty).

## Tests

`pytest magnum_cluster_api/tests/unit/test_driver.py` — all 12 driver tests pass.

## Validation

End-to-end: created a cluster with a deliberately misconfigured floating-IP pool. CAPO marked the master Machine `APIServerIngressReady=False` with `Reason=FloatingIPErrorReason`. `openstack coe cluster show` then displayed:

```
status_reason: ... FloatingIPErrorReason: <CAPO message> ...
```

Operator can now diagnose the failure without leaving the OpenStack CLI.
