### PR TITLE
fix(labels): restore template labels for sparse cluster labels

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -70,6 +70,11 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
+        # See note in delete_cluster: Magnum REPLACES template labels with the
+        # cluster's own --labels list.  Merge any missing keys back in so the
+        # Rust driver and downstream consumers see a complete label dict.
+        utils.fill_missing_labels_from_template(cluster)
+
         self.rust_driver.create_cluster(cluster)
 
         utils.validate_cluster(context, cluster)
@@ -444,6 +449,13 @@ class BaseDriver(driver.Driver):
         #               https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/842
         #               https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/990
         utils.delete_loadbalancers(context, cluster)
+
+        # NOTE(rlin): Magnum's `cluster create --labels` REPLACES (rather than
+        # merges) the cluster_template labels.  This means a cluster row may
+        # legitimately be missing keys (e.g. ``kube_tag``) that the Rust driver
+        # needs to deserialize ClusterLabels.  Merge template labels as a
+        # fallback so delete never trips over a sparse label dict.
+        utils.fill_missing_labels_from_template(cluster)
 
         self.rust_driver.delete_cluster(cluster)
         resources.Cluster(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -368,3 +368,43 @@ class TestUtils(base.BaseTestCase):
             context,
             fixed_network,
         )
+
+
+class TestFillMissingLabelsFromTemplate:
+    def _cluster(self, labels, template_labels):
+        cluster = mock.Mock()
+        cluster.labels = dict(labels)
+        cluster.cluster_template = mock.Mock()
+        cluster.cluster_template.labels = dict(template_labels)
+        return cluster
+
+    def test_fills_missing_keys(self):
+        """F3: missing keys (e.g. kube_tag) are pulled from the template."""
+        cluster = self._cluster(
+            {"extra_files": "x"},
+            {"kube_tag": "v1.30.0", "boot_volume_size": "20"},
+        )
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels["kube_tag"] == "v1.30.0"
+        assert cluster.labels["boot_volume_size"] == "20"
+        assert cluster.labels["extra_files"] == "x"
+
+    def test_does_not_override_cluster_values(self):
+        cluster = self._cluster({"kube_tag": "v1.34.3"}, {"kube_tag": "v1.30.0"})
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels["kube_tag"] == "v1.34.3"
+
+    def test_no_template_is_safe(self):
+        cluster = mock.Mock()
+        cluster.labels = {"a": "b"}
+        cluster.cluster_template = None
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels == {"a": "b"}
+
+    def test_none_labels_initialised(self):
+        cluster = mock.Mock()
+        cluster.labels = None
+        cluster.cluster_template = mock.Mock()
+        cluster.cluster_template.labels = {"kube_tag": "v1.30.0"}
+        utils.fill_missing_labels_from_template(cluster)
+        assert cluster.labels == {"kube_tag": "v1.30.0"}

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -379,7 +379,7 @@ class TestFillMissingLabelsFromTemplate:
         return cluster
 
     def test_fills_missing_keys(self):
-        """F3: missing keys (e.g. kube_tag) are pulled from the template."""
+        """Missing keys (e.g. kube_tag) are pulled from the template."""
         cluster = self._cluster(
             {"extra_files": "x"},
             {"kube_tag": "v1.30.0", "boot_volume_size": "20"},

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -191,6 +191,30 @@ def get_kube_tag(cluster: magnum_objects.Cluster) -> str:
     return cluster.labels.get("kube_tag", "v1.25.3")
 
 
+def fill_missing_labels_from_template(cluster: magnum_objects.Cluster) -> None:
+    """Merge cluster_template labels into ``cluster.labels`` for missing keys.
+
+    Magnum's ``cluster create --labels`` REPLACES the cluster_template labels
+    rather than merging, so a freshly-created cluster row can be missing keys
+    that downstream code (especially the Rust ClusterLabels deserialiser)
+    expects to be present (e.g. ``kube_tag``).  This helper fills in any
+    template-only keys without overriding values the operator explicitly set.
+
+    Mutates ``cluster.labels`` in place.  Safe to call multiple times — keys
+    already present on the cluster are left untouched.
+    """
+    template = getattr(cluster, "cluster_template", None)
+    if template is None:
+        return
+    template_labels = getattr(template, "labels", None) or {}
+    if not template_labels:
+        return
+    if cluster.labels is None:
+        cluster.labels = {}
+    for key, value in template_labels.items():
+        cluster.labels.setdefault(key, value)
+
+
 def get_auto_scaling_enabled(cluster: magnum_objects.Cluster) -> bool:
     return get_cluster_label_as_bool(cluster, "auto_scaling_enabled", False)
 


### PR DESCRIPTION
## Purpose

This draft PR now keeps only the sparse cluster-template label fallback that is still not covered by PR #1040 plus PR #1013.

Magnum `cluster create --labels` replaces, rather than merges, cluster-template labels. If a user supplies any sparse cluster labels, the stored cluster row can miss template keys such as `kube_tag`. The Rust label extractor and monitor then fail with `KeyError: 'kube_tag'`, and delete/status paths can also trip over the same sparse label dict.

## Scope Kept

- Merge missing `cluster.cluster_template.labels` into `cluster.labels` before Rust create/delete paths, without overriding user-provided labels.
- Keep the related unit coverage and remove the old internal codename from the test docstring.

## Scope Dropped After Retest

These were removed from this draft because PR #1040 already covers them when combined with PR #1013:

- OpenStackSDK application credential/service/volume/flavor compatibility.
- OpenStackSDK server group compatibility.
- Rust string boolean label parsing.
- hardware disk bus `None` normalization.
- nodegroup MachineSet-list test fixture adjustment.
- eventlet/tpool avoidance changes, with no separate failure reproduced in the combined retest.
- default amphorav2 provider test expectation.

## Validation

```bash
uvx --python 3.12 pre-commit run --all-files
# passed

uv run --python 3.10 pytest \
  magnum_cluster_api/tests/unit/test_utils.py \
  -q -k 'FillMissingLabelsFromTemplate'
# 4 passed, 16 deselected, 7 warnings
```

Live AIO retest with a temporary combined PR #1040 + PR #1013 image:

- Built and rolled the combined image to the OVN AIO Magnum workloads.
- Normal config-profile template create was accepted and persisted template-derived labels including `kube_tag`.
- Sparse-label create with an extra non-profile label was accepted but persisted only the sparse labels plus `config_profile`; the conductor then logged `KeyError: 'kube_tag'` while extracting `Cluster.labels`.
- Config-profile override create failed as expected with the PR #1013 validation message.
- The OVS AIO was quota-blocked before create-path validation; fallback AIO hosts were unreachable from this session.

Signed-off-by: Rico Lin <rico@vexxhost.com>