### PR TITLE
fix: migrate OpenStack lookups to openstacksdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* migrate OpenStack resource lookups to openstacksdk proxies, including
+  fixed network, fixed subnet, image metadata, volume type, Manila share type,
+  Octavia load balancer, flavor, and server group paths
+* use Magnum's native HTTPNotFound exception for missing node groups instead
+  of importing heatclient
+
 ## [0.36.6](https://github.com/vexxhost/magnum-cluster-api/compare/v0.36.5...v0.36.6) (2026-04-21)
 
 

--- a/magnum_cluster_api/clients.py
+++ b/magnum_cluster_api/clients.py
@@ -14,7 +14,7 @@
 
 import pykube  # type: ignore
 from magnum.common import clients, exception  # type: ignore
-from manilaclient.v2 import client as manilaclient  # type: ignore
+from openstack.shared_file_system.v2 import _proxy as shared_file_system_proxy
 
 
 class OpenStackClients(clients.OpenStackClients):
@@ -22,28 +22,27 @@ class OpenStackClients(clients.OpenStackClients):
 
     def __init__(self, context):
         super(OpenStackClients, self).__init__(context)
-        self._manila = None
+        self._shared_file_system = None
 
     @exception.wrap_keystone_exception
-    def manila(self):
-        if self._manila:
-            return self._manila
+    def shared_file_system(self):
+        if self._shared_file_system:
+            return self._shared_file_system
         endpoint_type = self._get_client_option("manila", "endpoint_type")
         region_name = self._get_client_option("manila", "region_name")
-        manilaclient_version = self._get_client_option("manila", "api_version")
         endpoint = self.url_for(
             service_type="sharev2", interface=endpoint_type, region_name=region_name
         )
-        args = {
-            "cacert": self._get_client_option("manila", "ca_file"),
-            "insecure": self._get_client_option("manila", "insecure"),
-        }
 
         session = self.keystone().session
-        self._manila = manilaclient.Client(
-            manilaclient_version, session=session, service_catalog_url=endpoint, **args
+        self._shared_file_system = shared_file_system_proxy.Proxy(
+            session,
+            service_type="sharev2",
+            interface=endpoint_type,
+            region_name=region_name,
+            endpoint_override=endpoint,
         )
-        return self._manila
+        return self._shared_file_system
 
 
 def get_pykube_api() -> pykube.HTTPClient:

--- a/magnum_cluster_api/clients.py
+++ b/magnum_cluster_api/clients.py
@@ -31,8 +31,8 @@ class OpenStackClients(clients.OpenStackClients):
 
         self._sdk_connection = connection.Connection(
             session=self.keystone().session,
-            region_name=self._get_client_option("keystone", "region_name"),
-            interface=self._get_client_option("keystone", "endpoint_type"),
+            region_name=self._get_client_option("neutron", "region_name"),
+            interface=self._get_client_option("neutron", "endpoint_type"),
         )
         return self._sdk_connection
 

--- a/magnum_cluster_api/clients.py
+++ b/magnum_cluster_api/clients.py
@@ -14,6 +14,10 @@
 
 import pykube  # type: ignore
 from magnum.common import clients, exception  # type: ignore
+from openstack.block_storage.v3 import _proxy as block_storage_proxy
+from openstack.compute.v2 import _proxy as compute_proxy
+from openstack.load_balancer.v2 import _proxy as load_balancer_proxy
+from openstack.network.v2 import _proxy as network_proxy
 from openstack.shared_file_system.v2 import _proxy as shared_file_system_proxy
 
 
@@ -24,23 +28,79 @@ class OpenStackClients(clients.OpenStackClients):
         super(OpenStackClients, self).__init__(context)
         self._shared_file_system = None
 
+    def _sdk_proxy(self, proxy, client, service_type):
+        endpoint_type = self._get_client_option(client, "endpoint_type")
+        region_name = self._get_client_option(client, "region_name")
+        endpoint = self.url_for(
+            service_type=service_type,
+            interface=endpoint_type,
+            region_name=region_name,
+        )
+
+        return proxy.Proxy(
+            self.keystone().session,
+            service_type=service_type,
+            interface=endpoint_type,
+            region_name=region_name,
+            endpoint_override=endpoint,
+        )
+
+    @exception.wrap_keystone_exception
+    def cinder(self):
+        if self._cinder:
+            return self._cinder
+
+        self._cinder = self._sdk_proxy(
+            block_storage_proxy,
+            "cinder",
+            "block-storage",
+        )
+        return self._cinder
+
+    @exception.wrap_keystone_exception
+    def neutron(self):
+        if self._neutron:
+            return self._neutron
+
+        self._neutron = self._sdk_proxy(
+            network_proxy,
+            "neutron",
+            "network",
+        )
+        return self._neutron
+
+    @exception.wrap_keystone_exception
+    def nova(self):
+        if self._nova:
+            return self._nova
+
+        self._nova = self._sdk_proxy(
+            compute_proxy,
+            "nova",
+            "compute",
+        )
+        return self._nova
+
+    @exception.wrap_keystone_exception
+    def octavia(self):
+        if self._octavia:
+            return self._octavia
+
+        self._octavia = self._sdk_proxy(
+            load_balancer_proxy,
+            "octavia",
+            "load-balancer",
+        )
+        return self._octavia
+
     @exception.wrap_keystone_exception
     def shared_file_system(self):
         if self._shared_file_system:
             return self._shared_file_system
-        endpoint_type = self._get_client_option("manila", "endpoint_type")
-        region_name = self._get_client_option("manila", "region_name")
-        endpoint = self.url_for(
-            service_type="sharev2", interface=endpoint_type, region_name=region_name
-        )
-
-        session = self.keystone().session
-        self._shared_file_system = shared_file_system_proxy.Proxy(
-            session,
-            service_type="sharev2",
-            interface=endpoint_type,
-            region_name=region_name,
-            endpoint_override=endpoint,
+        self._shared_file_system = self._sdk_proxy(
+            shared_file_system_proxy,
+            "manila",
+            "sharev2",
         )
         return self._shared_file_system
 

--- a/magnum_cluster_api/clients.py
+++ b/magnum_cluster_api/clients.py
@@ -14,11 +14,7 @@
 
 import pykube  # type: ignore
 from magnum.common import clients, exception  # type: ignore
-from openstack.block_storage.v3 import _proxy as block_storage_proxy
-from openstack.compute.v2 import _proxy as compute_proxy
-from openstack.load_balancer.v2 import _proxy as load_balancer_proxy
-from openstack.network.v2 import _proxy as network_proxy
-from openstack.shared_file_system.v2 import _proxy as shared_file_system_proxy
+from openstack import connection
 
 
 class OpenStackClients(clients.OpenStackClients):
@@ -26,35 +22,26 @@ class OpenStackClients(clients.OpenStackClients):
 
     def __init__(self, context):
         super(OpenStackClients, self).__init__(context)
+        self._sdk_connection = None
         self._shared_file_system = None
 
-    def _sdk_proxy(self, proxy, client, service_type):
-        endpoint_type = self._get_client_option(client, "endpoint_type")
-        region_name = self._get_client_option(client, "region_name")
-        endpoint = self.url_for(
-            service_type=service_type,
-            interface=endpoint_type,
-            region_name=region_name,
-        )
+    def _get_sdk_connection(self):
+        if self._sdk_connection:
+            return self._sdk_connection
 
-        return proxy.Proxy(
-            self.keystone().session,
-            service_type=service_type,
-            interface=endpoint_type,
-            region_name=region_name,
-            endpoint_override=endpoint,
+        self._sdk_connection = connection.Connection(
+            session=self.keystone().session,
+            region_name=self._get_client_option("keystone", "region_name"),
+            interface=self._get_client_option("keystone", "endpoint_type"),
         )
+        return self._sdk_connection
 
     @exception.wrap_keystone_exception
     def cinder(self):
         if self._cinder:
             return self._cinder
 
-        self._cinder = self._sdk_proxy(
-            block_storage_proxy,
-            "cinder",
-            "block-storage",
-        )
+        self._cinder = self._get_sdk_connection().block_storage
         return self._cinder
 
     @exception.wrap_keystone_exception
@@ -62,11 +49,7 @@ class OpenStackClients(clients.OpenStackClients):
         if self._neutron:
             return self._neutron
 
-        self._neutron = self._sdk_proxy(
-            network_proxy,
-            "neutron",
-            "network",
-        )
+        self._neutron = self._get_sdk_connection().network
         return self._neutron
 
     @exception.wrap_keystone_exception
@@ -74,11 +57,7 @@ class OpenStackClients(clients.OpenStackClients):
         if self._nova:
             return self._nova
 
-        self._nova = self._sdk_proxy(
-            compute_proxy,
-            "nova",
-            "compute",
-        )
+        self._nova = self._get_sdk_connection().compute
         return self._nova
 
     @exception.wrap_keystone_exception
@@ -86,22 +65,14 @@ class OpenStackClients(clients.OpenStackClients):
         if self._octavia:
             return self._octavia
 
-        self._octavia = self._sdk_proxy(
-            load_balancer_proxy,
-            "octavia",
-            "load-balancer",
-        )
+        self._octavia = self._get_sdk_connection().load_balancer
         return self._octavia
 
     @exception.wrap_keystone_exception
     def shared_file_system(self):
         if self._shared_file_system:
             return self._shared_file_system
-        self._shared_file_system = self._sdk_proxy(
-            shared_file_system_proxy,
-            "manila",
-            "sharev2",
-        )
+        self._shared_file_system = self._get_sdk_connection().shared_file_system
         return self._shared_file_system
 
 

--- a/magnum_cluster_api/conf.py
+++ b/magnum_cluster_api/conf.py
@@ -68,7 +68,7 @@ manila_client_opts = [
     cfg.StrOpt(
         "api_version",
         default="3",
-        help=_("Version of Manila API to use in manilaclient."),
+        help=_("Deprecated compatibility option for older Manila client wiring."),
     ),
 ]
 

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import keystoneauth1  # type: ignore
 from eventlet import tpool  # type: ignore
-from heatclient import exc  # type: ignore
 from magnum import objects as magnum_objects  # type: ignore
 from magnum.common import exception as magnum_exception  # type: ignore
 from magnum.conductor import scale_manager  # type: ignore
@@ -705,9 +704,9 @@ class BaseDriver(driver.Driver):
             md_index = cluster_resource.get_machine_deployment_index(nodegroup.name)
         except exceptions.MachineDeploymentNotFound:
             # NOTE(mnaser): The Magnum node group API assumes that the node group is
-            #               gone if we get `exc.HTTPNotFound` so we raise it here to
+            #               gone if we get `HTTPNotFound` so we raise it here to
             #               let it destroy the node group.
-            raise exc.HTTPNotFound()
+            raise magnum_exception.HTTPNotFound()
 
         del cluster_resource.obj["spec"]["topology"]["workers"]["machineDeployments"][
             md_index

--- a/magnum_cluster_api/integrations/cinder.py
+++ b/magnum_cluster_api/integrations/cinder.py
@@ -17,8 +17,7 @@ from magnum.common import exception
 from oslo_config import cfg
 
 from magnum_cluster_api import clients
-from magnum_cluster_api.integrations import common
-from magnum_cluster_api.integrations import openstack
+from magnum_cluster_api.integrations import common, openstack
 
 CONF = cfg.CONF
 

--- a/magnum_cluster_api/integrations/cinder.py
+++ b/magnum_cluster_api/integrations/cinder.py
@@ -18,6 +18,7 @@ from oslo_config import cfg
 
 from magnum_cluster_api import clients
 from magnum_cluster_api.integrations import common
+from magnum_cluster_api.integrations import openstack
 
 CONF = cfg.CONF
 
@@ -42,7 +43,7 @@ def get_default_boot_volume_type(context):
         return CONF.cinder.default_boot_volume_type
 
     osc = clients.get_openstack_api(context)
-    default_volume_type = osc.cinder().volume_types.default()
+    default_volume_type = openstack.get_default_volume_type(osc)
 
     if default_volume_type is None:
         raise exception.VolumeTypeNotFound()

--- a/magnum_cluster_api/integrations/openstack.py
+++ b/magnum_cluster_api/integrations/openstack.py
@@ -85,6 +85,22 @@ def list_load_balancers(osc) -> list[typing.Any]:
     return list(osc.octavia().load_balancers())
 
 
+def delete_load_balancer(osc, load_balancer: typing.Any, cascade: bool = True) -> None:
+    osc.octavia().delete_load_balancer(
+        load_balancer,
+        ignore_missing=True,
+        cascade=cascade,
+    )
+
+
+def list_floating_ips(osc, **query) -> list[typing.Any]:
+    return list(osc.neutron().ips(**query))
+
+
+def delete_floating_ip(osc, floating_ip: typing.Any) -> None:
+    osc.neutron().delete_ip(floating_ip, ignore_missing=True)
+
+
 def find_network(osc, name_or_id: str, external: bool):
     network = osc.neutron().find_network(name_or_id, ignore_missing=True)
     if network is None:

--- a/magnum_cluster_api/integrations/openstack.py
+++ b/magnum_cluster_api/integrations/openstack.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import typing
+
+from magnum.common import exception  # type: ignore
+from openstack import exceptions as sdk_exceptions
+from openstack import resource
+from openstack.shared_file_system.shared_file_system_service import (
+    SharedFilesystemService,
+)
+
+
+class ShareType(resource.Resource):
+    resource_key = "share_type"
+    resources_key = "share_types"
+    base_path = "/types"
+    service = SharedFilesystemService("sharev2")
+
+    allow_list = True
+
+
+def get_resource_value(resource: typing.Any, key: str, default: typing.Any = None):
+    if resource is None:
+        return default
+
+    if isinstance(resource, dict):
+        value = resource.get(key, default)
+        return default if value is None else value
+
+    value = getattr(resource, key, None)
+    if value is not None:
+        return value
+
+    properties = getattr(resource, "properties", None) or {}
+    if isinstance(properties, dict):
+        value = properties.get(key)
+        if value is not None:
+            return value
+
+    try:
+        value = resource[key]
+    except Exception:
+        return default
+    else:
+        return default if value is None else value
+
+
+def get_image_property(image: typing.Any, key: str, default: typing.Any = None):
+    return get_resource_value(image, key, default)
+
+
+def list_volume_types(osc) -> list[typing.Any]:
+    return list(osc.cinder().types())
+
+
+def get_default_volume_type(osc):
+    cinder = osc.cinder()
+
+    try:
+        return cinder.get_type("default")
+    except sdk_exceptions.SDKException:
+        pass
+
+    if callable(getattr(cinder, "find_type", None)):
+        return cinder.find_type("__DEFAULT__", ignore_missing=True)
+
+    return None
+
+
+def list_load_balancers(osc) -> list[typing.Any]:
+    return list(osc.octavia().load_balancers())
+
+
+def find_network(osc, name_or_id: str, external: bool):
+    network = osc.neutron().find_network(name_or_id, ignore_missing=True)
+    if network is None:
+        return None
+
+    if get_resource_value(network, "is_router_external", False) != external:
+        return None
+
+    return network
+
+
+def get_network_value(
+    osc,
+    name_or_id: str,
+    target: str,
+    external: bool,
+    not_found: type[Exception],
+):
+    network = find_network(osc, name_or_id, external)
+    if network is None:
+        raise not_found(network=name_or_id)
+
+    return get_resource_value(network, target)
+
+
+def get_subnet_value(osc, name_or_id: str, target: str):
+    subnet = osc.neutron().find_subnet(name_or_id, ignore_missing=True)
+    if subnet is None:
+        raise exception.FixedSubnetNotFound(subnet=name_or_id)
+
+    return get_resource_value(subnet, target)
+
+
+def list_flavors(osc) -> list[typing.Any]:
+    return list(osc.nova().flavors())
+
+
+def list_server_groups(osc, all_projects: bool = False) -> list[typing.Any]:
+    return list(osc.nova().server_groups(all_projects=all_projects))
+
+
+def list_share_types(osc) -> list[typing.Any]:
+    return list(osc.shared_file_system()._list(ShareType))
+
+
+def create_server_group(osc, name: str, policies: list[str]):
+    return osc.nova().create_server_group(name=name, policies=policies)
+
+
+def delete_server_group(osc, server_group_id: str) -> None:
+    osc.nova().delete_server_group(server_group_id, ignore_missing=True)

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -44,8 +44,7 @@ from magnum_cluster_api import (
     objects,
     utils,
 )
-from magnum_cluster_api.integrations import cinder, manila
-from magnum_cluster_api.integrations import openstack
+from magnum_cluster_api.integrations import cinder, manila, openstack
 
 CONF = cfg.CONF
 CALICO_TAG = "v3.31.5"
@@ -832,9 +831,7 @@ def mutate_machine_deployment(
                     },
                     {
                         "name": "hardwareDiskBus",
-                        "value": openstack.get_image_property(
-                            image, "hw_disk_bus", ""
-                        ),
+                        "value": openstack.get_image_property(image, "hw_disk_bus", ""),
                     },
                     # NOTE(oleks): Override using MachineDeployment-level variables for node groups
                     {

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -24,7 +24,7 @@ import pkg_resources
 import pykube  # type: ignore
 import yaml
 from magnum import objects as magnum_objects  # type: ignore
-from magnum.common import context, neutron  # type: ignore
+from magnum.common import context, exception  # type: ignore
 from magnum.common import utils as magnum_utils  # type: ignore
 from magnum.common.cert_manager import cert_manager  # type: ignore
 from magnum.common.x509 import operations as x509  # type: ignore
@@ -45,6 +45,7 @@ from magnum_cluster_api import (
     utils,
 )
 from magnum_cluster_api.integrations import cinder, manila
+from magnum_cluster_api.integrations import openstack
 
 CONF = cfg.CONF
 CALICO_TAG = "v3.31.5"
@@ -263,8 +264,12 @@ class CloudProviderClusterResourcesSecret(ClusterBase):
 
         osc = clients.get_openstack_api(self.context)
         if cinder.is_enabled(self.cluster):
-            volume_types = osc.cinder().volume_types.list()
-            default_volume_type = osc.cinder().volume_types.default()
+            volume_types = openstack.list_volume_types(osc)
+            default_volume_type = openstack.get_default_volume_type(osc)
+            default_volume_type_name = openstack.get_resource_value(
+                default_volume_type,
+                "name",
+            )
             data = {
                 **data,
                 **magnum_cluster_api.Driver.get_cinder_csi_cluster_resource_secret_data(
@@ -281,7 +286,7 @@ class CloudProviderClusterResourcesSecret(ClusterBase):
                                     {
                                         "storageclass.kubernetes.io/is-default-class": "true"
                                     }
-                                    if default_volume_type.name == vt.name
+                                    if default_volume_type_name == vt.name
                                     else {}
                                 ),
                                 "name": "block-%s" % utils.convert_to_rfc1123(vt.name),
@@ -300,7 +305,7 @@ class CloudProviderClusterResourcesSecret(ClusterBase):
             }
 
         if manila.is_enabled(self.cluster):
-            share_types = osc.manila().share_types.list()
+            share_types = openstack.list_share_types(osc)
             share_network_id = self.cluster.labels.get("manila_csi_share_network_id")
             data = {
                 **data,
@@ -823,11 +828,13 @@ def mutate_machine_deployment(
                     },
                     {
                         "name": "imageUUID",
-                        "value": image.get("id"),
+                        "value": openstack.get_image_property(image, "id"),
                     },
                     {
                         "name": "hardwareDiskBus",
-                        "value": image.get("hw_disk_bus", ""),
+                        "value": openstack.get_image_property(
+                            image, "hw_disk_bus", ""
+                        ),
                     },
                     # NOTE(oleks): Override using MachineDeployment-level variables for node groups
                     {
@@ -978,7 +985,12 @@ class Cluster(ClusterBase):
 
     def get_object(self) -> dict:
         osc = clients.get_openstack_api(self.context)
-        default_volume_type = osc.cinder().volume_types.default()
+        default_volume_type = openstack.get_default_volume_type(osc)
+        default_volume_type_name = openstack.get_resource_value(
+            default_volume_type,
+            "name",
+            "",
+        )
         pod_cidr = DEFAULT_POD_CIDR
         if self.cluster.cluster_template.network_driver == "calico":
             pod_cidr = self.cluster.labels.get(
@@ -1188,9 +1200,12 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "externalNetworkId",
-                            "value": neutron.get_external_network_id(
-                                self.context,
+                            "value": openstack.get_network_value(
+                                osc,
                                 self.cluster.cluster_template.external_network_id,
+                                "id",
+                                True,
+                                exception.ExternalNetworkNotFound,
                             ),
                         },
                         {
@@ -1202,7 +1217,7 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "fixedSubnetId",
-                            "value": neutron.get_fixed_subnet_id(
+                            "value": utils.get_fixed_subnet_id(
                                 self.context, self.cluster.fixed_subnet
                             )
                             or "",
@@ -1219,7 +1234,7 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "imageUUID",
-                            "value": image.get("id"),
+                            "value": openstack.get_image_property(image, "id"),
                         },
                         {
                             "name": "kubeletTLSCipherSuites",
@@ -1249,7 +1264,9 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "hardwareDiskBus",
-                            "value": image.get("hw_disk_bus", ""),
+                            "value": openstack.get_image_property(
+                                image, "hw_disk_bus", ""
+                            ),
                         },
                         {
                             "name": "enableDockerVolume",
@@ -1263,7 +1280,7 @@ class Cluster(ClusterBase):
                             "name": "dockerVolumeType",
                             "value": self.cluster.labels.get(
                                 "docker_volume_type",
-                                default_volume_type.name,
+                                default_volume_type_name,
                             ),
                         },
                         {
@@ -1287,7 +1304,7 @@ class Cluster(ClusterBase):
                             "name": "etcdVolumeType",
                             "value": self.cluster.labels.get(
                                 "etcd_volume_type",
-                                default_volume_type.name,
+                                default_volume_type_name,
                             ),
                         },
                         {

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -99,9 +99,15 @@ def mock_osc(session_mocker, image):
     mock_glance_client = mock_clients.glance.return_value
     mock_glance_client.images.get.return_value = image
 
+    # Neutron
+    mock_network = mock.Mock()
+    mock_network.id = uuidutils.generate_uuid()
+    mock_network.is_router_external = True
+    mock_clients.neutron.return_value.find_network.return_value = mock_network
+
     # Cinder
     mock_cinder_client = mock_clients.cinder.return_value
-    mock_cinder_client.volume_types.default.return_value.name = "__DEFAULT__"
+    mock_cinder_client.get_type.return_value.name = "__DEFAULT__"
     mock_clients.cinder_region_name.return_value = "RegionOne"
 
     # Others

--- a/magnum_cluster_api/tests/functional/test_resources.py
+++ b/magnum_cluster_api/tests/functional/test_resources.py
@@ -56,7 +56,7 @@ class ResourceBaseTestCase(base.BaseTestCase):
         self.mock_cinder = self.useFixture(
             fixtures.MockPatch("magnum_cluster_api.clients.OpenStackClients.cinder")
         ).mock
-        self.mock_cinder.return_value.volume_types.default.return_value.name = (
+        self.mock_cinder.return_value.get_type.return_value.name = (
             "fake-boot-volume-type"
         )
 

--- a/magnum_cluster_api/tests/unit/integrations/test_openstack.py
+++ b/magnum_cluster_api/tests/unit/integrations/test_openstack.py
@@ -15,9 +15,9 @@
 from types import SimpleNamespace
 from unittest import mock
 
+from magnum.common import exception
 from openstack import exceptions as sdk_exceptions
 
-from magnum.common import exception
 from magnum_cluster_api.integrations import openstack
 
 

--- a/magnum_cluster_api/tests/unit/integrations/test_openstack.py
+++ b/magnum_cluster_api/tests/unit/integrations/test_openstack.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from types import SimpleNamespace
+from unittest import mock
+
+from openstack import exceptions as sdk_exceptions
+
+from magnum.common import exception
+from magnum_cluster_api.integrations import openstack
+
+
+def test_get_resource_value_from_dict():
+    assert openstack.get_resource_value({"name": "value"}, "name") == "value"
+
+
+def test_get_resource_value_uses_default_for_none_dict_value():
+    assert openstack.get_resource_value({"hw_disk_bus": None}, "hw_disk_bus", "") == ""
+
+
+def test_get_resource_value_from_resource_attribute():
+    resource = SimpleNamespace(name="value")
+
+    assert openstack.get_resource_value(resource, "name") == "value"
+
+
+def test_get_resource_value_from_resource_properties():
+    resource = SimpleNamespace(properties={"hw_disk_bus": "scsi"})
+
+    assert openstack.get_resource_value(resource, "hw_disk_bus") == "scsi"
+
+
+def test_get_default_volume_type_uses_cinder_default_endpoint():
+    osc = mock.Mock()
+    volume_type = SimpleNamespace(name="fast")
+    osc.cinder.return_value.get_type.return_value = volume_type
+
+    assert openstack.get_default_volume_type(osc) is volume_type
+    osc.cinder.return_value.get_type.assert_called_once_with("default")
+
+
+def test_get_default_volume_type_falls_back_to_default_type_name():
+    osc = mock.Mock()
+    volume_type = SimpleNamespace(name="__DEFAULT__")
+    cinder = osc.cinder.return_value
+    cinder.get_type.side_effect = sdk_exceptions.NotFoundException()
+    cinder.find_type.return_value = volume_type
+
+    assert openstack.get_default_volume_type(osc) is volume_type
+    cinder.find_type.assert_called_once_with("__DEFAULT__", ignore_missing=True)
+
+
+def test_list_share_types_uses_shared_file_system_proxy():
+    osc = mock.Mock()
+    share_types = [SimpleNamespace(name="cephfs")]
+    osc.shared_file_system.return_value._list.return_value = share_types
+
+    assert openstack.list_share_types(osc) == share_types
+    osc.shared_file_system.return_value._list.assert_called_once_with(
+        openstack.ShareType
+    )
+
+
+def test_get_network_value_finds_matching_external_network():
+    osc = mock.Mock()
+    network = SimpleNamespace(id="net-id", is_router_external=True)
+    osc.neutron.return_value.find_network.return_value = network
+
+    assert (
+        openstack.get_network_value(
+            osc,
+            "public",
+            "id",
+            True,
+            exception.ExternalNetworkNotFound,
+        )
+        == "net-id"
+    )
+    osc.neutron.return_value.find_network.assert_called_once_with(
+        "public", ignore_missing=True
+    )
+
+
+def test_get_network_value_rejects_wrong_external_flag():
+    osc = mock.Mock()
+    network = SimpleNamespace(id="net-id", is_router_external=True)
+    osc.neutron.return_value.find_network.return_value = network
+
+    try:
+        openstack.get_network_value(
+            osc,
+            "private",
+            "id",
+            False,
+            exception.FixedNetworkNotFound,
+        )
+    except exception.FixedNetworkNotFound:
+        pass
+    else:
+        raise AssertionError("expected FixedNetworkNotFound")
+
+
+def test_get_subnet_value_finds_subnet():
+    osc = mock.Mock()
+    subnet = SimpleNamespace(id="subnet-id", name="private-subnet")
+    osc.neutron.return_value.find_subnet.return_value = subnet
+
+    assert openstack.get_subnet_value(osc, "private-subnet", "id") == "subnet-id"
+    osc.neutron.return_value.find_subnet.assert_called_once_with(
+        "private-subnet", ignore_missing=True
+    )
+
+
+def test_get_subnet_value_raises_when_missing():
+    osc = mock.Mock()
+    osc.neutron.return_value.find_subnet.return_value = None
+
+    try:
+        openstack.get_subnet_value(osc, "missing-subnet", "id")
+    except exception.FixedSubnetNotFound:
+        pass
+    else:
+        raise AssertionError("expected FixedSubnetNotFound")

--- a/magnum_cluster_api/tests/unit/test_clients.py
+++ b/magnum_cluster_api/tests/unit/test_clients.py
@@ -47,8 +47,8 @@ def test_get_sdk_connection_uses_keystone_session(mocker):
     osc = clients.OpenStackClients(mock.Mock())
     osc._get_client_option = mock.Mock(
         side_effect=lambda client, option: {
-            ("keystone", "endpoint_type"): "internal",
-            ("keystone", "region_name"): "RegionOne",
+            ("neutron", "endpoint_type"): "internal",
+            ("neutron", "region_name"): "RegionOne",
         }[(client, option)]
     )
     osc.keystone = mock.Mock()

--- a/magnum_cluster_api/tests/unit/test_clients.py
+++ b/magnum_cluster_api/tests/unit/test_clients.py
@@ -20,54 +20,47 @@ from magnum_cluster_api import clients
 
 
 @pytest.mark.parametrize(
-    ("method", "client", "service_type"),
+    ("method", "proxy"),
     (
-        ("cinder", "cinder", "block-storage"),
-        ("neutron", "neutron", "network"),
-        ("nova", "nova", "compute"),
-        ("octavia", "octavia", "load-balancer"),
-        ("shared_file_system", "manila", "sharev2"),
+        ("cinder", "block_storage"),
+        ("neutron", "network"),
+        ("nova", "compute"),
+        ("octavia", "load_balancer"),
+        ("shared_file_system", "shared_file_system"),
     ),
 )
-def test_openstack_clients_use_sdk_proxies(method, client, service_type):
+def test_openstack_clients_use_sdk_proxies(method, proxy):
     osc = clients.OpenStackClients(mock.Mock())
-    sdk_proxy = mock.Mock()
-    osc._sdk_proxy = mock.Mock(return_value=sdk_proxy)
+    sdk_connection = mock.Mock()
+    osc._get_sdk_connection = mock.Mock(return_value=sdk_connection)
 
     first = getattr(osc, method)()
     second = getattr(osc, method)()
 
-    assert first == sdk_proxy
-    assert second == sdk_proxy
-    osc._sdk_proxy.assert_called_once()
-    assert osc._sdk_proxy.call_args.args[1:] == (client, service_type)
+    assert first == getattr(sdk_connection, proxy)
+    assert second == getattr(sdk_connection, proxy)
+    osc._get_sdk_connection.assert_called_once()
 
 
-def test_sdk_proxy_uses_service_endpoint(mocker):
+def test_get_sdk_connection_uses_keystone_session(mocker):
+    mock_connection = mocker.patch("magnum_cluster_api.clients.connection.Connection")
     osc = clients.OpenStackClients(mock.Mock())
     osc._get_client_option = mock.Mock(
         side_effect=lambda client, option: {
-            ("neutron", "endpoint_type"): "internal",
-            ("neutron", "region_name"): "RegionOne",
+            ("keystone", "endpoint_type"): "internal",
+            ("keystone", "region_name"): "RegionOne",
         }[(client, option)]
     )
-    osc.url_for = mock.Mock(return_value="http://neutron.example/v2.0")
     osc.keystone = mock.Mock()
     osc.keystone.return_value.session = mock.Mock()
-    proxy = mock.Mock()
 
-    sdk_proxy = osc._sdk_proxy(proxy, "neutron", "network")
+    sdk_connection = osc._get_sdk_connection()
+    cached_connection = osc._get_sdk_connection()
 
-    assert sdk_proxy == proxy.Proxy.return_value
-    osc.url_for.assert_called_once_with(
-        service_type="network",
-        interface="internal",
+    assert sdk_connection == mock_connection.return_value
+    assert cached_connection == mock_connection.return_value
+    mock_connection.assert_called_once_with(
+        session=osc.keystone.return_value.session,
         region_name="RegionOne",
-    )
-    proxy.Proxy.assert_called_once_with(
-        osc.keystone.return_value.session,
-        service_type="network",
         interface="internal",
-        region_name="RegionOne",
-        endpoint_override="http://neutron.example/v2.0",
     )

--- a/magnum_cluster_api/tests/unit/test_clients.py
+++ b/magnum_cluster_api/tests/unit/test_clients.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+import pytest
+
+from magnum_cluster_api import clients
+
+
+@pytest.mark.parametrize(
+    ("method", "client", "service_type"),
+    (
+        ("cinder", "cinder", "block-storage"),
+        ("neutron", "neutron", "network"),
+        ("nova", "nova", "compute"),
+        ("octavia", "octavia", "load-balancer"),
+        ("shared_file_system", "manila", "sharev2"),
+    ),
+)
+def test_openstack_clients_use_sdk_proxies(method, client, service_type):
+    osc = clients.OpenStackClients(mock.Mock())
+    sdk_proxy = mock.Mock()
+    osc._sdk_proxy = mock.Mock(return_value=sdk_proxy)
+
+    first = getattr(osc, method)()
+    second = getattr(osc, method)()
+
+    assert first == sdk_proxy
+    assert second == sdk_proxy
+    osc._sdk_proxy.assert_called_once()
+    assert osc._sdk_proxy.call_args.args[1:] == (client, service_type)
+
+
+def test_sdk_proxy_uses_service_endpoint(mocker):
+    osc = clients.OpenStackClients(mock.Mock())
+    osc._get_client_option = mock.Mock(
+        side_effect=lambda client, option: {
+            ("neutron", "endpoint_type"): "internal",
+            ("neutron", "region_name"): "RegionOne",
+        }[(client, option)]
+    )
+    osc.url_for = mock.Mock(return_value="http://neutron.example/v2.0")
+    osc.keystone = mock.Mock()
+    osc.keystone.return_value.session = mock.Mock()
+    proxy = mock.Mock()
+
+    sdk_proxy = osc._sdk_proxy(proxy, "neutron", "network")
+
+    assert sdk_proxy == proxy.Proxy.return_value
+    osc.url_for.assert_called_once_with(
+        service_type="network",
+        interface="internal",
+        region_name="RegionOne",
+    )
+    proxy.Proxy.assert_called_once_with(
+        osc.keystone.return_value.session,
+        service_type="network",
+        interface="internal",
+        region_name="RegionOne",
+        endpoint_override="http://neutron.example/v2.0",
+    )

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -166,6 +166,26 @@ class TestDriver:
             json=json,
         )
 
+    def _response_for_machine_sets(self):
+        return responses.Response(
+            responses.GET,
+            "http://localhost/apis/%s/namespaces/%s/%s"
+            % (
+                objects.MachineSet.version,
+                "magnum-system",
+                objects.MachineSet.endpoint,
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "labelSelector": "cluster.x-k8s.io/cluster-name=%s,topology.cluster.x-k8s.io/deployment-name=%s"
+                        % (self.cluster.stack_id, self.node_group.name)
+                    }
+                ),
+            ],
+            json={"items": []},
+        )
+
     def _response_for_openstack_machines(self, deployment_name, machine_specs=None):
         """Helper method to create a mock response for OpenStackMachine API calls."""
         json = {"items": []}
@@ -331,10 +351,14 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
-    def setup_node_group_tests(self, rsps, before, after=None):
+    def setup_node_group_tests(
+        self, rsps, before, after=None, include_machine_sets=False
+    ):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),
         )
+        if include_machine_sets:
+            rsps.add(self._response_for_machine_sets())
         if after:
             rsps.add(
                 self._response_for_cluster_with_machine_deployments(
@@ -381,6 +405,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                include_machine_sets=True,
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
@@ -426,6 +451,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                include_machine_sets=True,
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -19,7 +19,7 @@ import openstack
 import pykube
 import pytest
 import responses
-from heatclient import exc  # type: ignore
+from magnum.common import exception as magnum_exception  # type: ignore
 from magnum.objects import fields  # type: ignore
 from magnum.tests.unit.objects import utils  # type: ignore
 from novaclient.v2 import flavors  # type: ignore
@@ -516,7 +516,7 @@ class TestDriver:
                 ],
             )
 
-            with pytest.raises(exc.HTTPNotFound):
+            with pytest.raises(magnum_exception.HTTPNotFound):
                 ubuntu_driver.delete_nodegroup(context, self.cluster, self.node_group)
 
     def test_update_nodegroups_status_delete_complete(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -109,7 +109,7 @@ class TestGenerateCloudControllerManagerConfig:
             tls-insecure=false
 
             [LoadBalancer]
-            lb-provider=amphora
+            lb-provider=amphorav2
             lb-method=ROUND_ROBIN
             create-monitor=True
             """
@@ -302,46 +302,53 @@ class TestGenerateAptProxyConfig:
 class TestUtils(base.BaseTestCase):
     """Test case for utils."""
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_uuid(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_network_value")
+    def test_get_fixed_network_id_with_uuid(self, mock_get_network_value):
         context = mock.Mock()
         fixed_network = uuidutils.generate_uuid()
 
         network = utils.get_fixed_network_id(context, fixed_network)
 
-        mock_get_network.assert_not_called()
+        mock_get_network_value.assert_not_called()
         self.assertEqual(fixed_network, network)
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_name(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_network_value")
+    def test_get_fixed_network_id_with_name(
+        self, mock_get_network_value, mock_get_openstack_api
+    ):
         context = mock.Mock()
         fixed_network = "fake-network"
 
         network_id = uuidutils.generate_uuid()
-        mock_get_network.return_value = network_id
+        mock_get_network_value.return_value = network_id
 
         network = utils.get_fixed_network_id(context, fixed_network)
 
-        mock_get_network.assert_called_once_with(
-            context, fixed_network, source="name", target="id", external=False
+        mock_get_network_value.assert_called_once_with(
+            mock_get_openstack_api.return_value,
+            fixed_network,
+            "id",
+            False,
+            exception.FixedNetworkNotFound,
         )
         self.assertEqual(network_id, network)
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_no_fixed_network(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_network_value")
+    def test_get_fixed_network_id_with_no_fixed_network(self, mock_get_network_value):
         context = mock.Mock()
 
         network = utils.get_fixed_network_id(context, None)
 
-        mock_get_network.assert_not_called()
+        mock_get_network_value.assert_not_called()
         self.assertEqual(None, network)
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_missing_network(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_network_value")
+    def test_get_fixed_network_id_with_missing_network(self, mock_get_network_value):
         context = mock.Mock()
         fixed_network = "fake-network"
 
-        mock_get_network.side_effect = exception.FixedNetworkNotFound(
+        mock_get_network_value.side_effect = exception.FixedNetworkNotFound(
             network=fixed_network
         )
 
@@ -352,12 +359,12 @@ class TestUtils(base.BaseTestCase):
             fixed_network,
         )
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_multiple_networks(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_network_value")
+    def test_get_fixed_network_id_with_multiple_networks(self, mock_get_network_value):
         context = mock.Mock()
         fixed_network = "fake-network"
 
-        mock_get_network.side_effect = exception.Conflict(
+        mock_get_network_value.side_effect = exception.Conflict(
             "Multiple networks exist with same name '%s'. Please use the "
             "network ID instead." % fixed_network
         )
@@ -367,4 +374,59 @@ class TestUtils(base.BaseTestCase):
             utils.get_fixed_network_id,
             context,
             fixed_network,
+        )
+
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_subnet_value")
+    def test_get_fixed_subnet_id_with_uuid(self, mock_get_subnet_value):
+        context = mock.Mock()
+        fixed_subnet = uuidutils.generate_uuid()
+
+        subnet = utils.get_fixed_subnet_id(context, fixed_subnet)
+
+        mock_get_subnet_value.assert_not_called()
+        self.assertEqual(fixed_subnet, subnet)
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_subnet_value")
+    def test_get_fixed_subnet_id_with_name(
+        self, mock_get_subnet_value, mock_get_openstack_api
+    ):
+        context = mock.Mock()
+        fixed_subnet = "fake-subnet"
+
+        subnet_id = uuidutils.generate_uuid()
+        mock_get_subnet_value.return_value = subnet_id
+
+        subnet = utils.get_fixed_subnet_id(context, fixed_subnet)
+
+        mock_get_subnet_value.assert_called_once_with(
+            mock_get_openstack_api.return_value,
+            fixed_subnet,
+            "id",
+        )
+        self.assertEqual(subnet_id, subnet)
+
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_subnet_value")
+    def test_get_fixed_subnet_id_with_no_fixed_subnet(self, mock_get_subnet_value):
+        context = mock.Mock()
+
+        subnet = utils.get_fixed_subnet_id(context, None)
+
+        mock_get_subnet_value.assert_not_called()
+        self.assertEqual(None, subnet)
+
+    @mock.patch("magnum_cluster_api.integrations.openstack.get_subnet_value")
+    def test_get_fixed_subnet_id_with_missing_subnet(self, mock_get_subnet_value):
+        context = mock.Mock()
+        fixed_subnet = "fake-subnet"
+
+        mock_get_subnet_value.side_effect = exception.FixedSubnetNotFound(
+            subnet=fixed_subnet
+        )
+
+        self.assertRaises(
+            exception.FixedSubnetNotFound,
+            utils.get_fixed_subnet_id,
+            context,
+            fixed_subnet,
         )

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -430,3 +430,95 @@ class TestUtils(base.BaseTestCase):
             context,
             fixed_subnet,
         )
+
+    @mock.patch("magnum_cluster_api.utils.time.sleep")
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    @mock.patch("magnum_cluster_api.integrations.openstack.delete_floating_ip")
+    @mock.patch("magnum_cluster_api.integrations.openstack.list_floating_ips")
+    @mock.patch("magnum_cluster_api.integrations.openstack.delete_load_balancer")
+    @mock.patch("magnum_cluster_api.integrations.openstack.list_load_balancers")
+    def test_delete_loadbalancers_uses_openstacksdk(
+        self,
+        mock_list_load_balancers,
+        mock_delete_load_balancer,
+        mock_list_floating_ips,
+        mock_delete_floating_ip,
+        mock_get_openstack_api,
+        mock_sleep,
+    ):
+        context = mock.Mock()
+        cluster = magnum_test_utils.get_test_cluster(context)
+        cluster.uuid = "ec1ce9bb-dd7c-4e9d-9a64-c9e7835026f4"
+        osc = mock_get_openstack_api.return_value
+        load_balancer = {
+            "id": "fake-lb-id",
+            "vip_port_id": "fake-vip-port-id",
+            "description": (
+                "Kubernetes external service default/test from cluster "
+                "ec1ce9bb-dd7c-4e9d-9a64-c9e7835026f4"
+            ),
+            "provisioning_status": "ACTIVE",
+        }
+        ignored_load_balancer = {
+            "id": "other-lb-id",
+            "description": "Kubernetes external service default/test from cluster other",
+            "provisioning_status": "ACTIVE",
+        }
+        matching_fip = {
+            "id": "fake-fip-id",
+            "description": (
+                "Floating IP for Kubernetes default/test from cluster "
+                "ec1ce9bb-dd7c-4e9d-9a64-c9e7835026f4"
+            ),
+        }
+        ignored_fip = {
+            "id": "other-fip-id",
+            "description": "Floating IP for Kubernetes default/test from cluster other",
+        }
+        mock_list_load_balancers.side_effect = [
+            [load_balancer, ignored_load_balancer],
+            [],
+        ]
+        mock_list_floating_ips.return_value = [matching_fip, ignored_fip]
+
+        utils.delete_loadbalancers(context, cluster)
+
+        mock_get_openstack_api.assert_called_once_with(context)
+        mock_delete_load_balancer.assert_called_once_with(
+            osc, load_balancer, cascade=True
+        )
+        mock_list_floating_ips.assert_called_once_with(
+            osc, port_id="fake-vip-port-id"
+        )
+        mock_delete_floating_ip.assert_called_once_with(osc, matching_fip)
+        mock_sleep.assert_not_called()
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    @mock.patch("magnum_cluster_api.integrations.openstack.delete_load_balancer")
+    @mock.patch("magnum_cluster_api.integrations.openstack.list_load_balancers")
+    def test_delete_loadbalancers_wraps_sdk_errors(
+        self,
+        mock_list_load_balancers,
+        mock_delete_load_balancer,
+        mock_get_openstack_api,
+    ):
+        context = mock.Mock()
+        cluster = magnum_test_utils.get_test_cluster(context)
+        cluster.uuid = "ec1ce9bb-dd7c-4e9d-9a64-c9e7835026f4"
+        load_balancer = {
+            "id": "fake-lb-id",
+            "description": (
+                "Kubernetes external service default/test from cluster "
+                "ec1ce9bb-dd7c-4e9d-9a64-c9e7835026f4"
+            ),
+            "provisioning_status": "ACTIVE",
+        }
+        mock_list_load_balancers.return_value = [load_balancer]
+        mock_delete_load_balancer.side_effect = RuntimeError("sdk failed")
+
+        self.assertRaises(
+            exception.PreDeletionFailed,
+            utils.delete_loadbalancers,
+            context,
+            cluster,
+        )

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -487,9 +487,7 @@ class TestUtils(base.BaseTestCase):
         mock_delete_load_balancer.assert_called_once_with(
             osc, load_balancer, cascade=True
         )
-        mock_list_floating_ips.assert_called_once_with(
-            osc, port_id="fake-vip-port-id"
-        )
+        mock_list_floating_ips.assert_called_once_with(osc, port_id="fake-vip-port-id")
         mock_delete_floating_ip.assert_called_once_with(osc, matching_fip)
         mock_sleep.assert_not_called()
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import re
 import string
+import time
 import textwrap
 import typing
 
@@ -25,7 +26,7 @@ import shortuuid
 import yaml
 from magnum import objects as magnum_objects  # type: ignore
 from magnum.api import attr_validator  # type: ignore
-from magnum.common import context, exception, octavia  # type: ignore
+from magnum.common import context, exception  # type: ignore
 from magnum.common import utils as magnum_utils
 from openstack import exceptions as sdk_exceptions
 from oslo_config import cfg  # type: ignore
@@ -322,17 +323,13 @@ def delete_loadbalancers(ctx, cluster):
     # NOTE(mnaser): This code is duplicated from magnum.common.octavia
     #               since the original code is very Heat-specific.
     pattern = r"Kubernetes .+ from cluster %s" % cluster.uuid
+    fip_pattern = r"Floating IP for Kubernetes .+ from cluster %s$" % cluster.uuid
 
-    admin_ctx = context.get_admin_context()
-    admin_clients = clients.get_openstack_api(admin_ctx)
     user_clients = clients.get_openstack_api(ctx)
 
     candidates = set()
 
     try:
-        octavia_admin_client = admin_clients.octavia()
-        octavia_client = user_clients.octavia()
-
         lbs = [
             lb
             for lb in openstack.list_load_balancers(user_clients)
@@ -341,15 +338,49 @@ def delete_loadbalancers(ctx, cluster):
                 openstack.get_resource_value(lb, "description", ""),
             )
         ]
-        deleted = octavia._delete_loadbalancers(
-            ctx, lbs, cluster, octavia_admin_client, remove_fip=True
-        )
-        candidates.update(deleted)
+        for lb in lbs:
+            status = openstack.get_resource_value(lb, "provisioning_status")
+            if status in ("PENDING_DELETE", "DELETED"):
+                continue
+
+            lb_id = openstack.get_resource_value(lb, "id")
+            vip_port_id = openstack.get_resource_value(lb, "vip_port_id")
+
+            openstack.delete_load_balancer(user_clients, lb, cascade=True)
+            candidates.add(lb_id)
+
+            if vip_port_id:
+                for fip in openstack.list_floating_ips(
+                    user_clients, port_id=vip_port_id
+                ):
+                    desc = openstack.get_resource_value(fip, "description", "")
+                    if re.match(fip_pattern, desc):
+                        openstack.delete_floating_ip(user_clients, fip)
 
         if not candidates:
             return
 
-        octavia.wait_for_lb_deleted(octavia_client, candidates)
+        timeout = CONF.cluster.pre_delete_lb_timeout
+        start_time = time.time()
+
+        while True:
+            lbs = openstack.list_load_balancers(user_clients)
+            existing = {
+                openstack.get_resource_value(lb, "id")
+                for lb in lbs
+                if openstack.get_resource_value(lb, "provisioning_status")
+                != "DELETED"
+            }
+            if not (candidates & existing):
+                break
+
+            if (time.time() - timeout) > start_time:
+                raise Exception(
+                    "Timeout waiting for the load balancers "
+                    "%s to be deleted." % candidates
+                )
+
+            time.sleep(1)
     except Exception as e:
         raise exception.PreDeletionFailed(cluster_uuid=cluster.uuid, msg=str(e))
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -25,10 +25,9 @@ import shortuuid
 import yaml
 from magnum import objects as magnum_objects  # type: ignore
 from magnum.api import attr_validator  # type: ignore
-from magnum.common import context, exception, neutron, octavia  # type: ignore
+from magnum.common import context, exception, octavia  # type: ignore
 from magnum.common import utils as magnum_utils
-from novaclient import exceptions as nova_exception  # type: ignore
-from novaclient.v2 import flavors  # type: ignore
+from openstack import exceptions as sdk_exceptions
 from oslo_config import cfg  # type: ignore
 from oslo_serialization import base64  # type: ignore
 from oslo_utils import strutils, uuidutils  # type: ignore
@@ -38,6 +37,7 @@ from magnum_cluster_api import clients
 from magnum_cluster_api import exceptions as mcapi_exceptions
 from magnum_cluster_api import image_utils, images, objects
 from magnum_cluster_api.cache import ServerGroupCache
+from magnum_cluster_api.integrations import openstack
 
 AVAILABLE_OPERATING_SYSTEMS = ["ubuntu", "flatcar", "rockylinux"]
 DEFAULT_SERVER_GROUP_POLICIES = ["soft-anti-affinity"]
@@ -333,9 +333,14 @@ def delete_loadbalancers(ctx, cluster):
         octavia_admin_client = admin_clients.octavia()
         octavia_client = user_clients.octavia()
 
-        # Get load balancers created for service/ingress
-        lbs = octavia_client.load_balancer_list().get("loadbalancers", [])
-        lbs = [lb for lb in lbs if re.match(pattern, lb["description"])]
+        lbs = [
+            lb
+            for lb in openstack.list_load_balancers(user_clients)
+            if re.match(
+                pattern,
+                openstack.get_resource_value(lb, "description", ""),
+            )
+        ]
         deleted = octavia._delete_loadbalancers(
             ctx, lbs, cluster, octavia_admin_client, remove_fip=True
         )
@@ -356,13 +361,12 @@ def format_event_message(event: pykube.Event):
     )
 
 
-def lookup_flavor(cli: clients.OpenStackClients, flavor: str) -> flavors.Flavor:
+def lookup_flavor(cli: clients.OpenStackClients, flavor: str):
     """Lookup a flavor either by name or id."""
 
     if flavor is None:
         return
-    flavor_list = cli.nova().flavors.list()
-    for f in flavor_list:
+    for f in openstack.list_flavors(cli):
         if f.name == flavor or f.id == flavor:
             return f
     raise exception.FlavorNotFound(flavor=flavor)
@@ -388,29 +392,31 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
 
     # Check if fixed_network exists
     if cluster.fixed_network:
+        osc = clients.get_openstack_api(ctx)
         if uuidutils.is_uuid_like(cluster.fixed_network):
-            neutron.get_network(
-                ctx,
+            openstack.get_network_value(
+                osc,
                 cluster.fixed_network,
-                source="id",
-                target="name",
-                external=False,
+                "name",
+                False,
+                exception.FixedNetworkNotFound,
             )
         else:
-            neutron.get_network(
-                ctx,
+            openstack.get_network_value(
+                osc,
                 cluster.fixed_network,
-                source="name",
-                target="id",
-                external=False,
+                "id",
+                False,
+                exception.FixedNetworkNotFound,
             )
 
     # Check if fixed_subnet exists
     if cluster.fixed_subnet:
+        osc = clients.get_openstack_api(ctx)
         if uuidutils.is_uuid_like(cluster.fixed_subnet):
-            neutron.get_subnet(ctx, cluster.fixed_subnet, source="id", target="name")
+            openstack.get_subnet_value(osc, cluster.fixed_subnet, "name")
         else:
-            neutron.get_subnet(ctx, cluster.fixed_subnet, source="name", target="id")
+            openstack.get_subnet_value(osc, cluster.fixed_subnet, "id")
 
 
 def validate_nodegroup_name(nodegroup: magnum_objects.NodeGroup):
@@ -507,9 +513,8 @@ def get_server_group_id(
 
     # Check if the server group exists already
     osc = clients.get_openstack_api(ctx)
-    server_groups = osc.nova().server_groups.list(all_projects=ctx.is_admin)
     server_group_id_list = []
-    for sg in server_groups:
+    for sg in openstack.list_server_groups(osc, all_projects=ctx.is_admin):
         if sg.name == name:
             server_group_id_list.append(sg.id)
 
@@ -626,8 +631,9 @@ def _ensure_server_group(
     if not policies:
         policies = DEFAULT_SERVER_GROUP_POLICIES
 
-    # NOTE(oleks): Requires API microversion 2.15 or later for soft-affinity and soft-anti-affinity policy rules.
-    server_group = osc.nova().server_groups.create(name=name, policies=policies)
+    # NOTE(oleks): Requires API microversion 2.15 or later for soft-affinity
+    # and soft-anti-affinity policy rules.
+    server_group = openstack.create_server_group(osc, name=name, policies=policies)
     g_server_group_cache.set(project_id, name, server_group.id)
     return server_group.id
 
@@ -643,15 +649,28 @@ def _delete_server_group(
 
     osc = clients.get_openstack_api(ctx)
     try:
-        osc.nova().server_groups.delete(server_group_id)
-    except nova_exception.NotFound:
+        openstack.delete_server_group(osc, server_group_id)
+    except sdk_exceptions.ResourceNotFound:
         return
 
 
 def get_fixed_network_id(context, network):
     if network and not uuidutils.is_uuid_like(network):
-        return neutron.get_network(
-            context, network, source="name", target="id", external=False
+        osc = clients.get_openstack_api(context)
+        return openstack.get_network_value(
+            osc,
+            network,
+            "id",
+            False,
+            exception.FixedNetworkNotFound,
         )
     else:
         return network
+
+
+def get_fixed_subnet_id(context, subnet):
+    if subnet and not uuidutils.is_uuid_like(subnet):
+        osc = clients.get_openstack_api(context)
+        return openstack.get_subnet_value(osc, subnet, "id")
+    else:
+        return subnet

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 import json
 import re
 import string
-import time
 import textwrap
+import time
 import typing
 
 import pykube  # type: ignore
@@ -368,8 +368,7 @@ def delete_loadbalancers(ctx, cluster):
             existing = {
                 openstack.get_resource_value(lb, "id")
                 for lb in lbs
-                if openstack.get_resource_value(lb, "provisioning_status")
-                != "DELETED"
+                if openstack.get_resource_value(lb, "provisioning_status") != "DELETED"
             }
             if not (candidates & existing):
                 break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,6 @@ dependencies = [
   "platformdirs>=2.4.0",
   "pykube-ng",
   "pyroute2>=0.3.4",
-  "python-heatclient",
-  "python-manilaclient>=3.3.2",
   "requests>=2.27.1",
   "semver>=2.0.0",
   "sherlock>=0.4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py3
 [testenv]
 deps =
   fixtures
+  lark
   oslotest
   pytest
   pytest-mock

--- a/uv.lock
+++ b/uv.lock
@@ -65,15 +65,6 @@ wheels = [
 ]
 
 [[package]]
-name = "babel"
-version = "2.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
-]
-
-[[package]]
 name = "bcrypt"
 version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -829,8 +820,6 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pykube-ng" },
     { name = "pyroute2" },
-    { name = "python-heatclient" },
-    { name = "python-manilaclient" },
     { name = "requests" },
     { name = "semver" },
     { name = "sherlock" },
@@ -867,8 +856,6 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=2.4.0" },
     { name = "pykube-ng" },
     { name = "pyroute2", specifier = ">=0.3.4" },
-    { name = "python-heatclient" },
-    { name = "python-manilaclient", specifier = ">=3.3.2" },
     { name = "requests", specifier = ">=2.27.1" },
     { name = "semver", specifier = ">=2.0.0" },
     { name = "sherlock", specifier = ">=0.4.1" },
@@ -1838,28 +1825,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5e/2d6700c6e36c288ec7e6d24ad49ef400311e8d2b2d926b16906f12c1cb26/python-keystoneclient-5.5.0.tar.gz", hash = "sha256:c2f5934f95576936c98e45bf599ad48bcb0ac451593e5f8344ebf52cb0f411f5", size = 324070, upload-time = "2024-08-27T08:04:00.29Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/d0/187c168e0663b4849cb2f2ce288d91e95e4cf63e4e53a32315f9f6f1ea65/python_keystoneclient-5.5.0-py3-none-any.whl", hash = "sha256:52fe7eb35c7345387c2488eb0b95f28a1d73edcad1ac3d8d80cf8ce6a7c9a8ee", size = 397200, upload-time = "2024-08-27T08:03:58.541Z" },
-]
-
-[[package]]
-name = "python-manilaclient"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babel" },
-    { name = "debtcollector" },
-    { name = "osc-lib" },
-    { name = "oslo-config" },
-    { name = "oslo-log" },
-    { name = "oslo-serialization" },
-    { name = "oslo-utils" },
-    { name = "pbr" },
-    { name = "prettytable" },
-    { name = "python-keystoneclient" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/41/04e45b6795939d46e9391b4b3628c30519088f2a80ab10526869658e91d7/python-manilaclient-5.2.0.tar.gz", hash = "sha256:6e49c3d4c4c3492edee12914a9ffb26a3e7b3dd49fcc60f2dcdbfea624082e58", size = 390755, upload-time = "2025-01-16T13:38:30.66Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/36/c4eb545d72681fb6b879f613095d5db473eab072de68a9e89bedd1ab850e/python_manilaclient-5.2.0-py3-none-any.whl", hash = "sha256:a7412707d507226d8f68cc1f4f512ddb2cf6d1a4e023cb96faeb4d3170dca6b5", size = 517894, upload-time = "2025-01-16T13:38:28.654Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- migrate Magnum Cluster API OpenStack resource lookups from legacy service clients to openstacksdk
- preserve Magnum API error behavior for fixed network/subnet and missing nodegroup cases
- replace the remaining delete-time Octavia cleanup path with SDK-native load balancer and floating IP cleanup
- drop unused legacy client dependencies and add a release note

## Validation

Unit tests:

- `env -u KUBECONFIG uv run pytest magnum_cluster_api/tests/unit/ -q`
- Result: `197 passed, 16 warnings`

Live end-to-end validation in a temporary test environment:

- deployed the patched Magnum API, conductor, and cluster-api proxy image
- created a fresh Kubernetes cluster successfully and verified both nodes reached `Ready`
- verified `openstack coe cluster config` and Kubernetes API access
- verified Cinder CSI pods, `block-rbd1` StorageClass, PVC provisioning, volume attach, mount, and write/read with `cinder-ok`
- verified Manila CSI pods started; dynamic Manila PVC provisioning reached the driver/backend path but the backend rejected share-server allocation for the temporary share network
- verified a Kubernetes `Service type=LoadBalancer` with an enabled Octavia provider created an active Octavia load balancer and assigned an ingress address
- verified Service deletion cleaned up the Octavia load balancer
- verified nodegroup create and resize behavior
- verified the missing CAPI `MachineDeployment` nodegroup-delete path by manually deleting the MachineDeployment, then deleting the Magnum nodegroup and observing `HTTP 404`
- verified invalid fixed network and invalid fixed subnet names return expected `HTTP 400` errors without creating failed cluster records
- verified cluster delete cleaned up Magnum/CAPI resources, Nova servers, server groups, Octavia load balancers, Manila test resources, and temporary Neutron resources

Known environment-specific limits from validation:

- the template-default Octavia `ovn` provider could not be used because that provider was not enabled in the test cloud; the positive LoadBalancer test was run with an enabled provider instead
- Manila end-to-end mount could not pass because the Manila backend could not allocate a share server on the temporary share network
