### PR TITLE
fix: add shared sdk connection config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* add explicit shared OpenStack SDK connection configuration, with existing
+  service client options retained as compatibility fallback
+
 ## [0.36.6](https://github.com/vexxhost/magnum-cluster-api/compare/v0.36.5...v0.36.6) (2026-04-21)
 
 

--- a/docs/user/configs.md
+++ b/docs/user/configs.md
@@ -89,6 +89,20 @@ Options under this group are used for configuring Manila client.
     **Type**: `boolean`
     **Default value**: `False`
 
+## openstack_client
+Options under this group are used for configuring the shared OpenStack SDK
+connection used by the Magnum Cluster API driver.
+
+`region_name`
+
+:   Region in Identity service catalog to use for the shared OpenStack SDK connection. If unset, legacy service client region options are used for compatibility.
+    **Type**: `string`
+
+`endpoint_type`
+
+:   Type of endpoint in Identity service catalog to use for the shared OpenStack SDK connection. If unset, legacy service client endpoint options are used for compatibility.
+    **Type**: `string`
+
 ## capi_client
 Options under this group are used for configuring Openstack authentication for CAPO.
 

--- a/magnum_cluster_api/clients.py
+++ b/magnum_cluster_api/clients.py
@@ -39,9 +39,23 @@ def _client_option(client, option):
 
 def _connection_options():
     options = {}
+    shared_endpoint_type = _client_option("openstack", "endpoint_type")
+    shared_region_name = _client_option("openstack", "region_name")
+
+    if shared_endpoint_type:
+        options["interface"] = shared_endpoint_type
+    if shared_region_name:
+        options["region_name"] = shared_region_name
+
     for service_type, client in SERVICE_CLIENTS.items():
-        endpoint_type = _client_option(client, "endpoint_type")
-        region_name = _client_option(client, "region_name")
+        endpoint_type = None
+        region_name = None
+
+        if not shared_endpoint_type:
+            endpoint_type = _client_option(client, "endpoint_type")
+        if not shared_region_name:
+            region_name = _client_option(client, "region_name")
+
         if endpoint_type:
             options[f"{service_type}_interface"] = endpoint_type
         if region_name:

--- a/magnum_cluster_api/conf.py
+++ b/magnum_cluster_api/conf.py
@@ -25,6 +25,10 @@ manila_client_group = cfg.OptGroup(
     name="manila_client", title="Options for the Manila client"
 )
 
+openstack_client_group = cfg.OptGroup(
+    name="openstack_client", title="Options for the shared OpenStack SDK client"
+)
+
 proxy_group = cfg.OptGroup(name="proxy", title="Options for Cluster API proxy")
 
 
@@ -73,6 +77,26 @@ manila_client_opts = [
 ]
 
 
+openstack_client_opts = [
+    cfg.StrOpt(
+        "region_name",
+        help=_(
+            "Region in Identity service catalog to use for the shared "
+            "OpenStack SDK connection. If unset, legacy service client "
+            "region options are used for compatibility."
+        ),
+    ),
+    cfg.StrOpt(
+        "endpoint_type",
+        help=_(
+            "Type of endpoint in Identity service catalog to use for the "
+            "shared OpenStack SDK connection. If unset, legacy service "
+            "client endpoint options are used for compatibility."
+        ),
+    ),
+]
+
+
 proxy_opts = [
     cfg.StrOpt(
         "haproxy_pid_path",
@@ -100,6 +124,7 @@ ALL_GROUPS = [
     auto_scaling_group,
     capi_client_group,
     manila_client_group,
+    openstack_client_group,
     proxy_group,
 ]
 
@@ -109,6 +134,7 @@ ALL_OPTS = [
     (capi_client_group, common_security_opts),
     (manila_client_group, manila_client_opts),
     (manila_client_group, common_security_opts),
+    (openstack_client_group, openstack_client_opts),
     (proxy_group, proxy_opts),
 ]
 

--- a/magnum_cluster_api/tests/unit/test_clients.py
+++ b/magnum_cluster_api/tests/unit/test_clients.py
@@ -31,6 +31,11 @@ def _keystone(mocker):
         group.region_name = "RegionOne"
         mocker.patch.object(clients.CONF, f"{client}_client", group)
 
+    openstack_group = mocker.Mock()
+    openstack_group.endpoint_type = None
+    openstack_group.region_name = None
+    mocker.patch.object(clients.CONF, "openstack_client", openstack_group)
+
     return keystone, connection
 
 
@@ -82,6 +87,53 @@ def test_get_openstack_api_skips_missing_service_config(mocker):
 
     assert "shared_file_system_interface" not in connection.call_args.kwargs
     assert "shared_file_system_region_name" not in connection.call_args.kwargs
+
+
+def test_get_openstack_api_uses_shared_sdk_options(mocker):
+    _, connection = _keystone(mocker)
+
+    clients.CONF.openstack_client.endpoint_type = "internal"
+    clients.CONF.openstack_client.region_name = "RegionTwo"
+
+    connection.reset_mock()
+
+    clients.get_openstack_api(context="context")
+
+    connection.assert_called_once_with(
+        session="session",
+        interface="internal",
+        region_name="RegionTwo",
+    )
+
+
+def test_get_openstack_api_mixes_shared_and_legacy_options(mocker):
+    _, connection = _keystone(mocker)
+
+    clients.CONF.openstack_client.endpoint_type = "internal"
+
+    connection.reset_mock()
+
+    clients.get_openstack_api(context="context")
+
+    assert connection.call_args.kwargs["interface"] == "internal"
+    assert "image_interface" not in connection.call_args.kwargs
+    assert connection.call_args.kwargs["image_region_name"] == "RegionOne"
+    assert connection.call_args.kwargs["compute_region_name"] == "RegionOne"
+    assert connection.call_args.kwargs["network_region_name"] == "RegionOne"
+
+
+def test_get_openstack_api_skips_unset_shared_sdk_options(mocker):
+    _, connection = _keystone(mocker)
+
+    clients.CONF.openstack_client.endpoint_type = None
+    clients.CONF.openstack_client.region_name = None
+
+    connection.reset_mock()
+
+    clients.get_openstack_api(context="context")
+
+    assert "interface" not in connection.call_args.kwargs
+    assert "region_name" not in connection.call_args.kwargs
 
 
 def test_get_cinder_region_name_uses_magnum_config(mocker):


### PR DESCRIPTION
## Summary

- add an explicit `openstack_client` config group for the shared openstacksdk connection
- keep PR 1031 service-client endpoint and region options as compatibility fallback
- document the new config path and cover precedence with unit tests

## Testing

- `uv run pytest magnum_cluster_api/tests/unit/test_clients.py -q`
- `uv run black --check magnum_cluster_api tests`
- `uv run isort --check-only magnum_cluster_api tests`
- `KUBECONFIG=<temp> uv run pytest magnum_cluster_api/tests/unit/ -q` (`207 passed, 15 warnings`)
- `pre-commit run --all-files` with Python 3.10 hook env override (default local `python3` is 3.8 and cannot install Black 25.1.0)

## Live Validation

Pending on OVS AIO and OVN AIO.