### PR TITLE
fix: validate server group member quota before provisioning

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -69,9 +69,10 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
-        self.rust_driver.create_cluster(cluster)
-
         utils.validate_cluster(context, cluster)
+        utils.validate_cluster_server_group_members_quota(context, cluster)
+
+        self.rust_driver.create_cluster(cluster)
 
         return self._create_cluster(context, cluster)
 
@@ -337,6 +338,16 @@ class BaseDriver(driver.Driver):
         """
         utils.validate_cluster(context, cluster)
 
+        if not nodes_to_remove:
+            if nodegroup.role == "master":
+                utils.validate_controlplane_server_group_members_quota(
+                    context, cluster, requested=node_count
+                )
+            else:
+                utils.validate_nodegroup_server_group_members_quota(
+                    context, cluster, nodegroup
+                )
+
         if nodes_to_remove:
             machines = objects.Machine.objects(self.k8s_api).filter(
                 namespace="magnum-system",
@@ -471,6 +482,7 @@ class BaseDriver(driver.Driver):
         blocking the Magnum API.
         """
         utils.validate_nodegroup(nodegroup)
+        utils.validate_nodegroup_server_group_members_quota(context, cluster, nodegroup)
         utils.ensure_worker_server_group(
             ctx=context, cluster=cluster, node_group=nodegroup
         )

--- a/magnum_cluster_api/exceptions.py
+++ b/magnum_cluster_api/exceptions.py
@@ -69,5 +69,13 @@ class MachineDeploymentNotFound(exception.ObjectNotFound):
     message = _("MachineDeployment %(name)s not found.")
 
 
+class ServerGroupMembersQuotaExceeded(exception.Invalid):
+    message = _(
+        "Requested %(requested)s members for server group %(server_group_name)s, "
+        "but the project server_group_members quota is %(limit)s. Reduce the "
+        "cluster node count or ask an administrator to raise the quota."
+    )
+
+
 class InvalidOctaviaLoadBalancerAlgorithm(exception.Invalid):
     message = _("Invalid value for octavia_lb_algorithm: %(octavia_lb_algorithm)s.")

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -14,6 +14,7 @@
 
 import os
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest import mock
 
 import openstack
@@ -103,6 +104,10 @@ def mock_osc(session_mocker, image):
     mock_clients.cinder_region_name.return_value = "RegionOne"
 
     # Others
+    mock_limits = mock_clients.nova.return_value.limits.get.return_value
+    mock_limits.absolute = [
+        SimpleNamespace(name="maxServerGroupMembers", value=10),
+    ]
     mock_clients.url_for.return_value = "http://fake_url"
 
     return mock_clients

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -27,7 +27,7 @@ from oslo_serialization import base64, jsonutils  # type: ignore
 from oslo_utils import uuidutils  # type: ignore
 from responses import matchers
 
-from magnum_cluster_api import driver, objects, resources
+from magnum_cluster_api import driver, exceptions, objects, resources
 
 
 def test_debian_driver_provides():
@@ -36,6 +36,145 @@ def test_debian_driver_provides():
     assert debian_driver.provides == [
         {"server_type": "vm", "os": "debian", "coe": "kubernetes"},
     ]
+
+
+def test_create_cluster_validates_quota_before_creating_capi_resources(context, mocker):
+    cluster = mocker.Mock()
+    cluster.save = mocker.Mock()
+
+    ubuntu_driver = driver.UbuntuDriver.__new__(driver.UbuntuDriver)
+    ubuntu_driver.k8s_api = mocker.Mock()
+    ubuntu_driver.rust_driver = mocker.Mock()
+    ubuntu_driver._create_cluster = mocker.Mock(return_value="created")
+
+    order = []
+    mocker.patch(
+        "magnum_cluster_api.utils.generate_cluster_api_name",
+        return_value="kube-test",
+    )
+    mocker.patch(
+        "magnum_cluster_api.utils.validate_cluster",
+        side_effect=lambda *_args: order.append("validate_cluster"),
+    )
+    mocker.patch(
+        "magnum_cluster_api.utils.validate_cluster_server_group_members_quota",
+        side_effect=lambda *_args: order.append("validate_quota"),
+    )
+    ubuntu_driver.rust_driver.create_cluster.side_effect = lambda *_args: order.append(
+        "create_capi_resources"
+    )
+    ubuntu_driver._create_cluster.side_effect = lambda *_args: order.append(
+        "create_openstack_resources"
+    )
+
+    ubuntu_driver.create_cluster(context, cluster, 60)
+
+    assert cluster.stack_id == "kube-test"
+    assert order == [
+        "validate_cluster",
+        "validate_quota",
+        "create_capi_resources",
+        "create_openstack_resources",
+    ]
+
+
+def test_create_cluster_stops_before_capi_resources_when_quota_exceeded(
+    context, mocker
+):
+    cluster = mocker.Mock()
+    cluster.save = mocker.Mock()
+
+    ubuntu_driver = driver.UbuntuDriver.__new__(driver.UbuntuDriver)
+    ubuntu_driver.k8s_api = mocker.Mock()
+    ubuntu_driver.rust_driver = mocker.Mock()
+    ubuntu_driver._create_cluster = mocker.Mock()
+
+    mocker.patch(
+        "magnum_cluster_api.utils.generate_cluster_api_name",
+        return_value="kube-test",
+    )
+    mocker.patch("magnum_cluster_api.utils.validate_cluster")
+    mocker.patch(
+        "magnum_cluster_api.utils.validate_cluster_server_group_members_quota",
+        side_effect=exceptions.ServerGroupMembersQuotaExceeded(
+            server_group_name="kube-test-default-worker",
+            requested=3,
+            limit=2,
+        ),
+    )
+
+    with pytest.raises(exceptions.ServerGroupMembersQuotaExceeded):
+        ubuntu_driver.create_cluster(context, cluster, 60)
+
+    ubuntu_driver.rust_driver.create_cluster.assert_not_called()
+    ubuntu_driver._create_cluster.assert_not_called()
+
+
+def test_create_nodegroup_validates_quota_before_creating_server_group(context, mocker):
+    cluster = mocker.Mock()
+    cluster.uuid = "cluster-test"
+    nodegroup = mocker.Mock()
+
+    ubuntu_driver = driver.UbuntuDriver.__new__(driver.UbuntuDriver)
+    ubuntu_driver.k8s_api = mocker.Mock()
+
+    cluster_resource = mocker.Mock()
+    cluster_resource.obj = {
+        "spec": {"topology": {"workers": {"machineDeployments": []}}},
+    }
+    mocker.patch(
+        "magnum_cluster_api.objects.Cluster.for_magnum_cluster",
+        return_value=cluster_resource,
+    )
+    mocker.patch(
+        "magnum_cluster_api.resources.mutate_machine_deployment",
+        return_value={"name": "default-worker"},
+    )
+    mocker.patch("magnum_cluster_api.utils.kube_apply_patch")
+    mocker.patch("magnum_cluster_api.utils.validate_nodegroup")
+
+    order = []
+    mocker.patch(
+        "magnum_cluster_api.utils.validate_nodegroup_server_group_members_quota",
+        side_effect=lambda *_args: order.append("validate_quota"),
+    )
+    mocker.patch(
+        "magnum_cluster_api.utils.ensure_worker_server_group",
+        side_effect=lambda **_kwargs: order.append("ensure_server_group"),
+    )
+    mocker.patch("magnum_cluster_api.sync.ClusterLock.acquire")
+    mocker.patch("magnum_cluster_api.sync.ClusterLock.release")
+
+    ubuntu_driver.create_nodegroup(context, cluster, nodegroup)
+
+    assert order == ["validate_quota", "ensure_server_group"]
+
+
+def test_resize_cluster_validates_worker_quota_before_updating_nodegroup(
+    context, mocker
+):
+    cluster = mocker.Mock()
+    cluster.uuid = "cluster-test"
+    nodegroup = mocker.Mock()
+    nodegroup.role = "worker"
+
+    ubuntu_driver = driver.UbuntuDriver.__new__(driver.UbuntuDriver)
+
+    order = []
+    mocker.patch("magnum_cluster_api.utils.validate_cluster")
+    mocker.patch(
+        "magnum_cluster_api.utils.validate_nodegroup_server_group_members_quota",
+        side_effect=lambda *_args: order.append("validate_quota"),
+    )
+    ubuntu_driver._update_nodegroup = mocker.Mock(
+        side_effect=lambda *_args: order.append("update_nodegroup")
+    )
+    mocker.patch("magnum_cluster_api.sync.ClusterLock.acquire")
+    mocker.patch("magnum_cluster_api.sync.ClusterLock.release")
+
+    ubuntu_driver.resize_cluster(context, cluster, None, 3, [], nodegroup)
+
+    assert order == ["validate_quota", "update_nodegroup"]
 
 
 @pytest.mark.parametrize(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -14,6 +14,7 @@
 
 import textwrap
 import types
+from types import SimpleNamespace
 from unittest import mock
 
 import pykube
@@ -27,6 +28,108 @@ from oslo_utils import uuidutils
 from oslotest import base
 
 from magnum_cluster_api import exceptions, utils
+
+
+def _mock_server_group_members_limit(mocker, limit):
+    osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    osc.nova.return_value.limits.get.return_value.absolute = [
+        SimpleNamespace(name="maxServerGroupMembers", value=limit),
+    ]
+    return osc
+
+
+def _get_cluster_with_worker(context, mocker, master_count=1, worker_count=1):
+    cluster = magnum_test_utils.get_test_cluster(
+        context,
+        labels={},
+    )
+    cluster.stack_id = "kube-test"
+
+    master = magnum_test_utils.get_test_nodegroup(
+        context,
+        name="default-master",
+        role="master",
+        node_count=master_count,
+        labels={},
+    )
+    worker = magnum_test_utils.get_test_nodegroup(
+        context,
+        name="default-worker",
+        role="worker",
+        node_count=worker_count,
+        labels={},
+    )
+    mocker.patch("magnum.objects.NodeGroup.list", return_value=[master, worker])
+
+    return cluster, worker
+
+
+def test_validate_cluster_server_group_members_quota_allows_limit(context, mocker):
+    cluster, _worker = _get_cluster_with_worker(context, mocker, worker_count=2)
+    _mock_server_group_members_limit(mocker, 2)
+
+    utils.validate_cluster_server_group_members_quota(context, cluster)
+
+
+def test_validate_cluster_server_group_members_quota_raises_for_control_plane(
+    context, mocker
+):
+    cluster, _worker = _get_cluster_with_worker(context, mocker, master_count=3)
+    _mock_server_group_members_limit(mocker, 2)
+
+    with pytest.raises(exceptions.ServerGroupMembersQuotaExceeded) as exc:
+        utils.validate_cluster_server_group_members_quota(context, cluster)
+
+    assert "kube-test" in str(exc.value)
+    assert "requested 3" in str(exc.value).lower()
+
+
+def test_validate_cluster_server_group_members_quota_raises_for_worker(context, mocker):
+    cluster, _worker = _get_cluster_with_worker(context, mocker, worker_count=3)
+    _mock_server_group_members_limit(mocker, 2)
+
+    with pytest.raises(exceptions.ServerGroupMembersQuotaExceeded) as exc:
+        utils.validate_cluster_server_group_members_quota(context, cluster)
+
+    assert "kube-test-default-worker" in str(exc.value)
+    assert "requested 3" in str(exc.value).lower()
+
+
+def test_validate_nodegroup_server_group_members_quota_uses_autoscaler_max(
+    context, mocker
+):
+    cluster, worker = _get_cluster_with_worker(context, mocker, worker_count=1)
+    cluster.labels["auto_scaling_enabled"] = "True"
+    worker.max_node_count = 5
+    _mock_server_group_members_limit(mocker, 3)
+
+    with pytest.raises(exceptions.ServerGroupMembersQuotaExceeded) as exc:
+        utils.validate_nodegroup_server_group_members_quota(context, cluster, worker)
+
+    assert "requested 5" in str(exc.value).lower()
+
+
+def test_validate_nodegroup_server_group_members_quota_ignores_unlimited_quota(
+    context, mocker
+):
+    cluster, worker = _get_cluster_with_worker(context, mocker, worker_count=100)
+    _mock_server_group_members_limit(mocker, -1)
+
+    utils.validate_nodegroup_server_group_members_quota(context, cluster, worker)
+
+
+def test_validate_controlplane_server_group_members_quota_uses_project_for_admin(
+    context, mocker
+):
+    cluster, _worker = _get_cluster_with_worker(context, mocker)
+    context.is_admin = True
+    osc = _mock_server_group_members_limit(mocker, 10)
+
+    utils.validate_controlplane_server_group_members_quota(context, cluster)
+
+    osc.nova.return_value.limits.get.assert_called_once_with(
+        tenant_id=cluster.project_id
+    )
 
 
 def test_generate_cluster_api_name(mocker):

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -494,6 +494,92 @@ def validate_cluster(ctx: context.RequestContext, cluster: magnum_objects.Cluste
             neutron.get_subnet(ctx, cluster.fixed_subnet, source="name", target="id")
 
 
+def _get_server_group_members_quota_limit(
+    ctx: context.RequestContext,
+    cluster: magnum_objects.Cluster,
+) -> typing.Optional[int]:
+    osc = clients.get_openstack_api(ctx)
+    tenant_id = cluster.project_id if ctx.is_admin else None
+    limits = osc.nova().limits.get(tenant_id=tenant_id)
+    absolute_limits = {limit.name: limit.value for limit in limits.absolute}
+    return absolute_limits.get("maxServerGroupMembers")
+
+
+def _validate_server_group_members_quota(
+    limit: typing.Optional[int],
+    server_group_name: str,
+    requested: int,
+):
+    if limit is None or limit == -1 or requested <= limit:
+        return
+
+    raise mcapi_exceptions.ServerGroupMembersQuotaExceeded(
+        server_group_name=server_group_name,
+        requested=requested,
+        limit=limit,
+    )
+
+
+def _get_node_group_server_group_members(
+    cluster: magnum_objects.Cluster,
+    node_group: magnum_objects.NodeGroup,
+) -> int:
+    if get_auto_scaling_enabled(cluster):
+        return get_node_group_max_node_count(node_group)
+    return node_group.node_count
+
+
+def validate_cluster_server_group_members_quota(
+    ctx: context.RequestContext,
+    cluster: magnum_objects.Cluster,
+):
+    limit = _get_server_group_members_quota_limit(ctx, cluster)
+    _validate_server_group_members_quota(
+        limit=limit,
+        server_group_name=cluster.stack_id,
+        requested=cluster.master_count,
+    )
+
+    for node_group in cluster.nodegroups:
+        if node_group.role == "master":
+            continue
+
+        _validate_server_group_members_quota(
+            limit=limit,
+            server_group_name=f"{cluster.stack_id}-{node_group.name}",
+            requested=_get_node_group_server_group_members(cluster, node_group),
+        )
+
+
+def validate_controlplane_server_group_members_quota(
+    ctx: context.RequestContext,
+    cluster: magnum_objects.Cluster,
+    requested: typing.Optional[int] = None,
+):
+    if requested is None:
+        requested = cluster.master_count
+
+    limit = _get_server_group_members_quota_limit(ctx, cluster)
+    _validate_server_group_members_quota(
+        limit=limit,
+        server_group_name=cluster.stack_id,
+        requested=requested,
+    )
+
+
+def validate_nodegroup_server_group_members_quota(
+    ctx: context.RequestContext,
+    cluster: magnum_objects.Cluster,
+    node_group: magnum_objects.NodeGroup,
+):
+    limit = _get_server_group_members_quota_limit(ctx, cluster)
+    _validate_server_group_members_quota(
+        limit=limit,
+        server_group_name=f"{cluster.stack_id}-{node_group.name}",
+        requested=_get_node_group_server_group_members(cluster, node_group),
+    )
+
+
 def validate_nodegroup_name(nodegroup: magnum_objects.NodeGroup):
     # Machine requires a lowercase RFC 1123 subdomain name.
     rgx = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"


### PR DESCRIPTION
## Summary
- add a Nova limits preflight for the server_group_members quota
- fail cluster, node group, and scale-up requests before creating CAPI/CAPO resources when the requested server group size is too large
- include autoscaler max_node_count in the validation and return an actionable Magnum error

## Testing
- /Users/dong/dongdev/VEXXHOST/magnum-cluster-api/.tox/unit/bin/python -m pytest magnum_cluster_api/tests/unit/test_utils.py -k 'server_group_members_quota' magnum_cluster_api/tests/unit/test_driver.py -k 'quota'
- uvx pre-commit run --files magnum_cluster_api/driver.py magnum_cluster_api/utils.py magnum_cluster_api/exceptions.py magnum_cluster_api/tests/conftest.py magnum_cluster_api/tests/unit/test_utils.py magnum_cluster_api/tests/unit/test_driver.py