### PR TITLE
fix(server-groups): evict stale cached ids

### DIFF
--- a/magnum_cluster_api/cache.py
+++ b/magnum_cluster_api/cache.py
@@ -18,3 +18,6 @@ class ServerGroupCache(object):
 
     def set(self, project_id, server_group_name, server_group_id):
         self._cache.set((project_id, server_group_name), server_group_id, self._ttl)
+
+    def delete(self, project_id, server_group_name):
+        self._cache.delete((project_id, server_group_name))

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -104,6 +104,9 @@ def mock_osc(session_mocker, image):
 
     # Others
     mock_clients.url_for.return_value = "http://fake_url"
+    mock_nova_client = mock_clients.nova.return_value
+    mock_nova_client.server_groups.list.return_value = []
+    mock_nova_client.server_groups.create.return_value.id = uuidutils.generate_uuid()
 
     return mock_clients
 

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -46,6 +46,74 @@ def test_generate_cluster_api_name(mocker):
     assert len(potential_node_name) <= 63
 
 
+def test_get_server_group_id_uses_verified_cache(context, mocker):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mock_cache.get.return_value = "server-group-id"
+    nova = types.SimpleNamespace(
+        server_groups=types.SimpleNamespace(
+            list=mocker.Mock(
+                return_value=[
+                    types.SimpleNamespace(name="kube-test", id="server-group-id")
+                ]
+            )
+        )
+    )
+    mocker.patch(
+        "magnum_cluster_api.clients.get_openstack_api"
+    ).return_value.nova.return_value = nova
+
+    server_group_id = utils.get_server_group_id(context, "kube-test", "project-id")
+
+    assert server_group_id == "server-group-id"
+    mock_cache.delete.assert_not_called()
+    mock_cache.set.assert_not_called()
+
+
+def test_get_server_group_id_evicts_stale_cache(context, mocker):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mock_cache.get.return_value = "stale-server-group-id"
+    osc = types.SimpleNamespace(
+        list_server_groups=mocker.Mock(
+            return_value=[types.SimpleNamespace(name="kube-test", id="server-group-id")]
+        )
+    )
+    mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value = osc
+
+    server_group_id = utils.get_server_group_id(context, "kube-test", "project-id")
+
+    assert server_group_id == "server-group-id"
+    mock_cache.delete.assert_called_once_with("project-id", "kube-test")
+    mock_cache.set.assert_called_once_with("project-id", "kube-test", "server-group-id")
+
+
+def test_delete_server_group_evicts_cache(context, mocker):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mocker.patch("magnum_cluster_api.utils.get_server_group_id").return_value = (
+        "server-group-id"
+    )
+    osc = types.SimpleNamespace(delete_server_group=mocker.Mock())
+    mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value = osc
+
+    utils._delete_server_group("kube-test", context, "project-id")
+
+    osc.delete_server_group.assert_called_once_with("server-group-id")
+    mock_cache.delete.assert_called_once_with("project-id", "kube-test")
+
+
+def test_delete_server_group_evicts_cache_after_ignored_not_found(context, mocker):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mocker.patch("magnum_cluster_api.utils.get_server_group_id").return_value = (
+        "server-group-id"
+    )
+    osc = types.SimpleNamespace(delete_server_group=mocker.Mock())
+    mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value = osc
+
+    utils._delete_server_group("kube-test", context, "project-id")
+
+    osc.delete_server_group.assert_called_once_with("server-group-id")
+    mock_cache.delete.assert_called_once_with("project-id", "kube-test")
+
+
 class TestGenerateCloudControllerManagerConfig:
     @pytest.fixture(autouse=True)
     def setup(self, context, pykube_api, mocker):

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -583,8 +583,7 @@ def get_server_group_id(
     name: str,
     project_id: typing.Optional[str] = None,
 ):
-    if g_server_group_cache.get(project_id, name):
-        return g_server_group_cache.get(project_id, name)
+    cached_server_group_id = g_server_group_cache.get(project_id, name)
 
     # Check if the server group exists already
     osc = clients.get_openstack_api(ctx)
@@ -593,6 +592,12 @@ def get_server_group_id(
     for sg in server_groups:
         if sg.name == name:
             server_group_id_list.append(sg.id)
+
+    if cached_server_group_id and cached_server_group_id in server_group_id_list:
+        return cached_server_group_id
+
+    if cached_server_group_id:
+        g_server_group_cache.delete(project_id, name)
 
     if len(server_group_id_list) == 1:
         g_server_group_cache.set(project_id, name, server_group_id_list[0])
@@ -724,6 +729,7 @@ def _delete_server_group(
 
     osc = clients.get_openstack_api(ctx)
     osc.delete_server_group(server_group_id)
+    g_server_group_cache.delete(project_id, name)
 
 
 def get_fixed_network_id(context, network):


### PR DESCRIPTION
## Summary

- verify cached Nova server group IDs still exist before reusing them
- evict server group cache entries after successful or already-missing deletes
- add focused unit coverage for stale-cache refresh and delete eviction

## Root Cause

Nodegroup recreation can happen quickly after a worker nodegroup delete. The previous server group ID may still be cached by `(project_id, server_group_name)` even after the Nova server group has been deleted. Reusing that stale ID renders an immutable CAPI `OpenStackMachineTemplate` with a server group Nova no longer has, causing worker server creation to fail.

## Validation

- `uv run pytest magnum_cluster_api/tests/unit/test_utils.py -k 'server_group'` -> 4 passed
- `git diff --check`

## Notes

A broader `uv run pytest magnum_cluster_api/tests/unit/test_utils.py` currently fails on an existing cloud-controller config expectation: the test expects `lb-provider=amphora`, while current code renders `amphorav2`. That failure is outside this server-group cache fix.
