### PR TITLE
ci: stop testing Magnum master on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
             python-version: "3.12"
           - openstack-version: "2023.2"
             python-version: "3.12"
+          - openstack-version: "master"
+            python-version: "3.10"
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1


### PR DESCRIPTION
## What changed

This removes the `coinstall (master, 3.10)` GitHub Actions matrix lane.

## Why

The lane is no longer a valid compatibility target. Magnum `master` currently declares:

```ini
python_requires = >=3.11
```

and its supported classifiers are Python 3.11, 3.12, 3.13, and 3.14. It no longer advertises Python 3.10 support on master.

The failing PR #1013 job matched that metadata. The `master + Python 3.10` coinstall resolved OpenStack master constraints to:

- `taskflow===6.2.0`
- `networkx===3.6.1`

`networkx===3.6.1` requires Python >=3.11, so dependency resolution fails before this repository is actually tested. Older OpenStack release lanes can still test Python 3.10 where those releases support it; this change only drops the invalid Magnum master + Python 3.10 combination.

## Validation

- Confirmed Magnum master `setup.cfg` has `python_requires = >=3.11`.
- Confirmed OpenStack master upper constraints include `taskflow===6.2.0` and `networkx===3.6.1`.
- Ran `git diff --check`.
- Parsed `.github/workflows/ci.yml` with PyYAML.
