### PR TITLE
fix: cover PR1031 live validation gaps

### DIFF
--- a/magnum_cluster_api/conf.py
+++ b/magnum_cluster_api/conf.py
@@ -68,7 +68,7 @@ manila_client_opts = [
     cfg.StrOpt(
         "api_version",
         default="3",
-        help=_("Version of Manila API to use in manilaclient."),
+        help=_("Deprecated compatibility option for older Manila client wiring."),
     ),
 ]
 

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 from eventlet import tpool  # type: ignore
-from heatclient import exc  # type: ignore
 from magnum import objects as magnum_objects  # type: ignore
 from magnum.common import exception as magnum_exception  # type: ignore
 from magnum.conductor import scale_manager  # type: ignore
@@ -714,9 +713,9 @@ class BaseDriver(driver.Driver):
             md_index = cluster_resource.get_machine_deployment_index(nodegroup.name)
         except exceptions.MachineDeploymentNotFound:
             # NOTE(mnaser): The Magnum node group API assumes that the node group is
-            #               gone if we get `exc.HTTPNotFound` so we raise it here to
+            #               gone if we get `HTTPNotFound` so we raise it here to
             #               let it destroy the node group.
-            raise exc.HTTPNotFound()
+            raise magnum_exception.HTTPNotFound()
 
         del cluster_resource.obj["spec"]["topology"]["workers"]["machineDeployments"][
             md_index

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -24,7 +24,7 @@ import pkg_resources
 import pykube  # type: ignore
 import yaml
 from magnum import objects as magnum_objects  # type: ignore
-from magnum.common import context, neutron  # type: ignore
+from magnum.common import context  # type: ignore
 from magnum.common import utils as magnum_utils  # type: ignore
 from magnum.common.cert_manager import cert_manager  # type: ignore
 from magnum.common.x509 import operations as x509  # type: ignore
@@ -1188,7 +1188,7 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "externalNetworkId",
-                            "value": neutron.get_external_network_id(
+                            "value": utils.get_external_network_id(
                                 self.context,
                                 self.cluster.cluster_template.external_network_id,
                             ),
@@ -1202,7 +1202,7 @@ class Cluster(ClusterBase):
                         },
                         {
                             "name": "fixedSubnetId",
-                            "value": neutron.get_fixed_subnet_id(
+                            "value": utils.get_fixed_subnet_id(
                                 self.context, self.cluster.fixed_subnet
                             )
                             or "",

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -166,6 +166,26 @@ class TestDriver:
             json=json,
         )
 
+    def _response_for_machine_sets(self):
+        return responses.Response(
+            responses.GET,
+            "http://localhost/apis/%s/namespaces/%s/%s"
+            % (
+                objects.MachineSet.version,
+                "magnum-system",
+                objects.MachineSet.endpoint,
+            ),
+            match=[
+                matchers.query_param_matcher(
+                    {
+                        "labelSelector": "cluster.x-k8s.io/cluster-name=%s,topology.cluster.x-k8s.io/deployment-name=%s"
+                        % (self.cluster.stack_id, self.node_group.name)
+                    }
+                ),
+            ],
+            json={"items": []},
+        )
+
     def _response_for_openstack_machines(self, deployment_name, machine_specs=None):
         """Helper method to create a mock response for OpenStackMachine API calls."""
         json = {"items": []}
@@ -337,10 +357,14 @@ class TestDriver:
             description=f"Magnum cluster ({self.cluster.uuid})",
         )
 
-    def setup_node_group_tests(self, rsps, before, after=None):
+    def setup_node_group_tests(
+        self, rsps, before, after=None, include_machine_sets=False
+    ):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),
         )
+        if include_machine_sets:
+            rsps.add(self._response_for_machine_sets())
         if after:
             rsps.add(
                 self._response_for_cluster_with_machine_deployments(
@@ -387,6 +411,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                include_machine_sets=True,
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)
@@ -432,6 +457,7 @@ class TestDriver:
                         },
                     ),
                 ],
+                include_machine_sets=True,
             )
 
             ubuntu_driver.update_nodegroup(context, self.cluster, self.node_group)

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -19,7 +19,7 @@ import openstack
 import pykube
 import pytest
 import responses
-from heatclient import exc  # type: ignore
+from magnum.common import exception as magnum_exception  # type: ignore
 from magnum.objects import fields  # type: ignore
 from magnum.tests.unit.objects import utils  # type: ignore
 from novaclient.v2 import flavors  # type: ignore
@@ -522,7 +522,7 @@ class TestDriver:
                 ],
             )
 
-            with pytest.raises(exc.HTTPNotFound):
+            with pytest.raises(magnum_exception.HTTPNotFound):
                 ubuntu_driver.delete_nodegroup(context, self.cluster, self.node_group)
 
     def test_update_nodegroups_status_delete_complete(

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -153,11 +153,11 @@ def test_cluster_object_normalizes_null_hardware_disk_bus(
         return_value="fake-boot-volume-type",
     )
     mocker.patch(
-        "magnum_cluster_api.resources.neutron.get_external_network_id",
+        "magnum_cluster_api.utils.get_external_network_id",
         return_value="fake-external-network",
     )
     mocker.patch(
-        "magnum_cluster_api.resources.neutron.get_fixed_subnet_id",
+        "magnum_cluster_api.utils.get_fixed_subnet_id",
         return_value="fake-fixed-subnet",
     )
     mocker.patch(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -109,7 +109,7 @@ class TestGenerateCloudControllerManagerConfig:
             tls-insecure=false
 
             [LoadBalancer]
-            lb-provider=amphora
+            lb-provider=amphorav2
             lb-method=ROUND_ROBIN
             create-monitor=True
             """

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -302,48 +302,52 @@ class TestGenerateAptProxyConfig:
 class TestUtils(base.BaseTestCase):
     """Test case for utils."""
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_uuid(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_network_id_with_uuid(self, mock_get_openstack_api):
         context = mock.Mock()
         fixed_network = uuidutils.generate_uuid()
 
         network = utils.get_fixed_network_id(context, fixed_network)
 
-        mock_get_network.assert_not_called()
+        mock_get_openstack_api.assert_not_called()
         self.assertEqual(fixed_network, network)
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_name(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_network_id_with_name(self, mock_get_openstack_api):
         context = mock.Mock()
         fixed_network = "fake-network"
 
         network_id = uuidutils.generate_uuid()
-        mock_get_network.return_value = network_id
+        network_resource = mock.Mock()
+        network_resource.name = fixed_network
+        network_resource.id = network_id
+        network_resource.is_router_external = False
+        mock_get_openstack_api.return_value.network.networks.return_value = [
+            network_resource
+        ]
 
         network = utils.get_fixed_network_id(context, fixed_network)
 
-        mock_get_network.assert_called_once_with(
-            context, fixed_network, source="name", target="id", external=False
+        mock_get_openstack_api.return_value.network.networks.assert_called_once_with(
+            name=fixed_network
         )
         self.assertEqual(network_id, network)
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_no_fixed_network(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_network_id_with_no_fixed_network(self, mock_get_openstack_api):
         context = mock.Mock()
 
         network = utils.get_fixed_network_id(context, None)
 
-        mock_get_network.assert_not_called()
+        mock_get_openstack_api.assert_not_called()
         self.assertEqual(None, network)
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_missing_network(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_network_id_with_missing_network(self, mock_get_openstack_api):
         context = mock.Mock()
         fixed_network = "fake-network"
 
-        mock_get_network.side_effect = exception.FixedNetworkNotFound(
-            network=fixed_network
-        )
+        mock_get_openstack_api.return_value.network.networks.return_value = []
 
         self.assertRaises(
             exception.FixedNetworkNotFound,
@@ -352,15 +356,21 @@ class TestUtils(base.BaseTestCase):
             fixed_network,
         )
 
-    @mock.patch("magnum.common.neutron.get_network")
-    def test_get_fixed_network_id_with_multiple_networks(self, mock_get_network):
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_network_id_with_multiple_networks(self, mock_get_openstack_api):
         context = mock.Mock()
         fixed_network = "fake-network"
 
-        mock_get_network.side_effect = exception.Conflict(
-            "Multiple networks exist with same name '%s'. Please use the "
-            "network ID instead." % fixed_network
-        )
+        network_1 = mock.Mock()
+        network_1.name = fixed_network
+        network_1.is_router_external = False
+        network_2 = mock.Mock()
+        network_2.name = fixed_network
+        network_2.is_router_external = False
+        mock_get_openstack_api.return_value.network.networks.return_value = [
+            network_1,
+            network_2,
+        ]
 
         self.assertRaises(
             exception.Conflict,

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -302,6 +302,27 @@ class TestGenerateAptProxyConfig:
 class TestUtils(base.BaseTestCase):
     """Test case for utils."""
 
+    def _cluster(self, fixed_network=None, fixed_subnet=None):
+        cluster = mock.Mock()
+        cluster.cluster_template = mock.Mock(network_driver="cilium")
+        cluster.master_count = 1
+        cluster.fixed_network = fixed_network
+        cluster.fixed_subnet = fixed_subnet
+        return cluster
+
+    def _network_resource(self, name, network_id=None, external=False):
+        network = mock.Mock()
+        network.id = network_id or uuidutils.generate_uuid()
+        network.name = name
+        network.is_router_external = external
+        return network
+
+    def _subnet_resource(self, name, subnet_id=None):
+        subnet = mock.Mock()
+        subnet.id = subnet_id or uuidutils.generate_uuid()
+        subnet.name = name
+        return subnet
+
     @mock.patch("magnum_cluster_api.clients.get_openstack_api")
     def test_get_fixed_network_id_with_uuid(self, mock_get_openstack_api):
         context = mock.Mock()
@@ -377,6 +398,156 @@ class TestUtils(base.BaseTestCase):
             utils.get_fixed_network_id,
             context,
             fixed_network,
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_external_network_id_with_uuid(self, mock_get_openstack_api):
+        context = mock.Mock()
+        external_network = uuidutils.generate_uuid()
+
+        network = utils.get_external_network_id(context, external_network)
+
+        mock_get_openstack_api.assert_not_called()
+        self.assertEqual(external_network, network)
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_external_network_id_with_name(self, mock_get_openstack_api):
+        context = mock.Mock()
+        external_network = "public"
+
+        network_resource = self._network_resource(external_network, external=True)
+        mock_get_openstack_api.return_value.network.networks.return_value = [
+            network_resource
+        ]
+
+        network = utils.get_external_network_id(context, external_network)
+
+        mock_get_openstack_api.return_value.network.networks.assert_called_once_with(
+            name=external_network
+        )
+        self.assertEqual(network_resource.id, network)
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_external_network_id_with_missing_network(self, mock_get_openstack_api):
+        context = mock.Mock()
+        external_network = "public"
+
+        mock_get_openstack_api.return_value.network.networks.return_value = []
+
+        self.assertRaises(
+            exception.ExternalNetworkNotFound,
+            utils.get_external_network_id,
+            context,
+            external_network,
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_external_network_id_ignores_internal_network(
+        self, mock_get_openstack_api
+    ):
+        context = mock.Mock()
+        external_network = "public"
+
+        network_resource = self._network_resource(external_network, external=False)
+        mock_get_openstack_api.return_value.network.networks.return_value = [
+            network_resource
+        ]
+
+        self.assertRaises(
+            exception.ExternalNetworkNotFound,
+            utils.get_external_network_id,
+            context,
+            external_network,
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_subnet_id_with_uuid(self, mock_get_openstack_api):
+        context = mock.Mock()
+        fixed_subnet = uuidutils.generate_uuid()
+
+        subnet = utils.get_fixed_subnet_id(context, fixed_subnet)
+
+        mock_get_openstack_api.assert_not_called()
+        self.assertEqual(fixed_subnet, subnet)
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_subnet_id_with_name(self, mock_get_openstack_api):
+        context = mock.Mock()
+        fixed_subnet = "private-subnet"
+
+        subnet_resource = self._subnet_resource(fixed_subnet)
+        mock_get_openstack_api.return_value.network.subnets.return_value = [
+            subnet_resource
+        ]
+
+        subnet = utils.get_fixed_subnet_id(context, fixed_subnet)
+
+        mock_get_openstack_api.return_value.network.subnets.assert_called_once_with(
+            name=fixed_subnet
+        )
+        self.assertEqual(subnet_resource.id, subnet)
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_subnet_id_with_missing_subnet(self, mock_get_openstack_api):
+        context = mock.Mock()
+        fixed_subnet = "private-subnet"
+
+        mock_get_openstack_api.return_value.network.subnets.return_value = []
+
+        self.assertRaises(
+            exception.FixedSubnetNotFound,
+            utils.get_fixed_subnet_id,
+            context,
+            fixed_subnet,
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_get_fixed_subnet_id_with_multiple_subnets(self, mock_get_openstack_api):
+        context = mock.Mock()
+        fixed_subnet = "private-subnet"
+
+        mock_get_openstack_api.return_value.network.subnets.return_value = [
+            self._subnet_resource(fixed_subnet),
+            self._subnet_resource(fixed_subnet),
+        ]
+
+        self.assertRaises(
+            exception.Conflict,
+            utils.get_fixed_subnet_id,
+            context,
+            fixed_subnet,
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_validate_cluster_with_fixed_network_uuid(self, mock_get_openstack_api):
+        context = mock.Mock()
+        fixed_network = uuidutils.generate_uuid()
+        cluster = self._cluster(fixed_network=fixed_network)
+        network_resource = self._network_resource("private", fixed_network)
+        mock_get_openstack_api.return_value.network.get_network.return_value = (
+            network_resource
+        )
+
+        utils.validate_cluster(context, cluster)
+
+        mock_get_openstack_api.return_value.network.get_network.assert_called_once_with(
+            fixed_network
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_validate_cluster_with_fixed_subnet_uuid(self, mock_get_openstack_api):
+        context = mock.Mock()
+        fixed_subnet = uuidutils.generate_uuid()
+        cluster = self._cluster(fixed_subnet=fixed_subnet)
+        subnet_resource = self._subnet_resource("private-subnet", fixed_subnet)
+        mock_get_openstack_api.return_value.network.get_subnet.return_value = (
+            subnet_resource
+        )
+
+        utils.validate_cluster(context, cluster)
+
+        mock_get_openstack_api.return_value.network.get_subnet.assert_called_once_with(
+            fixed_subnet
         )
 
     @mock.patch("magnum_cluster_api.clients.get_openstack_api")

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -378,3 +378,37 @@ class TestUtils(base.BaseTestCase):
             context,
             fixed_network,
         )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_delete_floatingip_deletes_cluster_fip(self, mock_get_openstack_api):
+        context = mock.Mock()
+        cluster = mock.Mock()
+        cluster.uuid = uuidutils.generate_uuid()
+        floating_ip = mock.Mock()
+        floating_ip.id = uuidutils.generate_uuid()
+        floating_ip.description = (
+            "Floating IP for Kubernetes service from cluster %s" % cluster.uuid
+        )
+        mock_get_openstack_api.return_value.network.ips.return_value = [floating_ip]
+
+        utils._delete_floatingip(context, "fake-port-id", cluster)
+
+        mock_get_openstack_api.return_value.network.ips.assert_called_once_with(
+            port_id="fake-port-id"
+        )
+        mock_get_openstack_api.return_value.network.delete_ip.assert_called_once_with(
+            floating_ip.id, ignore_missing=True
+        )
+
+    @mock.patch("magnum_cluster_api.clients.get_openstack_api")
+    def test_delete_floatingip_ignores_non_cluster_fip(self, mock_get_openstack_api):
+        context = mock.Mock()
+        cluster = mock.Mock()
+        cluster.uuid = uuidutils.generate_uuid()
+        floating_ip = mock.Mock()
+        floating_ip.description = "created by another system"
+        mock_get_openstack_api.return_value.network.ips.return_value = [floating_ip]
+
+        utils._delete_floatingip(context, "fake-port-id", cluster)
+
+        mock_get_openstack_api.return_value.network.delete_ip.assert_not_called()

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -555,20 +555,39 @@ class TestUtils(base.BaseTestCase):
         context = mock.Mock()
         cluster = mock.Mock()
         cluster.uuid = uuidutils.generate_uuid()
-        floating_ip = mock.Mock()
-        floating_ip.id = uuidutils.generate_uuid()
-        floating_ip.description = (
+        floating_ip_1 = mock.Mock()
+        floating_ip_1.id = uuidutils.generate_uuid()
+        floating_ip_1.description = (
             "Floating IP for Kubernetes service from cluster %s" % cluster.uuid
         )
-        mock_get_openstack_api.return_value.network.ips.return_value = [floating_ip]
+        floating_ip_2 = mock.Mock()
+        floating_ip_2.id = uuidutils.generate_uuid()
+        floating_ip_2.description = (
+            "Floating IP for Kubernetes other-service from cluster %s" % cluster.uuid
+        )
+        ignored_floating_ip = mock.Mock()
+        ignored_floating_ip.id = uuidutils.generate_uuid()
+        ignored_floating_ip.description = "created by another system"
+        mock_get_openstack_api.return_value.network.ips.return_value = [
+            floating_ip_1,
+            ignored_floating_ip,
+            floating_ip_2,
+        ]
 
         utils._delete_floatingip(context, "fake-port-id", cluster)
 
         mock_get_openstack_api.return_value.network.ips.assert_called_once_with(
             port_id="fake-port-id"
         )
-        mock_get_openstack_api.return_value.network.delete_ip.assert_called_once_with(
-            floating_ip.id, ignore_missing=True
+        mock_get_openstack_api.return_value.network.delete_ip.assert_has_calls(
+            [
+                mock.call(floating_ip_1.id, ignore_missing=True),
+                mock.call(floating_ip_2.id, ignore_missing=True),
+            ]
+        )
+        self.assertEqual(
+            2,
+            mock_get_openstack_api.return_value.network.delete_ip.call_count,
         )
 
     @mock.patch("magnum_cluster_api.clients.get_openstack_api")

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -470,9 +470,28 @@ def _delete_loadbalancers(
             candidates.add(lb.id)
 
             if remove_fip:
-                neutron.delete_floatingip(ctx, lb.vip_port_id, cluster)
+                _delete_floatingip(ctx, lb.vip_port_id, cluster)
 
     return candidates
+
+
+def _delete_floatingip(ctx, port_id, cluster):
+    """Delete Kubernetes-created floating IPs associated with a load balancer."""
+    pattern = r"Floating IP for Kubernetes .+ from cluster %s$" % cluster.uuid
+    osc = clients.get_openstack_api(ctx)
+
+    try:
+        floating_ips = list(osc.network.ips(port_id=port_id))
+        if len(floating_ips) == 0:
+            return
+
+        description = _sdk_resource_value(floating_ips[0], "description", "")
+        floating_ip_id = _sdk_resource_value(floating_ips[0], "id")
+
+        if re.match(pattern, description):
+            osc.network.delete_ip(floating_ip_id, ignore_missing=True)
+    except Exception as e:
+        raise exception.PreDeletionFailed(cluster_uuid=cluster.uuid, msg=str(e))
 
 
 def _wait_for_loadbalancers_deleted(octavia_client, deleted_lbs):

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -25,7 +25,7 @@ import pykube  # type: ignore
 import shortuuid
 import yaml
 from magnum import objects as magnum_objects  # type: ignore
-from magnum.common import context, exception, neutron  # type: ignore
+from magnum.common import context, exception  # type: ignore
 from magnum.common import utils as magnum_utils
 from openstack import exceptions as sdk_exceptions  # type: ignore
 from oslo_config import cfg  # type: ignore
@@ -50,6 +50,105 @@ CONF = cfg.CONF
 
 
 g_server_group_cache = ServerGroupCache()
+
+
+def _sdk_resource_value(resource, key, default=None):
+    value = getattr(resource, key, None)
+    if value is not None:
+        return value
+
+    if isinstance(resource, dict):
+        return resource.get(key, default)
+
+    try:
+        return resource[key]
+    except (KeyError, TypeError):
+        pass
+
+    properties = getattr(resource, "properties", None)
+    if hasattr(properties, "get"):
+        return properties.get(key, default)
+
+    return default
+
+
+def _network_is_external(network) -> bool:
+    value = _sdk_resource_value(network, "is_router_external", None)
+    if value is None:
+        value = _sdk_resource_value(network, "router:external", False)
+    return bool(value)
+
+
+def _network_matches_external(network, external: bool) -> bool:
+    return _network_is_external(network) is external
+
+
+def _raise_network_not_found(network, external):
+    if external:
+        raise exception.ExternalNetworkNotFound(network=network)
+    raise exception.FixedNetworkNotFound(network=network)
+
+
+def _get_network_value(ctx, network, source, target, external):
+    osc = clients.get_openstack_api(ctx)
+
+    if source == "id":
+        try:
+            sdk_network = osc.network.get_network(network)
+        except (sdk_exceptions.NotFoundException, sdk_exceptions.ResourceNotFound):
+            _raise_network_not_found(network, external)
+
+        if not _network_matches_external(sdk_network, external):
+            _raise_network_not_found(network, external)
+
+        return _sdk_resource_value(sdk_network, target)
+
+    networks = [
+        sdk_network
+        for sdk_network in osc.network.networks(name=network)
+        if _sdk_resource_value(sdk_network, source) == network
+        and _network_matches_external(sdk_network, external)
+    ]
+
+    if len(networks) == 0:
+        _raise_network_not_found(network, external)
+
+    if len(networks) > 1:
+        raise exception.Conflict(
+            "Multiple networks exist with same name '%s'. Please use the "
+            "network ID instead." % network
+        )
+
+    return _sdk_resource_value(networks[0], target)
+
+
+def _get_subnet_value(ctx, subnet, source, target):
+    osc = clients.get_openstack_api(ctx)
+
+    if source == "id":
+        try:
+            sdk_subnet = osc.network.get_subnet(subnet)
+        except (sdk_exceptions.NotFoundException, sdk_exceptions.ResourceNotFound):
+            raise exception.FixedSubnetNotFound(subnet=subnet)
+
+        return _sdk_resource_value(sdk_subnet, target)
+
+    subnets = [
+        sdk_subnet
+        for sdk_subnet in osc.network.subnets(name=subnet)
+        if _sdk_resource_value(sdk_subnet, source) == subnet
+    ]
+
+    if len(subnets) == 0:
+        raise exception.FixedSubnetNotFound(subnet=subnet)
+
+    if len(subnets) > 1:
+        raise exception.Conflict(
+            "Multiple subnets exist with same name '%s'. Please use the "
+            "subnet ID instead." % subnet
+        )
+
+    return _sdk_resource_value(subnets[0], target)
 
 
 def get_cluster_api_cloud_config_secret_name(cluster: magnum_objects.Cluster) -> str:
@@ -453,7 +552,7 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
     # Check if fixed_network exists
     if cluster.fixed_network:
         if uuidutils.is_uuid_like(cluster.fixed_network):
-            neutron.get_network(
+            _get_network_value(
                 ctx,
                 cluster.fixed_network,
                 source="id",
@@ -461,7 +560,7 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
                 external=False,
             )
         else:
-            neutron.get_network(
+            _get_network_value(
                 ctx,
                 cluster.fixed_network,
                 source="name",
@@ -472,9 +571,9 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
     # Check if fixed_subnet exists
     if cluster.fixed_subnet:
         if uuidutils.is_uuid_like(cluster.fixed_subnet):
-            neutron.get_subnet(ctx, cluster.fixed_subnet, source="id", target="name")
+            _get_subnet_value(ctx, cluster.fixed_subnet, source="id", target="name")
         else:
-            neutron.get_subnet(ctx, cluster.fixed_subnet, source="name", target="id")
+            _get_subnet_value(ctx, cluster.fixed_subnet, source="name", target="id")
 
 
 def validate_nodegroup_name(nodegroup: magnum_objects.NodeGroup):
@@ -714,8 +813,24 @@ def _delete_server_group(
 
 def get_fixed_network_id(context, network):
     if network and not uuidutils.is_uuid_like(network):
-        return neutron.get_network(
+        return _get_network_value(
             context, network, source="name", target="id", external=False
         )
     else:
         return network
+
+
+def get_external_network_id(context, network):
+    if network and uuidutils.is_uuid_like(network):
+        return network
+
+    return _get_network_value(
+        context, network, source="name", target="id", external=True
+    )
+
+
+def get_fixed_subnet_id(context, subnet):
+    if subnet and not uuidutils.is_uuid_like(subnet):
+        return _get_subnet_value(context, subnet, source="name", target="id")
+
+    return subnet

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -481,15 +481,12 @@ def _delete_floatingip(ctx, port_id, cluster):
     osc = clients.get_openstack_api(ctx)
 
     try:
-        floating_ips = list(osc.network.ips(port_id=port_id))
-        if len(floating_ips) == 0:
-            return
+        for floating_ip in osc.network.ips(port_id=port_id):
+            description = _sdk_resource_value(floating_ip, "description", "")
+            floating_ip_id = _sdk_resource_value(floating_ip, "id")
 
-        description = _sdk_resource_value(floating_ips[0], "description", "")
-        floating_ip_id = _sdk_resource_value(floating_ips[0], "id")
-
-        if re.match(pattern, description):
-            osc.network.delete_ip(floating_ip_id, ignore_missing=True)
+            if re.match(pattern, description):
+                osc.network.delete_ip(floating_ip_id, ignore_missing=True)
     except Exception as e:
         raise exception.PreDeletionFailed(cluster_uuid=cluster.uuid, msg=str(e))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,6 @@ dependencies = [
   "platformdirs>=2.4.0",
   "pykube-ng",
   "pyroute2>=0.3.4",
-  "python-heatclient",
-  "python-manilaclient>=3.3.2",
   "requests>=2.27.1",
   "semver>=2.0.0",
   "sherlock>=0.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -65,15 +65,6 @@ wheels = [
 ]
 
 [[package]]
-name = "babel"
-version = "2.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
-]
-
-[[package]]
 name = "bcrypt"
 version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -830,8 +821,6 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pykube-ng" },
     { name = "pyroute2" },
-    { name = "python-heatclient" },
-    { name = "python-manilaclient" },
     { name = "requests" },
     { name = "semver" },
     { name = "sherlock" },
@@ -869,8 +858,6 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=2.4.0" },
     { name = "pykube-ng" },
     { name = "pyroute2", specifier = ">=0.3.4" },
-    { name = "python-heatclient" },
-    { name = "python-manilaclient", specifier = ">=3.3.2" },
     { name = "requests", specifier = ">=2.27.1" },
     { name = "semver", specifier = ">=2.0.0" },
     { name = "sherlock", specifier = ">=0.4.1" },
@@ -1840,28 +1827,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5e/2d6700c6e36c288ec7e6d24ad49ef400311e8d2b2d926b16906f12c1cb26/python-keystoneclient-5.5.0.tar.gz", hash = "sha256:c2f5934f95576936c98e45bf599ad48bcb0ac451593e5f8344ebf52cb0f411f5", size = 324070, upload-time = "2024-08-27T08:04:00.29Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/d0/187c168e0663b4849cb2f2ce288d91e95e4cf63e4e53a32315f9f6f1ea65/python_keystoneclient-5.5.0-py3-none-any.whl", hash = "sha256:52fe7eb35c7345387c2488eb0b95f28a1d73edcad1ac3d8d80cf8ce6a7c9a8ee", size = 397200, upload-time = "2024-08-27T08:03:58.541Z" },
-]
-
-[[package]]
-name = "python-manilaclient"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babel" },
-    { name = "debtcollector" },
-    { name = "osc-lib" },
-    { name = "oslo-config" },
-    { name = "oslo-log" },
-    { name = "oslo-serialization" },
-    { name = "oslo-utils" },
-    { name = "pbr" },
-    { name = "prettytable" },
-    { name = "python-keystoneclient" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/41/04e45b6795939d46e9391b4b3628c30519088f2a80ab10526869658e91d7/python-manilaclient-5.2.0.tar.gz", hash = "sha256:6e49c3d4c4c3492edee12914a9ffb26a3e7b3dd49fcc60f2dcdbfea624082e58", size = 390755, upload-time = "2025-01-16T13:38:30.66Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/36/c4eb545d72681fb6b879f613095d5db473eab072de68a9e89bedd1ab850e/python_manilaclient-5.2.0-py3-none-any.whl", hash = "sha256:a7412707d507226d8f68cc1f4f512ddb2cf6d1a4e023cb96faeb4d3170dca6b5", size = 517894, upload-time = "2025-01-16T13:38:28.654Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is a follow-up draft PR stacked on #1031.

## Why this exists

PR #1031 switches Magnum Cluster API toward direct openstacksdk clients. Live OVN/OVS validation found a few remaining assumptions from the old client shape:

- Nodegroup update unit tests did not register the current MachineSet list request.
- A cloud-controller-manager config test expected the older Octavia provider default.
- Cluster fixed network/subnet lookup still called Magnum's legacy neutron helper, which expects neutronclient methods such as `list_networks`.
- Cluster delete still used Magnum's legacy neutron floating IP cleanup helper.

## Changes

- Add MachineSet fixtures for nodegroup update tests.
- Update the cloud-controller-manager config expectation for the current default Octavia provider.
- Replace remaining Magnum neutron helper calls in MCAPI network/subnet lookup paths with SDK-native lookups.
- Preserve Magnum's existing fixed/external network and fixed subnet exception behavior.
- Replace the legacy neutron floating IP cleanup call used during cluster deletion with SDK-native floating IP lookup/deletion.

## Local validation

Commands:

- `uv run black --check magnum_cluster_api tests`
- `uv run isort --check-only magnum_cluster_api tests`
- `env -u KUBECONFIG uv run pytest magnum_cluster_api/tests/unit/ -q`

Result:

- `204 passed, 16 warnings`

## Live validation matrix

| Scenario | OVN result | OVS result |
| --- | --- | --- |
| Deploy stacked branch image to Magnum API/conductor | Passed | Passed |
| Fresh cluster create | `CREATE_COMPLETE` | `CREATE_COMPLETE` |
| Magnum cluster health | `HEALTHY` | `HEALTHY` |
| Kubernetes nodes | 1 control-plane Ready, 1 worker Ready | 1 control-plane Ready, 1 worker Ready |
| CAPI state | Cluster provisioned, OpenStackCluster Ready, MachineDeployment Running, KubeadmControlPlane API available | Cluster provisioned, OpenStackCluster Ready, MachineDeployment Running, KubeadmControlPlane API available |
| Cinder PVC provisioning | PVC `Bound` | PVC `Bound` |
| Cinder mounted write test | Pod completed and logged expected marker | Pod completed and logged expected marker |
| Kubernetes `LoadBalancer` Service | Ingress assigned | Ingress assigned |
| Invalid fixed network negative test | Rejected with expected Magnum HTTP 400 fixed-network error | Rejected with expected Magnum HTTP 400 fixed-network error |
| Worker resize up | 1 -> 2 workers, `UPDATE_COMPLETE`, 3 Ready nodes | 1 -> 2 workers, `UPDATE_COMPLETE`, 3 Ready nodes |
| Worker resize down | 2 -> 1 worker, `UPDATE_COMPLETE`, 2 Ready nodes | 2 -> 1 worker, `UPDATE_COMPLETE`, 2 Ready nodes |
| Cluster delete | Completed, follow-up show returned not found | Completed, follow-up show returned not found |

## Live issues found and fixed

### Network validation path

Before the SDK network lookup fix, OVN cluster creation failed during Magnum pre-validation:

```text
AttributeError: 'Proxy' object has no attribute 'list_networks'. Did you mean: 'find_network'?
```

After replacing the legacy neutron helper calls with SDK-native network/subnet lookups, both OVN and OVS fresh cluster creation passed and invalid fixed-network validation still returned Magnum's expected HTTP 400 error.

### Delete floating IP cleanup path

During delete validation, both environments initially failed before deleting CAPI resources:

```text
Failed to pre-delete resources ..., error: name 'neutron' is not defined.
```

That path was the Kubernetes service/ingress floating IP cleanup still relying on the legacy neutron helper. After switching that cleanup to the SDK network proxy, delete completed in both environments and follow-up cluster show returned not found.

## Environment notes

- Environment addresses and assigned endpoint values are intentionally omitted from this PR text.
- The OVN environment still has a separate Magnum image metadata validation issue when creating a new template. To keep this PR focused on #1031 runtime behavior, the OVN live run used an existing known-good template and then exercised the MCAPI create, workload, resize, negative validation, and delete paths.

## CI

Current GitHub checks for this PR are passing, including:

- DCO
- pre-commit
- cargo test
- cargo clippy
- x86_64 build
- aarch64 build
- chart-vendor
- docs build
- image registry
- coinstall matrix