### PR TITLE
fix: use string values for bool-ish cluster labels

### DIFF
--- a/src/addons/cinder_csi.rs
+++ b/src/addons/cinder_csi.rs
@@ -201,7 +201,7 @@ impl ClusterAddon for Addon {
     }
 
     fn enabled(&self) -> bool {
-        self.cluster.labels.cinder_csi_enabled
+        self.cluster.labels.cinder_csi_enabled.eq_ignore_ascii_case("true")
     }
 
     fn secret_name(&self) -> Result<String, ClusterError> {

--- a/src/addons/manila_csi.rs
+++ b/src/addons/manila_csi.rs
@@ -129,7 +129,7 @@ impl ClusterAddon for Addon {
     }
 
     fn enabled(&self) -> bool {
-        self.cluster.labels.manila_csi_enabled
+        self.cluster.labels.manila_csi_enabled.eq_ignore_ascii_case("true")
     }
 
     fn secret_name(&self) -> Result<String, ClusterError> {

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -43,9 +43,9 @@ pub struct ClusterLabels {
     pub cilium_hubble_ui_enabled: String,
 
     /// Enable the use of the Cinder CSI driver for the cluster.
-    #[builder(default = true)]
-    #[pyo3(default = true)]
-    pub cinder_csi_enabled: bool,
+    #[builder(default="true".to_owned())]
+    #[pyo3(default="true".to_owned())]
+    pub cinder_csi_enabled: String,
 
     /// The tag of the Cinder CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
@@ -53,9 +53,9 @@ pub struct ClusterLabels {
     pub cinder_csi_plugin_tag: String,
 
     /// Enable the use of the Manila CSI driver for the cluster.
-    #[builder(default = true)]
-    #[pyo3(default = true)]
-    pub manila_csi_enabled: bool,
+    #[builder(default="true".to_owned())]
+    #[pyo3(default="true".to_owned())]
+    pub manila_csi_enabled: String,
 
     /// The tag of the Manila CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]


### PR DESCRIPTION
The OpenStack OpenTofu/Terraform provider (and I suspect other OpenStack
clients) expects that all OpenStack labels are strings and submits them
as such (e.g. see the code comment for `cilium_hubble_ui_enabled`).
Using `bool` for some labels causes issues with clients and internally
after a cluster or template has already been created with bad values.

Change `cinder_csi_enabled` and `manila_csi_enabled` struct fields to
`String`.

fixes #1063
