### PR TITLE
docs(labels): document octavia_enabled, enable_keystone_auth + dev-doc on label flow

### DIFF
--- a/docs/developer/labels.md
+++ b/docs/developer/labels.md
@@ -15,8 +15,8 @@ debugging "I set this label, why didn't it take effect?".
 │   Applies defaults, normalisation, validation.             │
 │   May derive *additional* booleans from a single label     │
 │   (e.g. `master_lb_floating_ip_enabled` →                  │
-│   `disableAPIServerFloatingIP` + `disableAPIServerFloating-│
-│   IPManaged`).                                             │
+│   `disableAPIServerFloatingIP` +                           │
+│   `disableAPIServerFloatingIPManaged`).                    │
 └──────────────────────┬─────────────────────────────────────┘
                        │ injected as ClusterTopology variables
                        ▼
@@ -78,6 +78,10 @@ debugging "I set this label, why didn't it take effect?".
 * **Adding a label with no warning on typo.**  Magnum silently ignores
   labels it does not understand; if a label has no effect, double-check
   the spelling against `magnum_cluster_api/utils.py`.
+
+* **Rust variable count test.**  If you add a new ClusterClass variable,
+  `src/resources.rs` has `test_convert_values_to_cluster_topology_variables`
+  which asserts the total number of variables; bump the expected count.
 
 ## Where each existing label lives
 

--- a/docs/developer/labels.md
+++ b/docs/developer/labels.md
@@ -1,0 +1,92 @@
+# How a Magnum label flows through the driver
+
+Magnum cluster template / cluster labels are how operators configure a cluster.
+In `magnum-cluster-api` a single label may pass through up to **three** layers
+before it changes a piece of generated YAML.  This document describes those
+layers so contributors know where to add new labels and where to look when
+debugging "I set this label, why didn't it take effect?".
+
+## The three layers
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Layer 1 — Python: label lookup (utils.py, resources.py)    │
+│   Reads `cluster.labels[<name>]` (str → typed value).      │
+│   Applies defaults, normalisation, validation.             │
+│   May derive *additional* booleans from a single label     │
+│   (e.g. `master_lb_floating_ip_enabled` →                  │
+│   `disableAPIServerFloatingIP` + `disableAPIServerFloating-│
+│   IPManaged`).                                             │
+└──────────────────────┬─────────────────────────────────────┘
+                       │ injected as ClusterTopology variables
+                       ▼
+┌────────────────────────────────────────────────────────────┐
+│ Layer 2 — Rust: feature module (src/features/<name>.rs)    │
+│   Defines a `FeatureValues` struct with `serde(rename =    │
+│   "<camelCase>")` for each ClusterClass variable it        │
+│   consumes.  Emits `ClusterClassPatches` gated on those    │
+│   variables.                                               │
+└──────────────────────┬─────────────────────────────────────┘
+                       │ JSON Patches applied at template-render time
+                       ▼
+┌────────────────────────────────────────────────────────────┐
+│ Layer 3 — CAPI / CAPO: ClusterClass topology resolves the  │
+│   patches against the underlying templates                 │
+│   (KubeadmControlPlaneTemplate, OpenStackClusterTemplate,  │
+│   OpenStackMachineTemplate, KubeadmConfigTemplate).        │
+│   The result is the final spec for each managed resource.  │
+└────────────────────────────────────────────────────────────┘
+```
+
+## Adding a new label — checklist
+
+1. **Decide the data type.**  Magnum labels are strings on the wire.  Decide
+   the parsed type your feature wants (`bool`, `String`, list, …).
+2. **Layer 1.**  Add a getter / parser in `magnum_cluster_api/utils.py`
+   (or extend `magnum_cluster_api/resources.py` if it's a per-cluster
+   variable).  Add a default that matches existing semantics so untouched
+   clusters do not regress.
+3. **Layer 2.**  Add a field to the relevant `FeatureValues` struct in
+   `src/features/<feature>.rs` with `#[serde(rename = "<camelCase>")]`.
+   Emit any `ClusterClassPatches` you need.  Gate optional behaviour with
+   `enabledIf: "{{ if .yourCamelCaseVar }}true{{end}}"`.
+4. **Layer 3.**  Verify the rendered YAML in unit tests
+   (`cargo test --lib <feature>`) — the `TestClusterResources` helper
+   applies the patches against the template defaults so you can assert
+   the final shape.
+5. **Docs.**  Add an entry under the appropriate section of
+   `docs/user/labels.md`.  Include: default value, supported values, and
+   the **operational consequence** (not just "what flag it sets").
+
+## Common pitfalls
+
+* **Single label drives multiple variables.**  Some labels split into
+  several variables for downstream gating — for example,
+  `master_lb_floating_ip_enabled` populates *both*
+  `disableAPIServerFloatingIP` (the actual boolean) *and*
+  `disableAPIServerFloatingIPManaged` (a presence flag that activates the
+  patch).  See `src/immutable_fields.rs` and
+  `src/features/disable_api_server_floating_ip.rs` for the canonical
+  example.
+
+* **Variable name vs. label name.**  ClusterClass variables are camelCase
+  (`disableAPIServerFloatingIP`); Magnum labels are snake_case
+  (`master_lb_floating_ip_enabled`).  These are not always direct
+  translations of each other — always check `resources.py` for the actual
+  mapping.
+
+* **Adding a label with no warning on typo.**  Magnum silently ignores
+  labels it does not understand; if a label has no effect, double-check
+  the spelling against `magnum_cluster_api/utils.py`.
+
+## Where each existing label lives
+
+For the user-facing list with defaults and operational consequences,
+see [`docs/user/labels.md`](../user/labels.md).
+
+For the ClusterClass variable shape (Layer 2 → Layer 3), grep for the
+`#[serde(rename = "...")]` attributes in `src/features/`.
+
+For the Magnum label → variable mapping (Layer 1 → Layer 2), grep
+`cluster.labels` in `magnum_cluster_api/utils.py` and
+`magnum_cluster_api/resources.py`.

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -124,6 +124,20 @@ is often accomplished by deploying a driver on each node.
 
    Default value: Octavia default
 
+* `octavia_enabled`
+
+   Controls whether the OpenStack Cloud Controller Manager runs the `service`
+   controller, which reconciles `Service.type=LoadBalancer` against Octavia LBaaS.
+
+   When set to `false`, the `service` controller is omitted from the OCCM
+   `--controllers` flag.  Use this on bare-metal / edge / no-Octavia
+   deployments to avoid OCCM crash-looping on Octavia warm-up — the rest
+   of OCCM (`cloud-node`, `cloud-node-lifecycle`, `route`) keeps running
+   so node `ProviderID` is set and kubelet reaches `Ready`.  The only
+   feature lost is `Service.type=LoadBalancer` reconciliation.
+
+   Default value: `true`
+
 * `octavia_lb_algorithm`
 
    The Octavia load balancer algorithm to configure for the load balancers
@@ -246,6 +260,22 @@ is often accomplished by deploying a driver on each node.
    Default value: `true`
 
 ## OIDC
+
+* `enable_keystone_auth`
+
+   Enable the [k8s-keystone-auth](https://github.com/kubernetes/cloud-provider-openstack/tree/master/cmd/k8s-keystone-auth)
+   webhook for translating Keystone tokens into Kubernetes user/group identities.
+
+   When enabled, the kube-apiserver static-pod manifest is patched (via a
+   `kubectl kustomize` step in `postKubeadmCommands`) to add
+   `--authentication-token-webhook-config-file`,
+   `--authorization-webhook-config-file`, and to set
+   `--authorization-mode=Node,RBAC,Webhook`.  `Node` and `RBAC` are kept
+   in the authorizer chain so the cluster remains functional for system
+   requests even if the keystone-auth backend Pod is unreachable; only
+   Keystone-token-bearing requests depend on the webhook.
+
+   Default value: `false`
 
 * `oidc_issuer_url`
 


### PR DESCRIPTION
## Problem

mcapi's label → ClusterClass variable → patch behaviour mapping is split across three layers:

1. Python — `magnum_cluster_api/utils.py`, `magnum_cluster_api/resources.py` — read labels from the Magnum cluster/template and emit topology variables.
2. Rust — `src/features/*.rs` — declare `ClusterClassVariables` and JSON-patches that consume those variables.
3. CAPI — the rendered ClusterClass on the management cluster — applies the patches.

There is no single source of truth, so contributors and operators have a hard time knowing where to add a new label, where to debug an existing one, or even which labels are recognised. Two impactful labels (`octavia_enabled` and `enable_keystone_auth`) were entirely undocumented despite having significant operational consequences.

## Solution

Documentation-only baseline:

* `docs/user/labels.md` — add `octavia_enabled` and `enable_keystone_auth` entries with default values, behaviour, and operational notes.
* `docs/developer/labels.md` (new) — describe the three-layer architecture, with a checklist for adding a new label, the common pitfalls (forgetting one of the three layers; mismatched casing; missing topology-variable count bump in `resources.rs`), and pointers to the existing label catalog and Rust feature modules.

Auto-generation of the user-facing table from the ClusterClass feature inventory (`cargo run --bin gen-labels-doc`) is intentionally **out of scope** for this PR — the doc-only baseline first ensures the layered architecture is documented and the two undocumented labels are visible. A follow-up can wire in the generator once the catalogue stabilises.

## Changes

* `docs/user/labels.md` — new entries for `octavia_enabled`, `enable_keystone_auth`.
* `docs/developer/labels.md` — new file (architecture + checklist).

## Tests

Docs only — no code change. `cargo test --lib` and `pytest` both unaffected.
