### PR TITLE
feat(cinder-csi): expose topology and volumeBindingMode as cluster labels

### DIFF
--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -178,6 +178,24 @@ is often accomplished by deploying a driver on each node.
 
    Default value: Automatically detected based on `kube_tag` label.
 
+* `cinder_csi_topology`
+
+   Controls the `--feature-gates=Topology=...` flag on the Cinder CSI
+   provisioner sidecar. Set to `"false"` when the Cinder availability zone
+   and the Nova compute availability zone names do not match; doing so
+   prevents PersistentVolumes from receiving a `nodeAffinity` constraint
+   tied to the Cinder AZ.
+
+   Default value: `"true"`
+
+* `cinder_csi_volume_binding_mode`
+
+   The `volumeBindingMode` for all generated `block-*` StorageClasses.
+   Set to `"WaitForFirstConsumer"` to defer volume creation (and AZ
+   selection) until a pod is actually scheduled to a node.
+
+   Default value: `"Immediate"`
+
 ### Manila
 
 * `manila_csi_plugin_tag`

--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -291,7 +291,9 @@ class CloudProviderClusterResourcesSecret(ClusterBase):
                                 "type": vt.name,
                             },
                             "reclaimPolicy": "Delete",
-                            "volumeBindingMode": "Immediate",
+                            "volumeBindingMode": self.cluster.labels.get(
+                                "cinder_csi_volume_binding_mode", "Immediate"
+                            ),
                         }
                     )
                     for vt in volume_types

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -12,7 +12,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from unittest import mock
+
 import pytest
+import yaml
 from magnum.objects import fields
 from magnum.tests.unit.objects import utils
 from novaclient.v2 import flavors  # type: ignore
@@ -161,3 +164,62 @@ class TestExistingMutateMachineDeployment:
         else:
             assert md["replicas"] == self.node_group.node_count
             assert md["metadata"]["annotations"] == {}
+
+
+class TestCloudProviderClusterResourcesSecretVolumeBindingMode:
+    @pytest.fixture(autouse=True)
+    def setup(self, context, mocker):
+        self.context = context
+
+        volume_type = mock.MagicMock()
+        volume_type.name = "standard"
+
+        mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api")
+        mock_osc.return_value.cinder.return_value.volume_types.list.return_value = [volume_type]
+        mock_osc.return_value.cinder.return_value.volume_types.default.return_value.name = "other"
+
+        mocker.patch(
+            "magnum_cluster_api.integrations.cinder.is_enabled", return_value=True
+        )
+        mocker.patch(
+            "magnum_cluster_api.integrations.manila.is_enabled", return_value=False
+        )
+        mocker.patch(
+            "magnum_cluster_api.magnum_cluster_api.Driver"
+            ".get_cloud_provider_cluster_resource_secret_data",
+            return_value={},
+        )
+        mocker.patch(
+            "magnum_cluster_api.magnum_cluster_api.Driver"
+            ".get_cinder_csi_cluster_resource_secret_data",
+            return_value={},
+        )
+        mocker.patch(
+            "magnum_cluster_api.utils.generate_cloud_controller_manager_config",
+            return_value="",
+        )
+        mocker.patch("magnum.common.utils.get_openstack_ca", return_value="")
+
+    def _get_storage_class(self, cluster_labels):
+        cluster = mock.MagicMock()
+        cluster.labels = cluster_labels
+
+        secret = resources.CloudProviderClusterResourcesSecret(
+            self.context,
+            mock.MagicMock(),
+            mock.MagicMock(),
+            cluster,
+        )
+        obj = secret.get_object()
+        sc_yaml = obj["stringData"]["storageclass-block-standard.yaml"]
+        return yaml.safe_load(sc_yaml)
+
+    def test_default_is_immediate(self):
+        sc = self._get_storage_class({})
+        assert sc["volumeBindingMode"] == "Immediate"
+
+    def test_label_overrides_binding_mode(self):
+        sc = self._get_storage_class(
+            {"cinder_csi_volume_binding_mode": "WaitForFirstConsumer"}
+        )
+        assert sc["volumeBindingMode"] == "WaitForFirstConsumer"

--- a/src/addons/cinder_csi.rs
+++ b/src/addons/cinder_csi.rs
@@ -24,9 +24,15 @@ pub struct CSIValues {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub struct CSIProvisionerComponent {
+    pub image: ImageDetails,
+    pub topology: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CSIComponents {
     attacher: CSIComponent,
-    provisioner: CSIComponent,
+    provisioner: CSIProvisionerComponent,
     snapshotter: CSIComponent,
     resizer: CSIComponent,
     livenessprobe: CSIComponent,
@@ -104,12 +110,13 @@ impl TryFrom<magnum::Cluster> for CSIValues {
                         .image
                         .using_cluster::<Self>(&cluster, &cluster.labels.csi_attacher_tag)?,
                 },
-                provisioner: CSIComponent {
+                provisioner: CSIProvisionerComponent {
                     image: values
                         .csi
                         .provisioner
                         .image
                         .using_cluster::<Self>(&cluster, &cluster.labels.csi_provisioner_tag)?,
+                    topology: cluster.labels.cinder_csi_topology.clone(),
                 },
                 snapshotter: CSIComponent {
                     image: values
@@ -429,6 +436,45 @@ mod tests {
         );
         assert_eq!(values.storage_class.enabled, false);
         assert_eq!(values.cluster_id, cluster.uuid);
+    }
+
+    #[test]
+    fn test_cinder_csi_topology_default() {
+        let cluster = magnum::Cluster {
+            uuid: "sample-uuid".to_string(),
+            labels: magnum::ClusterLabels::builder().build(),
+            stack_id: "kube-abcde".to_string().into(),
+            cluster_template: magnum::ClusterTemplate {
+                network_driver: "cilium".to_string(),
+            },
+            ..Default::default()
+        };
+
+        let values: CSIValues = cluster.try_into().expect("failed to create values");
+        assert_eq!(values.csi.provisioner.topology, "true");
+    }
+
+    #[test]
+    fn test_cinder_csi_topology_disabled() {
+        let cluster = magnum::Cluster {
+            uuid: "sample-uuid".to_string(),
+            labels: magnum::ClusterLabels::builder()
+                .cinder_csi_topology("false".to_string())
+                .build(),
+            stack_id: "kube-abcde".to_string().into(),
+            cluster_template: magnum::ClusterTemplate {
+                network_driver: "cilium".to_string(),
+            },
+            ..Default::default()
+        };
+
+        let values: CSIValues = cluster.clone().try_into().expect("failed to create values");
+        assert_eq!(values.csi.provisioner.topology, "false");
+
+        let addon = Addon::new(cluster);
+        let manifests = addon.manifests().expect("failed to get manifests");
+        let manifest = manifests.get("cinder-csi.yaml").expect("manifest missing");
+        assert!(manifest.contains("--feature-gates=Topology=false"));
     }
 
     #[test]

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -52,6 +52,18 @@ pub struct ClusterLabels {
     #[pyo3(default="v1.32.0".to_owned())]
     pub cinder_csi_plugin_tag: String,
 
+    /// Controls --feature-gates=Topology=... on the csi-provisioner container.
+    /// Set to "false" when the Cinder AZ and the Nova compute AZ don't match.
+    #[builder(default = "true".to_owned())]
+    #[pyo3(default = "true".to_owned())]
+    pub cinder_csi_topology: String,
+
+    /// volumeBindingMode for generated block-* StorageClasses.
+    /// Set to "WaitForFirstConsumer" to defer volume creation until a node is chosen.
+    #[builder(default = "Immediate".to_owned())]
+    #[pyo3(default = "Immediate".to_owned())]
+    pub cinder_csi_volume_binding_mode: String,
+
     /// Enable the use of the Manila CSI driver for the cluster.
     #[builder(default = true)]
     #[pyo3(default = true)]


### PR DESCRIPTION
Fixes PV scheduling failures when the Cinder AZ and Nova compute AZ don't match (reported in #366).

Two opt-in cluster-template labels are added:

- `cinder_csi_topology`: controls `--feature-gates=Topology=...` on the `csi-provisioner` sidecar. Set to `"false"` to stop PVs from receiving a `nodeAffinity` pinned to the Cinder AZ. Default: `"true"`
- `cinder_csi_volume_binding_mode`: controls `volumeBindingMode` on generated `block-*` StorageClasses. Set to `"WaitForFirstConsumer"` to defer volume creation until a pod is scheduled. Default: `"Immediate"`

Both default to the current hardcoded values so existing clusters and cluster templates require no changes. Also fixes a silent serde drop of `csi.provisioner.topology` by introducing `CSIProvisionerComponent` with an explicit `topology` field.