### PR TITLE
chore(zuul): bump hydrophone Kubernetes versions

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -70,55 +70,73 @@
         MAGNUM_GUEST_IMAGE_URL: "{{ image_url }}"
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.33.11
+    name: magnum-cluster-api-hydrophone-v1.33.12
     parent: magnum-cluster-api-hydrophone
     vars:
-      kube_tag: v1.33.11
+      kube_tag: v1.33.12
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.33.11-calico
-    parent: magnum-cluster-api-hydrophone-v1.33.11
+    name: magnum-cluster-api-hydrophone-v1.33.12-calico
+    parent: magnum-cluster-api-hydrophone-v1.33.12
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.33.11-cilium
-    parent: magnum-cluster-api-hydrophone-v1.33.11
+    name: magnum-cluster-api-hydrophone-v1.33.12-cilium
+    parent: magnum-cluster-api-hydrophone-v1.33.12
     vars:
       network_driver: cilium
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.34.7
+    name: magnum-cluster-api-hydrophone-v1.34.8
     parent: magnum-cluster-api-hydrophone
     vars:
-      kube_tag: v1.34.7
+      kube_tag: v1.34.8
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.34.7-calico
-    parent: magnum-cluster-api-hydrophone-v1.34.7
+    name: magnum-cluster-api-hydrophone-v1.34.8-calico
+    parent: magnum-cluster-api-hydrophone-v1.34.8
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.34.7-cilium
-    parent: magnum-cluster-api-hydrophone-v1.34.7
+    name: magnum-cluster-api-hydrophone-v1.34.8-cilium
+    parent: magnum-cluster-api-hydrophone-v1.34.8
     vars:
       network_driver: cilium
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.35.4
+    name: magnum-cluster-api-hydrophone-v1.35.5
     parent: magnum-cluster-api-hydrophone
     vars:
-      kube_tag: v1.35.4
+      kube_tag: v1.35.5
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.35.4-calico
-    parent: magnum-cluster-api-hydrophone-v1.35.4
+    name: magnum-cluster-api-hydrophone-v1.35.5-calico
+    parent: magnum-cluster-api-hydrophone-v1.35.5
     vars:
       network_driver: calico
 
 - job:
-    name: magnum-cluster-api-hydrophone-v1.35.4-cilium
-    parent: magnum-cluster-api-hydrophone-v1.35.4
+    name: magnum-cluster-api-hydrophone-v1.35.5-cilium
+    parent: magnum-cluster-api-hydrophone-v1.35.5
+    vars:
+      network_driver: cilium
+
+- job:
+    name: magnum-cluster-api-hydrophone-v1.36.1
+    parent: magnum-cluster-api-hydrophone
+    vars:
+      kube_tag: v1.36.1
+
+- job:
+    name: magnum-cluster-api-hydrophone-v1.36.1-calico
+    parent: magnum-cluster-api-hydrophone-v1.36.1
+    vars:
+      network_driver: calico
+
+- job:
+    name: magnum-cluster-api-hydrophone-v1.36.1-cilium
+    parent: magnum-cluster-api-hydrophone-v1.36.1
     vars:
       network_driver: cilium

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -1,17 +1,21 @@
 - project:
     check:
       jobs:
-        - magnum-cluster-api-hydrophone-v1.33.11-calico
-        - magnum-cluster-api-hydrophone-v1.33.11-cilium
-        - magnum-cluster-api-hydrophone-v1.34.7-calico
-        - magnum-cluster-api-hydrophone-v1.34.7-cilium
-        - magnum-cluster-api-hydrophone-v1.35.4-calico
-        - magnum-cluster-api-hydrophone-v1.35.4-cilium
+        - magnum-cluster-api-hydrophone-v1.33.12-calico
+        - magnum-cluster-api-hydrophone-v1.33.12-cilium
+        - magnum-cluster-api-hydrophone-v1.34.8-calico
+        - magnum-cluster-api-hydrophone-v1.34.8-cilium
+        - magnum-cluster-api-hydrophone-v1.35.5-calico
+        - magnum-cluster-api-hydrophone-v1.35.5-cilium
+        - magnum-cluster-api-hydrophone-v1.36.1-calico
+        - magnum-cluster-api-hydrophone-v1.36.1-cilium
     gate:
       jobs:
-        - magnum-cluster-api-hydrophone-v1.33.11-calico
-        - magnum-cluster-api-hydrophone-v1.33.11-cilium
-        - magnum-cluster-api-hydrophone-v1.34.7-calico
-        - magnum-cluster-api-hydrophone-v1.34.7-cilium
-        - magnum-cluster-api-hydrophone-v1.35.4-calico
-        - magnum-cluster-api-hydrophone-v1.35.4-cilium
+        - magnum-cluster-api-hydrophone-v1.33.12-calico
+        - magnum-cluster-api-hydrophone-v1.33.12-cilium
+        - magnum-cluster-api-hydrophone-v1.34.8-calico
+        - magnum-cluster-api-hydrophone-v1.34.8-cilium
+        - magnum-cluster-api-hydrophone-v1.35.5-calico
+        - magnum-cluster-api-hydrophone-v1.35.5-cilium
+        - magnum-cluster-api-hydrophone-v1.36.1-calico
+        - magnum-cluster-api-hydrophone-v1.36.1-cilium


### PR DESCRIPTION
## Summary
- bump Hydrophone Zuul jobs to Kubernetes v1.33.12, v1.34.8, and v1.35.5
- add the v1.36.1 Hydrophone calico/cilium jobs to check and gate

## Testing
- uvx --python 3.12 pre-commit run --all-files