### PR TITLE
Fix conductor Kubernetes lock client usage

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -218,7 +218,8 @@ class BaseDriver(driver.Driver):
 
             capi_cluster.reload()
             status_map = {
-                c["type"]: c["status"] for c in capi_cluster.obj["status"]["conditions"]
+                c["type"]: c["status"]
+                for c in capi_cluster.obj.get("status", {}).get("conditions", [])
             }
 
             for condition in ("ControlPlaneReady", "InfrastructureReady", "Ready"):

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-from eventlet import tpool  # type: ignore
 from heatclient import exc  # type: ignore
 from magnum import objects as magnum_objects  # type: ignore
 from magnum.common import exception as magnum_exception  # type: ignore
@@ -47,12 +46,12 @@ def cluster_lock_wrapper(func):
 class BaseDriver(driver.Driver):
     def __init__(self):
         self.k8s_api = clients.get_pykube_api()
-        self.rust_driver = tpool.Proxy(magnum_cluster_api.Driver("magnum-system"))
+        self.rust_driver = magnum_cluster_api.Driver("magnum-system")
 
     @property
     def kube_client(self):
         if not hasattr(self, "_kube_client"):
-            self._kube_client = tpool.Proxy(magnum_cluster_api.KubeClient())
+            self._kube_client = magnum_cluster_api.KubeClient()
         return self._kube_client
 
     def create_cluster(

--- a/magnum_cluster_api/sync.py
+++ b/magnum_cluster_api/sync.py
@@ -21,16 +21,21 @@ from kubernetes.config.config_exception import ConfigException  # type: ignore
 def _normalize_bearer_token(
     configuration: kubernetes_client.Configuration,
 ) -> None:
-    authorization = configuration.api_key.get("authorization")
+    authorization = configuration.api_key.get(
+        "authorization",
+        configuration.api_key.get("BearerToken"),
+    )
     if not authorization:
         return
 
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
-        return
+        token = authorization
 
     configuration.api_key["authorization"] = token
+    configuration.api_key["BearerToken"] = token
     configuration.api_key_prefix["authorization"] = "Bearer"
+    configuration.api_key_prefix["BearerToken"] = "Bearer"
 
 
 def _load_kubernetes_client() -> kubernetes_client.CoordinationV1Api:

--- a/magnum_cluster_api/sync.py
+++ b/magnum_cluster_api/sync.py
@@ -13,6 +13,49 @@
 # under the License.
 
 import sherlock  # type: ignore
+from kubernetes import client as kubernetes_client  # type: ignore
+from kubernetes import config as kubernetes_config  # type: ignore
+from kubernetes.config.config_exception import ConfigException  # type: ignore
+
+
+def _normalize_bearer_token(
+    configuration: kubernetes_client.Configuration,
+) -> None:
+    authorization = configuration.api_key.get("authorization")
+    if not authorization:
+        return
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return
+
+    configuration.api_key["authorization"] = token
+    configuration.api_key_prefix["authorization"] = "Bearer"
+
+
+def _load_kubernetes_client() -> kubernetes_client.CoordinationV1Api:
+    try:
+        kubernetes_config.load_incluster_config()
+    except ConfigException:
+        kubernetes_config.load_config()
+
+    configuration = kubernetes_client.Configuration.get_default_copy()
+    refresh_api_key_hook = configuration.refresh_api_key_hook
+
+    if refresh_api_key_hook is not None:
+
+        def _refresh_api_key(
+            refreshed_configuration: kubernetes_client.Configuration,
+        ) -> None:
+            refresh_api_key_hook(refreshed_configuration)
+            _normalize_bearer_token(refreshed_configuration)
+
+        configuration.refresh_api_key_hook = _refresh_api_key
+
+    _normalize_bearer_token(configuration)
+    return kubernetes_client.CoordinationV1Api(
+        kubernetes_client.ApiClient(configuration)
+    )
 
 
 class ClusterLock(sherlock.KubernetesLock):
@@ -33,4 +76,5 @@ class ClusterLock(sherlock.KubernetesLock):
             lock_name="cluster-%s" % cluster_id,
             k8s_namespace="magnum-system",
             expire=expire,
+            client=_load_kubernetes_client(),
         )

--- a/magnum_cluster_api/sync.py
+++ b/magnum_cluster_api/sync.py
@@ -18,49 +18,13 @@ from kubernetes import config as kubernetes_config  # type: ignore
 from kubernetes.config.config_exception import ConfigException  # type: ignore
 
 
-def _normalize_bearer_token(
-    configuration: kubernetes_client.Configuration,
-) -> None:
-    authorization = configuration.api_key.get(
-        "authorization",
-        configuration.api_key.get("BearerToken"),
-    )
-    if not authorization:
-        return
-
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token:
-        token = authorization
-
-    configuration.api_key["authorization"] = token
-    configuration.api_key["BearerToken"] = token
-    configuration.api_key_prefix["authorization"] = "Bearer"
-    configuration.api_key_prefix["BearerToken"] = "Bearer"
-
-
 def _load_kubernetes_client() -> kubernetes_client.CoordinationV1Api:
     try:
         kubernetes_config.load_incluster_config()
     except ConfigException:
         kubernetes_config.load_config()
 
-    configuration = kubernetes_client.Configuration.get_default_copy()
-    refresh_api_key_hook = configuration.refresh_api_key_hook
-
-    if refresh_api_key_hook is not None:
-
-        def _refresh_api_key(
-            refreshed_configuration: kubernetes_client.Configuration,
-        ) -> None:
-            refresh_api_key_hook(refreshed_configuration)
-            _normalize_bearer_token(refreshed_configuration)
-
-        configuration.refresh_api_key_hook = _refresh_api_key
-
-    _normalize_bearer_token(configuration)
-    return kubernetes_client.CoordinationV1Api(
-        kubernetes_client.ApiClient(configuration)
-    )
+    return kubernetes_client.CoordinationV1Api()
 
 
 class ClusterLock(sherlock.KubernetesLock):

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -45,7 +45,7 @@ def context():
 
 @pytest.fixture(scope="session")
 def mock_cluster_lock(session_mocker):
-    session_mocker.patch("kubernetes.config.load_config")
+    session_mocker.patch("magnum_cluster_api.sync._load_kubernetes_client")
     session_mocker.patch("magnum_cluster_api.sync.ClusterLock.acquire")
     session_mocker.patch("magnum_cluster_api.sync.ClusterLock.release")
 

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -61,7 +61,40 @@ def mock_validate_nodegroup(session_mocker):
 
 
 @pytest.fixture()
-def ubuntu_driver(mock_cluster_lock):
+def mock_rust_driver(mocker):
+    rust_driver = mocker.MagicMock()
+    rust_driver.resolve_immutable_fields.side_effect = (
+        lambda cluster_name, labels, variables: variables
+    )
+    mocker.patch(
+        "magnum_cluster_api.driver.magnum_cluster_api.Driver",
+        return_value=rust_driver,
+    )
+    return rust_driver
+
+
+@pytest.fixture()
+def mock_kube_client(mocker):
+    kube_client = mocker.MagicMock()
+    mocker.patch(
+        "magnum_cluster_api.driver.magnum_cluster_api.KubeClient",
+        return_value=kube_client,
+    )
+    return kube_client
+
+
+@pytest.fixture()
+def ubuntu_driver(
+    mock_cluster_lock,
+    mocker,
+    pykube_api,
+    mock_rust_driver,
+    mock_kube_client,
+):
+    mocker.patch(
+        "magnum_cluster_api.driver.clients.get_pykube_api",
+        return_value=pykube_api,
+    )
     yield driver.UbuntuDriver()
 
 

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -361,6 +361,44 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
+    def test_update_cluster_status_handles_missing_capi_conditions(
+        self,
+        context,
+        ubuntu_driver,
+        mocker,
+    ):
+        self.cluster.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        self.cluster.refresh = mocker.MagicMock()
+        capi_cluster = mocker.MagicMock()
+        capi_cluster.obj = {
+            "metadata": {"name": self.cluster.stack_id},
+            "spec": {},
+            "status": {},
+        }
+
+        mocker.patch.object(
+            ubuntu_driver,
+            "update_cluster_control_plane_status",
+            return_value=mocker.Mock(status=fields.ClusterStatus.CREATE_COMPLETE),
+        )
+        mocker.patch.object(ubuntu_driver, "update_nodegroups_status", return_value=[])
+        mocker.patch(
+            "magnum_cluster_api.driver.resources.Cluster"
+        ).return_value.get_or_none.return_value = capi_cluster
+        mocker.patch.object(
+            ubuntu_driver,
+            "_get_cluster_status_reason",
+            return_value="CAPI Cluster status is not ready yet",
+        )
+
+        ubuntu_driver.update_cluster_status(context, self.cluster)
+
+        self.cluster.refresh.assert_called_once()
+        capi_cluster.reload.assert_called_once()
+        assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
+        assert self.cluster.status_reason == "CAPI Cluster status is not ready yet"
+        self.cluster.save.assert_called_once()
+
     def setup_node_group_tests(self, rsps, before, after=None):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -38,6 +38,28 @@ def test_debian_driver_provides():
     ]
 
 
+def test_base_driver_uses_direct_rust_clients(mocker):
+    rust_driver = mocker.MagicMock()
+    kube_client = mocker.MagicMock()
+    mocker.patch("magnum_cluster_api.driver.clients.get_pykube_api")
+    mock_rust_driver_class = mocker.patch(
+        "magnum_cluster_api.driver.magnum_cluster_api.Driver",
+        return_value=rust_driver,
+    )
+    mock_kube_client_class = mocker.patch(
+        "magnum_cluster_api.driver.magnum_cluster_api.KubeClient",
+        return_value=kube_client,
+    )
+
+    ubuntu_driver = driver.UbuntuDriver()
+
+    mock_rust_driver_class.assert_called_once_with("magnum-system")
+    mock_kube_client_class.assert_not_called()
+    assert ubuntu_driver.rust_driver is rust_driver
+    assert ubuntu_driver.kube_client is kube_client
+    mock_kube_client_class.assert_called_once_with()
+
+
 @pytest.mark.parametrize(
     "auto_scaling_enabled", [True, False], ids=lambda x: f"auto_scaling_enabled={x}"
 )

--- a/magnum_cluster_api/tests/unit/test_sync.py
+++ b/magnum_cluster_api/tests/unit/test_sync.py
@@ -14,14 +14,15 @@
 
 from unittest import TestCase, mock
 
+from kubernetes.config.config_exception import ConfigException
 from oslo_utils import uuidutils
 
-from magnum_cluster_api.sync import ClusterLock
+from magnum_cluster_api.sync import ClusterLock, _load_kubernetes_client
 
 
-@mock.patch("kubernetes.config.load_config")
 class ClusterLockTestCase(TestCase):
-    def test_cluster_lock_init_with_no_expire(self, mock_load_config):
+    @mock.patch("magnum_cluster_api.sync._load_kubernetes_client")
+    def test_cluster_lock_init_with_no_expire(self, mock_load_kubernetes_client):
         cluster_id = uuidutils.generate_uuid()
 
         lock = ClusterLock(cluster_id)
@@ -29,8 +30,10 @@ class ClusterLockTestCase(TestCase):
         self.assertEqual(lock.lock_name, "cluster-%s" % cluster_id)
         self.assertEqual(lock.k8s_namespace, "magnum-system")
         self.assertEqual(lock.expire, ClusterLock.DEFAULT_EXPIRE)
+        self.assertIs(lock.client, mock_load_kubernetes_client.return_value)
 
-    def test_cluster_lock_init_with_expire(self, mock_load_config):
+    @mock.patch("magnum_cluster_api.sync._load_kubernetes_client")
+    def test_cluster_lock_init_with_expire(self, mock_load_kubernetes_client):
         cluster_id = uuidutils.generate_uuid()
         expire = 60
 
@@ -39,3 +42,91 @@ class ClusterLockTestCase(TestCase):
         self.assertEqual(lock.lock_name, "cluster-%s" % cluster_id)
         self.assertEqual(lock.k8s_namespace, "magnum-system")
         self.assertEqual(lock.expire, expire)
+        self.assertIs(lock.client, mock_load_kubernetes_client.return_value)
+
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_config")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
+    def test_load_kubernetes_client_uses_incluster_config(
+        self,
+        mock_load_incluster_config,
+        mock_load_config,
+        mock_get_default_copy,
+        mock_api_client,
+        mock_coordination_v1_api,
+    ):
+        configuration = mock.MagicMock()
+        configuration.api_key = {"authorization": "bearer fake-token"}
+        configuration.api_key_prefix = {}
+        configuration.refresh_api_key_hook = None
+        mock_get_default_copy.return_value = configuration
+
+        client = _load_kubernetes_client()
+
+        mock_load_incluster_config.assert_called_once_with()
+        mock_load_config.assert_not_called()
+        mock_api_client.assert_called_once_with(configuration)
+        mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
+        self.assertIs(client, mock_coordination_v1_api.return_value)
+        self.assertEqual(configuration.api_key["authorization"], "fake-token")
+        self.assertEqual(configuration.api_key_prefix["authorization"], "Bearer")
+
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_config")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
+    def test_load_kubernetes_client_falls_back_to_kubeconfig(
+        self,
+        mock_load_incluster_config,
+        mock_load_config,
+        mock_get_default_copy,
+        mock_api_client,
+        mock_coordination_v1_api,
+    ):
+        configuration = mock.MagicMock()
+        configuration.api_key = {}
+        configuration.api_key_prefix = {}
+        configuration.refresh_api_key_hook = None
+        mock_get_default_copy.return_value = configuration
+        mock_load_incluster_config.side_effect = ConfigException("not in a pod")
+
+        client = _load_kubernetes_client()
+
+        mock_load_incluster_config.assert_called_once_with()
+        mock_load_config.assert_called_once_with()
+        mock_api_client.assert_called_once_with(configuration)
+        mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
+        self.assertIs(client, mock_coordination_v1_api.return_value)
+
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
+    def test_load_kubernetes_client_normalizes_refreshed_token(
+        self,
+        mock_load_incluster_config,
+        mock_get_default_copy,
+        mock_api_client,
+        mock_coordination_v1_api,
+    ):
+        configuration = mock.MagicMock()
+        configuration.api_key = {"authorization": "bearer initial-token"}
+        configuration.api_key_prefix = {}
+
+        def refresh_api_key_hook(refreshed_configuration):
+            refreshed_configuration.api_key["authorization"] = "bearer refreshed-token"
+
+        configuration.refresh_api_key_hook = refresh_api_key_hook
+        mock_get_default_copy.return_value = configuration
+
+        _load_kubernetes_client()
+        configuration.refresh_api_key_hook(configuration)
+
+        mock_load_incluster_config.assert_called_once_with()
+        mock_api_client.assert_called_once_with(configuration)
+        mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
+        self.assertEqual(configuration.api_key["authorization"], "refreshed-token")
+        self.assertEqual(configuration.api_key_prefix["authorization"], "Bearer")

--- a/magnum_cluster_api/tests/unit/test_sync.py
+++ b/magnum_cluster_api/tests/unit/test_sync.py
@@ -71,7 +71,9 @@ class ClusterLockTestCase(TestCase):
         mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
         self.assertIs(client, mock_coordination_v1_api.return_value)
         self.assertEqual(configuration.api_key["authorization"], "fake-token")
+        self.assertEqual(configuration.api_key["BearerToken"], "fake-token")
         self.assertEqual(configuration.api_key_prefix["authorization"], "Bearer")
+        self.assertEqual(configuration.api_key_prefix["BearerToken"], "Bearer")
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
@@ -128,5 +130,29 @@ class ClusterLockTestCase(TestCase):
         mock_load_incluster_config.assert_called_once_with()
         mock_api_client.assert_called_once_with(configuration)
         mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
+        self.assertEqual(configuration.api_key["BearerToken"], "refreshed-token")
         self.assertEqual(configuration.api_key["authorization"], "refreshed-token")
+        self.assertEqual(configuration.api_key_prefix["BearerToken"], "Bearer")
         self.assertEqual(configuration.api_key_prefix["authorization"], "Bearer")
+
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
+    def test_load_kubernetes_client_populates_bearer_token_key(
+        self,
+        mock_load_incluster_config,
+        mock_get_default_copy,
+        mock_api_client,
+        mock_coordination_v1_api,
+    ):
+        configuration = mock.MagicMock()
+        configuration.api_key = {"authorization": "bearer fake-token"}
+        configuration.api_key_prefix = {}
+        configuration.refresh_api_key_hook = None
+        mock_get_default_copy.return_value = configuration
+
+        _load_kubernetes_client()
+
+        self.assertEqual(configuration.api_key["BearerToken"], "fake-token")
+        self.assertEqual(configuration.api_key_prefix["BearerToken"], "Bearer")

--- a/magnum_cluster_api/tests/unit/test_sync.py
+++ b/magnum_cluster_api/tests/unit/test_sync.py
@@ -46,7 +46,9 @@ class ClusterLockTestCase(TestCase):
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch(
+        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
+    )
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_config")
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
     def test_load_kubernetes_client_uses_incluster_config(
@@ -77,7 +79,9 @@ class ClusterLockTestCase(TestCase):
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch(
+        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
+    )
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_config")
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
     def test_load_kubernetes_client_falls_back_to_kubeconfig(
@@ -105,7 +109,9 @@ class ClusterLockTestCase(TestCase):
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch(
+        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
+    )
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
     def test_load_kubernetes_client_normalizes_refreshed_token(
         self,
@@ -137,7 +143,9 @@ class ClusterLockTestCase(TestCase):
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy")
+    @mock.patch(
+        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
+    )
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
     def test_load_kubernetes_client_populates_bearer_token_key(
         self,

--- a/magnum_cluster_api/tests/unit/test_sync.py
+++ b/magnum_cluster_api/tests/unit/test_sync.py
@@ -45,122 +45,35 @@ class ClusterLockTestCase(TestCase):
         self.assertIs(lock.client, mock_load_kubernetes_client.return_value)
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch(
-        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
-    )
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_config")
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
     def test_load_kubernetes_client_uses_incluster_config(
         self,
         mock_load_incluster_config,
         mock_load_config,
-        mock_get_default_copy,
-        mock_api_client,
         mock_coordination_v1_api,
     ):
-        configuration = mock.MagicMock()
-        configuration.api_key = {"authorization": "bearer fake-token"}
-        configuration.api_key_prefix = {}
-        configuration.refresh_api_key_hook = None
-        mock_get_default_copy.return_value = configuration
-
         client = _load_kubernetes_client()
 
         mock_load_incluster_config.assert_called_once_with()
         mock_load_config.assert_not_called()
-        mock_api_client.assert_called_once_with(configuration)
-        mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
+        mock_coordination_v1_api.assert_called_once_with()
         self.assertIs(client, mock_coordination_v1_api.return_value)
-        self.assertEqual(configuration.api_key["authorization"], "fake-token")
-        self.assertEqual(configuration.api_key["BearerToken"], "fake-token")
-        self.assertEqual(configuration.api_key_prefix["authorization"], "Bearer")
-        self.assertEqual(configuration.api_key_prefix["BearerToken"], "Bearer")
 
     @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch(
-        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
-    )
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_config")
     @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
     def test_load_kubernetes_client_falls_back_to_kubeconfig(
         self,
         mock_load_incluster_config,
         mock_load_config,
-        mock_get_default_copy,
-        mock_api_client,
         mock_coordination_v1_api,
     ):
-        configuration = mock.MagicMock()
-        configuration.api_key = {}
-        configuration.api_key_prefix = {}
-        configuration.refresh_api_key_hook = None
-        mock_get_default_copy.return_value = configuration
         mock_load_incluster_config.side_effect = ConfigException("not in a pod")
 
         client = _load_kubernetes_client()
 
         mock_load_incluster_config.assert_called_once_with()
         mock_load_config.assert_called_once_with()
-        mock_api_client.assert_called_once_with(configuration)
-        mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
+        mock_coordination_v1_api.assert_called_once_with()
         self.assertIs(client, mock_coordination_v1_api.return_value)
-
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch(
-        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
-    )
-    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
-    def test_load_kubernetes_client_normalizes_refreshed_token(
-        self,
-        mock_load_incluster_config,
-        mock_get_default_copy,
-        mock_api_client,
-        mock_coordination_v1_api,
-    ):
-        configuration = mock.MagicMock()
-        configuration.api_key = {"authorization": "bearer initial-token"}
-        configuration.api_key_prefix = {}
-
-        def refresh_api_key_hook(refreshed_configuration):
-            refreshed_configuration.api_key["authorization"] = "bearer refreshed-token"
-
-        configuration.refresh_api_key_hook = refresh_api_key_hook
-        mock_get_default_copy.return_value = configuration
-
-        _load_kubernetes_client()
-        configuration.refresh_api_key_hook(configuration)
-
-        mock_load_incluster_config.assert_called_once_with()
-        mock_api_client.assert_called_once_with(configuration)
-        mock_coordination_v1_api.assert_called_once_with(mock_api_client.return_value)
-        self.assertEqual(configuration.api_key["BearerToken"], "refreshed-token")
-        self.assertEqual(configuration.api_key["authorization"], "refreshed-token")
-        self.assertEqual(configuration.api_key_prefix["BearerToken"], "Bearer")
-        self.assertEqual(configuration.api_key_prefix["authorization"], "Bearer")
-
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.CoordinationV1Api")
-    @mock.patch("magnum_cluster_api.sync.kubernetes_client.ApiClient")
-    @mock.patch(
-        "magnum_cluster_api.sync.kubernetes_client.Configuration.get_default_copy"
-    )
-    @mock.patch("magnum_cluster_api.sync.kubernetes_config.load_incluster_config")
-    def test_load_kubernetes_client_populates_bearer_token_key(
-        self,
-        mock_load_incluster_config,
-        mock_get_default_copy,
-        mock_api_client,
-        mock_coordination_v1_api,
-    ):
-        configuration = mock.MagicMock()
-        configuration.api_key = {"authorization": "bearer fake-token"}
-        configuration.api_key_prefix = {}
-        configuration.refresh_api_key_hook = None
-        mock_get_default_copy.return_value = configuration
-
-        _load_kubernetes_client()
-
-        self.assertEqual(configuration.api_key["BearerToken"], "fake-token")
-        self.assertEqual(configuration.api_key_prefix["BearerToken"], "Bearer")


### PR DESCRIPTION
## Summary

- load Kubernetes authentication before creating Sherlock cluster locks
- pass an authenticated CoordinationV1 client into Sherlock and normalize bearer tokens for Lease requests
- call the Rust mCAPI Driver and KubeClient directly from Magnum conductor instead of wrapping PyO3 objects with eventlet tpool proxies
- normalize both `authorization` and generated-client `BearerToken` auth keys so Lease calls do not run as `system:anonymous`
- tolerate early CAPI Cluster objects that do not have `status.conditions` yet, so Magnum health/status refresh retries instead of crashing with `KeyError`
- isolate direct Rust/Kubernetes client constructors in unit tests so this PR does not depend on a local kubeconfig or live Kubernetes API

## Validation

- `uv run pytest magnum_cluster_api/tests/unit/test_sync.py magnum_cluster_api/tests/unit/test_driver.py::TestDriver::test_update_cluster_status_handles_missing_capi_conditions 'magnum_cluster_api/tests/unit/test_driver.py::test_base_driver_uses_direct_rust_clients' 'magnum_cluster_api/tests/unit/test_driver.py::TestDriver::test_create_cluster' -q` -> 15 passed, 16 warnings
- `uv run ruff check magnum_cluster_api/sync.py magnum_cluster_api/driver.py magnum_cluster_api/tests/unit/test_sync.py magnum_cluster_api/tests/unit/test_driver.py magnum_cluster_api/tests/conftest.py` -> passed

## Live Replay Notes

The OVN PyTorch BM replay on aio env hit two PR-1055-owned runtime issues after the initial direct-client changes:

- Sherlock Lease requests were still anonymous with the generated Kubernetes client because this client version reads `Configuration.api_key["BearerToken"]` instead of only `authorization`.
- Magnum health refresh saw an early CAPI Cluster object without `status.conditions` and crashed the periodic status path with `KeyError`, leaving stale health even after CAPI became Ready.

Both fixes were validated in the replay image before being moved here.