### PR TITLE
fix(keystone-auth): schedule webhook on control planes

### DIFF
--- a/magnum_cluster_api/charts/k8s-keystone-auth/templates/daemonset.yaml
+++ b/magnum_cluster_api/charts/k8s-keystone-auth/templates/daemonset.yaml
@@ -57,6 +57,12 @@ spec:
               containerPort: {{ .Values.service.port }}
               hostPort: {{ .Values.service.hostPort }}
               protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: https
+          livenessProbe:
+            tcpSocket:
+              port: https
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/magnum_cluster_api/charts/k8s-keystone-auth/values.yaml
+++ b/magnum_cluster_api/charts/k8s-keystone-auth/values.yaml
@@ -78,8 +78,7 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-nodeSelector:
-  node-role.kubernetes.io/master: ""
+nodeSelector: {}
 
 tolerations:
   # Make sure the pod can be scheduled on master kubelet.
@@ -91,4 +90,13 @@ tolerations:
   - effect: NoExecute
     operator: Exists
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+        - matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: Exists


### PR DESCRIPTION
## Summary

Follow-up to #1018 for the remaining Keystone webhook listener gap.

The kube-apiserver webhook config points at `https://127.0.0.1:8443/webhook`, so the `k8s-keystone-auth` DaemonSet must run on every control-plane host. Newer kubeadm nodes use `node-role.kubernetes.io/control-plane`, while the chart only selected the legacy `node-role.kubernetes.io/master` label. That can leave no webhook backend listening on the API server host.

This PR:

- replaces the single-label `nodeSelector` with default node affinity that accepts either `control-plane` or legacy `master`
- keeps the host-network listener on `127.0.0.1:8443`
- adds TCP readiness and liveness probes for the HTTPS listener

## Validation

Rendered the chart and asserted the generated DaemonSet has:

- node affinity terms for both `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master`
- no default `nodeSelector` that would AND the labels together
- TCP readiness/liveness probes on the `https` port
- `--listen 127.0.0.1:8443`

Commands:

```bash
helm template k8s-keystone-auth magnum_cluster_api/charts/k8s-keystone-auth --namespace kube-system > /tmp/k8s-keystone-auth-rendered.yaml
python3 - <<'PY'
import yaml
with open('/tmp/k8s-keystone-auth-rendered.yaml') as fh:
    docs = [doc for doc in yaml.safe_load_all(fh) if doc]
daemonsets = [doc for doc in docs if doc.get('kind') == 'DaemonSet']
assert len(daemonsets) == 1, daemonsets
ds = daemonsets[0]
spec = ds['spec']['template']['spec']
terms = spec['affinity']['nodeAffinity']['requiredDuringSchedulingIgnoredDuringExecution']['nodeSelectorTerms']
keys = {expr['key'] for term in terms for expr in term['matchExpressions']}
assert 'node-role.kubernetes.io/control-plane' in keys, keys
assert 'node-role.kubernetes.io/master' in keys, keys
assert 'nodeSelector' not in spec, spec.get('nodeSelector')
container = spec['containers'][0]
assert container['readinessProbe']['tcpSocket']['port'] == 'https'
assert container['livenessProbe']['tcpSocket']['port'] == 'https'
assert container['args'][container['args'].index('--listen') + 1] == '127.0.0.1:8443'
PY

git diff --check HEAD~1..HEAD
```
