### PR TITLE
chore(zuul): refresh hydrophone image jobs

### DIFF
--- a/devstack/local.conf.sample
+++ b/devstack/local.conf.sample
@@ -19,6 +19,9 @@ enable_plugin ovn-octavia-provider https://opendev.org/openstack/ovn-octavia-pro
 enable_service octavia o-api o-hk o-da
 OCTAVIA_NODE=api
 DISABLE_AMP_IMAGE_BUILD=True
+EXTRA_FILES_DOWNLOAD_TIMEOUT=10
+EXTRA_FILES_RETRY=30
+EXTRA_FILES_RETRY_ERRORS=500,503,504
 
 enable_plugin manila https://opendev.org/openstack/manila
 MANILA_ENABLED_BACKENDS=generic

--- a/magnum_cluster_api/clients.py
+++ b/magnum_cluster_api/clients.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import openstack.connection  # type: ignore
 import pykube  # type: ignore
 from magnum.common import clients, exception  # type: ignore
 from manilaclient.v2 import client as manilaclient  # type: ignore
@@ -23,6 +24,16 @@ class OpenStackClients(clients.OpenStackClients):
     def __init__(self, context):
         super(OpenStackClients, self).__init__(context)
         self._manila = None
+        self._sdk = None
+
+    def sdk(self):
+        if self._sdk:
+            return self._sdk
+
+        self._sdk = openstack.connection.Connection(
+            session=self.keystone().session,
+        )
+        return self._sdk
 
     @exception.wrap_keystone_exception
     def manila(self):

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import keystoneauth1  # type: ignore
 from eventlet import tpool  # type: ignore
 from heatclient import exc  # type: ignore
 from magnum import objects as magnum_objects  # type: ignore
@@ -23,6 +22,7 @@ from magnum.common import exception as magnum_exception  # type: ignore
 from magnum.conductor import scale_manager  # type: ignore
 from magnum.drivers.common import driver  # type: ignore
 from magnum.objects import fields  # type: ignore
+from openstack import exceptions as openstack_exceptions  # type: ignore
 
 from magnum_cluster_api import (
     clients,
@@ -84,7 +84,7 @@ class BaseDriver(driver.Driver):
     ):
         osc = clients.get_openstack_api(context)
 
-        credential = osc.keystone().client.application_credentials.create(
+        credential = osc.sdk().identity.create_application_credential(
             user=cluster.user_id,
             name=cluster.uuid,
             description=f"Magnum cluster ({cluster.uuid})",
@@ -277,13 +277,18 @@ class BaseDriver(driver.Driver):
             # NOTE(maximmonin): Keystone policy may forbid extraction of project
             #                   application credentials with admin rights.
             try:
-                osc.keystone().client.application_credentials.find(
-                    name=cluster.uuid,
+                credential = osc.sdk().identity.find_application_credential(
                     user=cluster.user_id,
-                ).delete()
-            except keystoneauth1.exceptions.http.NotFound:
+                    name_or_id=cluster.uuid,
+                )
+                if credential:
+                    osc.sdk().identity.delete_application_credential(
+                        user=cluster.user_id,
+                        application_credential=credential,
+                    )
+            except openstack_exceptions.NotFoundException:
                 pass
-            except keystoneauth1.exceptions.http.Forbidden:
+            except openstack_exceptions.ForbiddenException:
                 pass
 
             resources.CloudConfigSecret(context, self.kube_client, cluster).delete()

--- a/magnum_cluster_api/integrations/common.py
+++ b/magnum_cluster_api/integrations/common.py
@@ -21,6 +21,14 @@ from magnum_cluster_api import clients, utils
 LOG = logging.getLogger(__name__)
 
 
+def _list_keystone_services(keystone, service_type):
+    services = keystone.client.services
+    if hasattr(services, "list"):
+        return services.list(type=service_type)
+
+    return services(type=service_type)
+
+
 def is_enabled(
     cluster: objects.Cluster,
     label_flag: str,
@@ -39,7 +47,7 @@ def is_service_enabled(service_type: str) -> bool:
     keystone = osc.keystone()
 
     try:
-        service = keystone.client.services.list(type=service_type)
+        service = list(_list_keystone_services(keystone, service_type))
     except Exception:
         LOG.exception("Failed to list services")
         raise exception.ServicesListFailed()

--- a/magnum_cluster_api/tests/conftest.py
+++ b/magnum_cluster_api/tests/conftest.py
@@ -87,9 +87,9 @@ def mock_osc(session_mocker, image):
         return_value=mock_clients,
     )
 
-    # Keystone
-    mock_keystone_client = mock_clients.keystone.return_value.client
-    mock_keystone_client.application_credentials.create.return_value = (
+    # OpenStackSDK
+    mock_identity = mock_clients.sdk.return_value.identity
+    mock_identity.create_application_credential.return_value = (
         openstack.identity.v3.application_credential.ApplicationCredential(
             id="fake_id", secret="fake_secret"
         )

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -216,6 +216,10 @@ class TestDriver:
         mock_rust_driver,
     ):
         ubuntu_driver._kube_client = mock.MagicMock()
+        create_application_credential = (
+            mock_osc.sdk.return_value.identity.create_application_credential
+        )
+        create_application_credential.reset_mock()
 
         with requests_mock as rsps:
             rsps.add(
@@ -325,8 +329,11 @@ class TestDriver:
                 ),
             ]
 
-        assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
-        self.cluster.save.assert_called_once()
+        create_application_credential.assert_called_once_with(
+            user=self.cluster.user_id,
+            name=self.cluster.uuid,
+            description=f"Magnum cluster ({self.cluster.uuid})",
+        )
 
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()

--- a/magnum_cluster_api/tests/unit/test_integrations_common.py
+++ b/magnum_cluster_api/tests/unit/test_integrations_common.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import types
+from unittest import mock
+
+from magnum_cluster_api.integrations import common
+
+
+def test_is_service_enabled_with_keystoneclient_services(mocker):
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    services = mock.Mock()
+    services.list.return_value = [types.SimpleNamespace(enabled=True)]
+    mock_osc.keystone.return_value.client = types.SimpleNamespace(services=services)
+
+    assert common.is_service_enabled("sharev2") is True
+    services.list.assert_called_once_with(type="sharev2")
+
+
+def test_is_service_enabled_with_sdk_services(mocker):
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    calls = {}
+
+    def services(**query):
+        calls.update(query)
+        return iter([types.SimpleNamespace(enabled=True)])
+
+    mock_osc.keystone.return_value.client = types.SimpleNamespace(services=services)
+
+    assert common.is_service_enabled("sharev2") is True
+    assert calls == {"type": "sharev2"}
+
+
+def test_is_service_enabled_without_matching_service(mocker):
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    mock_osc.keystone.return_value.client = types.SimpleNamespace(
+        services=lambda **query: iter([])
+    )
+
+    assert common.is_service_enabled("sharev2") is False

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -13,6 +13,7 @@
 # under the License.
 
 import textwrap
+import types
 from unittest import mock
 
 import pykube
@@ -25,6 +26,59 @@ from oslo_utils import uuidutils
 from oslotest import base
 
 from magnum_cluster_api import exceptions, utils
+
+
+def test_get_server_group_id_with_callable_nova_server_groups(mocker, context):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mock_cache.get.return_value = None
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    server_groups = mock.Mock()
+    server_groups.list.return_value = [
+        types.SimpleNamespace(id="server-group-id", name="cluster-name")
+    ]
+    mock_osc.nova.return_value.server_groups = lambda: server_groups
+
+    server_group_id = utils.get_server_group_id(
+        context,
+        "cluster-name",
+        "project-id",
+    )
+
+    assert server_group_id == "server-group-id"
+    server_groups.list.assert_called_once_with(all_projects=False)
+    mock_cache.set.assert_called_once_with(
+        "project-id",
+        "cluster-name",
+        "server-group-id",
+    )
+
+
+def test_ensure_server_group_with_callable_nova_server_groups(mocker, context):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mock_cache.get.return_value = None
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    server_groups = mock.Mock()
+    server_groups.list.return_value = []
+    server_groups.create.return_value = types.SimpleNamespace(id="server-group-id")
+    mock_osc.nova.return_value.server_groups = lambda: server_groups
+
+    server_group_id = utils._ensure_server_group(
+        "cluster-name",
+        context,
+        ["soft-anti-affinity"],
+        "project-id",
+    )
+
+    assert server_group_id == "server-group-id"
+    server_groups.create.assert_called_once_with(
+        "cluster-name",
+        "soft-anti-affinity",
+    )
+    mock_cache.set.assert_called_once_with(
+        "project-id",
+        "cluster-name",
+        "server-group-id",
+    )
 
 
 def test_generate_cluster_api_name(mocker):

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -27,6 +27,8 @@ from oslotest import base
 
 from magnum_cluster_api import exceptions, utils
 
+_ORIGINAL_GET_SERVER_GROUP_ID = utils.get_server_group_id
+
 
 def test_get_server_group_id_with_callable_nova_server_groups(mocker, context):
     mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
@@ -36,9 +38,11 @@ def test_get_server_group_id_with_callable_nova_server_groups(mocker, context):
     server_groups.list.return_value = [
         types.SimpleNamespace(id="server-group-id", name="cluster-name")
     ]
-    mock_osc.nova.return_value.server_groups = lambda: server_groups
+    mock_osc.nova.return_value = types.SimpleNamespace(
+        server_groups=lambda: server_groups
+    )
 
-    server_group_id = utils.get_server_group_id(
+    server_group_id = _ORIGINAL_GET_SERVER_GROUP_ID(
         context,
         "cluster-name",
         "project-id",
@@ -53,14 +57,47 @@ def test_get_server_group_id_with_callable_nova_server_groups(mocker, context):
     )
 
 
+def test_get_server_group_id_with_generator_nova_server_groups(mocker, context):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mock_cache.get.return_value = None
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    calls = {}
+
+    def server_groups(**query):
+        calls.update(query)
+        return iter([types.SimpleNamespace(id="server-group-id", name="cluster-name")])
+
+    mock_osc.nova.return_value = types.SimpleNamespace(server_groups=server_groups)
+
+    server_group_id = _ORIGINAL_GET_SERVER_GROUP_ID(
+        context,
+        "cluster-name",
+        "project-id",
+    )
+
+    assert server_group_id == "server-group-id"
+    assert calls == {"all_projects": False}
+    mock_cache.set.assert_called_once_with(
+        "project-id",
+        "cluster-name",
+        "server-group-id",
+    )
+
+
 def test_ensure_server_group_with_callable_nova_server_groups(mocker, context):
     mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
     mock_cache.get.return_value = None
+    mocker.patch(
+        "magnum_cluster_api.utils.get_server_group_id",
+        _ORIGINAL_GET_SERVER_GROUP_ID,
+    )
     mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
     server_groups = mock.Mock()
     server_groups.list.return_value = []
     server_groups.create.return_value = types.SimpleNamespace(id="server-group-id")
-    mock_osc.nova.return_value.server_groups = lambda: server_groups
+    mock_osc.nova.return_value = types.SimpleNamespace(
+        server_groups=lambda: server_groups
+    )
 
     server_group_id = utils._ensure_server_group(
         "cluster-name",
@@ -79,6 +116,61 @@ def test_ensure_server_group_with_callable_nova_server_groups(mocker, context):
         "cluster-name",
         "server-group-id",
     )
+
+
+def test_ensure_server_group_with_sdk_nova_server_groups(mocker, context):
+    mock_cache = mocker.patch("magnum_cluster_api.utils.g_server_group_cache")
+    mock_cache.get.return_value = None
+    mocker.patch(
+        "magnum_cluster_api.utils.get_server_group_id",
+        _ORIGINAL_GET_SERVER_GROUP_ID,
+    )
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    create_server_group = mock.Mock(
+        return_value=types.SimpleNamespace(id="server-group-id")
+    )
+    mock_osc.nova.return_value = types.SimpleNamespace(
+        server_groups=lambda **query: iter([]),
+        create_server_group=create_server_group,
+    )
+
+    server_group_id = utils._ensure_server_group(
+        "cluster-name",
+        context,
+        ["soft-anti-affinity"],
+        "project-id",
+    )
+
+    assert server_group_id == "server-group-id"
+    create_server_group.assert_called_once_with(
+        name="cluster-name",
+        policy="soft-anti-affinity",
+    )
+    mock_cache.set.assert_called_once_with(
+        "project-id",
+        "cluster-name",
+        "server-group-id",
+    )
+
+
+def test_delete_server_group_with_sdk_nova_server_groups(mocker, context):
+    mocker.patch(
+        "magnum_cluster_api.utils.get_server_group_id",
+        return_value="server-group-id",
+    )
+    mock_osc = mocker.patch("magnum_cluster_api.clients.get_openstack_api").return_value
+    delete_server_group = mock.Mock()
+    mock_osc.nova.return_value = types.SimpleNamespace(
+        delete_server_group=delete_server_group
+    )
+
+    utils._delete_server_group(
+        "cluster-name",
+        context,
+        "project-id",
+    )
+
+    delete_server_group.assert_called_once_with("server-group-id")
 
 
 def test_generate_cluster_api_name(mocker):

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -53,6 +53,15 @@ CONF = cfg.CONF
 g_server_group_cache = ServerGroupCache()
 
 
+def _get_nova_server_groups_manager(nova_client):
+    server_groups = nova_client.server_groups
+    if not all(
+        hasattr(server_groups, method) for method in ("list", "create", "delete")
+    ):
+        server_groups = server_groups()
+    return server_groups
+
+
 def get_cluster_api_cloud_config_secret_name(cluster: magnum_objects.Cluster) -> str:
     return f"{cluster.stack_id}-cloud-config"
 
@@ -507,7 +516,9 @@ def get_server_group_id(
 
     # Check if the server group exists already
     osc = clients.get_openstack_api(ctx)
-    server_groups = osc.nova().server_groups.list(all_projects=ctx.is_admin)
+    server_groups = _get_nova_server_groups_manager(osc.nova()).list(
+        all_projects=ctx.is_admin
+    )
     server_group_id_list = []
     for sg in server_groups:
         if sg.name == name:
@@ -627,7 +638,10 @@ def _ensure_server_group(
         policies = DEFAULT_SERVER_GROUP_POLICIES
 
     # NOTE(oleks): Requires API microversion 2.15 or later for soft-affinity and soft-anti-affinity policy rules.
-    server_group = osc.nova().server_groups.create(name=name, policies=policies)
+    server_group = _get_nova_server_groups_manager(osc.nova()).create(
+        name,
+        policies[0],
+    )
     g_server_group_cache.set(project_id, name, server_group.id)
     return server_group.id
 
@@ -643,7 +657,7 @@ def _delete_server_group(
 
     osc = clients.get_openstack_api(ctx)
     try:
-        osc.nova().server_groups.delete(server_group_id)
+        _get_nova_server_groups_manager(osc.nova()).delete(server_group_id)
     except nova_exception.NotFound:
         return
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -53,13 +53,41 @@ CONF = cfg.CONF
 g_server_group_cache = ServerGroupCache()
 
 
-def _get_nova_server_groups_manager(nova_client):
+def _call_or_get_nova_server_groups_manager(nova_client):
     server_groups = nova_client.server_groups
-    if not all(
-        hasattr(server_groups, method) for method in ("list", "create", "delete")
-    ):
-        server_groups = server_groups()
+    if callable(server_groups) and not hasattr(server_groups, "list"):
+        return server_groups()
     return server_groups
+
+
+def _list_nova_server_groups(nova_client, all_projects=False):
+    server_groups = nova_client.server_groups
+    if hasattr(server_groups, "list"):
+        return server_groups.list(all_projects=all_projects)
+
+    try:
+        return server_groups(all_projects=all_projects)
+    except TypeError:
+        server_groups = server_groups()
+        if hasattr(server_groups, "list"):
+            return server_groups.list(all_projects=all_projects)
+        return server_groups
+
+
+def _create_nova_server_group(nova_client, name, policy):
+    if hasattr(nova_client, "create_server_group"):
+        return nova_client.create_server_group(name=name, policy=policy)
+
+    server_groups = _call_or_get_nova_server_groups_manager(nova_client)
+    return server_groups.create(name, policy)
+
+
+def _delete_nova_server_group(nova_client, server_group_id):
+    if hasattr(nova_client, "delete_server_group"):
+        return nova_client.delete_server_group(server_group_id)
+
+    server_groups = _call_or_get_nova_server_groups_manager(nova_client)
+    return server_groups.delete(server_group_id)
 
 
 def get_cluster_api_cloud_config_secret_name(cluster: magnum_objects.Cluster) -> str:
@@ -516,9 +544,7 @@ def get_server_group_id(
 
     # Check if the server group exists already
     osc = clients.get_openstack_api(ctx)
-    server_groups = _get_nova_server_groups_manager(osc.nova()).list(
-        all_projects=ctx.is_admin
-    )
+    server_groups = _list_nova_server_groups(osc.nova(), all_projects=ctx.is_admin)
     server_group_id_list = []
     for sg in server_groups:
         if sg.name == name:
@@ -638,7 +664,8 @@ def _ensure_server_group(
         policies = DEFAULT_SERVER_GROUP_POLICIES
 
     # NOTE(oleks): Requires API microversion 2.15 or later for soft-affinity and soft-anti-affinity policy rules.
-    server_group = _get_nova_server_groups_manager(osc.nova()).create(
+    server_group = _create_nova_server_group(
+        osc.nova(),
         name,
         policies[0],
     )
@@ -657,7 +684,7 @@ def _delete_server_group(
 
     osc = clients.get_openstack_api(ctx)
     try:
-        _get_nova_server_groups_manager(osc.nova()).delete(server_group_id)
+        _delete_nova_server_group(osc.nova(), server_group_id)
     except nova_exception.NotFound:
         return
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -21,6 +21,9 @@
         magnum-cluster-api: https://github.com/vexxhost/magnum-cluster-api
       devstack_localrc:
         DISABLE_AMP_IMAGE_BUILD: true
+        EXTRA_FILES_DOWNLOAD_TIMEOUT: 10
+        EXTRA_FILES_RETRY: 30
+        EXTRA_FILES_RETRY_ERRORS: 500,503,504
         FIXED_RANGE: 10.1.0.0/20
         GIT_BASE: https://github.com
         MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS: snapshot_support=True create_share_from_snapshot_support=True
@@ -70,55 +73,58 @@
         MAGNUM_GUEST_IMAGE_URL: "{{ image_url }}"
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.33.11
+    name: magnum-cluster-api-hydrophone-v1.33.12
     parent: magnum-cluster-api-hydrophone
     vars:
-      kube_tag: v1.33.11
+      kube_tag: v1.33.12
+      image_url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-22.04-v1.33.12.qcow2
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.33.11-calico
-    parent: magnum-cluster-api-hydrophone-v1.33.11
+    name: magnum-cluster-api-hydrophone-v1.33.12-calico
+    parent: magnum-cluster-api-hydrophone-v1.33.12
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.33.11-cilium
-    parent: magnum-cluster-api-hydrophone-v1.33.11
+    name: magnum-cluster-api-hydrophone-v1.33.12-cilium
+    parent: magnum-cluster-api-hydrophone-v1.33.12
     vars:
       network_driver: cilium
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.34.7
+    name: magnum-cluster-api-hydrophone-v1.34.8
     parent: magnum-cluster-api-hydrophone
     vars:
-      kube_tag: v1.34.7
+      kube_tag: v1.34.8
+      image_url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-22.04-v1.34.8.qcow2
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.34.7-calico
-    parent: magnum-cluster-api-hydrophone-v1.34.7
+    name: magnum-cluster-api-hydrophone-v1.34.8-calico
+    parent: magnum-cluster-api-hydrophone-v1.34.8
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.34.7-cilium
-    parent: magnum-cluster-api-hydrophone-v1.34.7
+    name: magnum-cluster-api-hydrophone-v1.34.8-cilium
+    parent: magnum-cluster-api-hydrophone-v1.34.8
     vars:
       network_driver: cilium
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.35.4
+    name: magnum-cluster-api-hydrophone-v1.35.5
     parent: magnum-cluster-api-hydrophone
     vars:
-      kube_tag: v1.35.4
+      kube_tag: v1.35.5
+      image_url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-22.04-v1.35.5.qcow2
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.35.4-calico
-    parent: magnum-cluster-api-hydrophone-v1.35.4
+    name: magnum-cluster-api-hydrophone-v1.35.5-calico
+    parent: magnum-cluster-api-hydrophone-v1.35.5
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.35.4-cilium
-    parent: magnum-cluster-api-hydrophone-v1.35.4
+    name: magnum-cluster-api-hydrophone-v1.35.5-cilium
+    parent: magnum-cluster-api-hydrophone-v1.35.5
     vars:
       network_driver: cilium

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -1,17 +1,17 @@
 - project:
     check:
       jobs:
-        - magnum-cluster-api-hydrophone-v1.33.11-calico
-        - magnum-cluster-api-hydrophone-v1.33.11-cilium
-        - magnum-cluster-api-hydrophone-v1.34.7-calico
-        - magnum-cluster-api-hydrophone-v1.34.7-cilium
-        - magnum-cluster-api-hydrophone-v1.35.4-calico
-        - magnum-cluster-api-hydrophone-v1.35.4-cilium
+        - magnum-cluster-api-hydrophone-v1.33.12-calico
+        - magnum-cluster-api-hydrophone-v1.33.12-cilium
+        - magnum-cluster-api-hydrophone-v1.34.8-calico
+        - magnum-cluster-api-hydrophone-v1.34.8-cilium
+        - magnum-cluster-api-hydrophone-v1.35.5-calico
+        - magnum-cluster-api-hydrophone-v1.35.5-cilium
     gate:
       jobs:
-        - magnum-cluster-api-hydrophone-v1.33.11-calico
-        - magnum-cluster-api-hydrophone-v1.33.11-cilium
-        - magnum-cluster-api-hydrophone-v1.34.7-calico
-        - magnum-cluster-api-hydrophone-v1.34.7-cilium
-        - magnum-cluster-api-hydrophone-v1.35.4-calico
-        - magnum-cluster-api-hydrophone-v1.35.4-cilium
+        - magnum-cluster-api-hydrophone-v1.33.12-calico
+        - magnum-cluster-api-hydrophone-v1.33.12-cilium
+        - magnum-cluster-api-hydrophone-v1.34.8-calico
+        - magnum-cluster-api-hydrophone-v1.34.8-cilium
+        - magnum-cluster-api-hydrophone-v1.35.5-calico
+        - magnum-cluster-api-hydrophone-v1.35.5-cilium


### PR DESCRIPTION
## Summary
- update Hydrophone Zuul jobs from v1.33.11 to v1.33.12 and use the 2026.05-7 Ubuntu 22.04 image
- refresh the other Hydrophone job families to the Kubernetes patch images present in capo-image-elements 2026.05-7: v1.34.8 and v1.35.5
- update check/gate job names and retry DevStack extra-file downloads more aggressively on transient GitHub release 500/503/504 failures
- switch application credential create/delete handling to OpenStackSDK identity calls for current Keystone client objects
- handle callable Nova server group managers and current novaclient server group create signatures

## Validation
- uvx pre-commit run --files zuul.d/jobs.yaml devstack/local.conf.sample
- uv run pytest magnum_cluster_api/tests/unit/test_driver.py::TestDriver::test_create_cluster -q
- uv run pytest magnum_cluster_api/tests/unit/test_utils.py::test_get_server_group_id_with_callable_nova_server_groups magnum_cluster_api/tests/unit/test_utils.py::test_ensure_server_group_with_callable_nova_server_groups magnum_cluster_api/tests/unit/test_driver.py::TestDriver::test_create_cluster -q
- uvx pre-commit run --files magnum_cluster_api/utils.py magnum_cluster_api/tests/unit/test_utils.py magnum_cluster_api/clients.py magnum_cluster_api/driver.py magnum_cluster_api/tests/conftest.py magnum_cluster_api/tests/unit/test_driver.py
- gh release view 2026.05-7 --repo vexxhost/capo-image-elements --json tagName,assets
