### PR TITLE
fix: handle mCAPI status and label edge cases

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -219,7 +219,8 @@ class BaseDriver(driver.Driver):
 
             capi_cluster.reload()
             status_map = {
-                c["type"]: c["status"] for c in capi_cluster.obj["status"]["conditions"]
+                c["type"]: c["status"]
+                for c in capi_cluster.obj.get("status", {}).get("conditions", [])
             }
 
             for condition in ("ControlPlaneReady", "InfrastructureReady", "Ready"):

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -453,6 +453,8 @@ class BaseDriver(driver.Driver):
         """
         if cluster.stack_id is None:
             return
+        self._merge_cluster_template_labels(cluster)
+
         # NOTE(mnaser): This should be removed when this is fixed:
         #
         #               https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/842

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -58,8 +58,14 @@ class BaseDriver(driver.Driver):
 
     @staticmethod
     def _merge_cluster_template_labels(cluster: magnum_objects.Cluster) -> None:
-        for key, value in cluster.cluster_template.labels.items():
-            cluster.labels.setdefault(key, value)
+        label_sources = [
+            getattr(cluster, "labels_skipped", {}) or {},
+            getattr(getattr(cluster, "cluster_template", None), "labels", {}) or {},
+        ]
+
+        for labels in label_sources:
+            for key, value in labels.items():
+                cluster.labels.setdefault(key, value)
 
     def create_cluster(
         self, context, cluster: magnum_objects.Cluster, cluster_create_timeout: int

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -56,6 +56,11 @@ class BaseDriver(driver.Driver):
             self._kube_client = tpool.Proxy(magnum_cluster_api.KubeClient())
         return self._kube_client
 
+    @staticmethod
+    def _merge_cluster_template_labels(cluster: magnum_objects.Cluster) -> None:
+        for key, value in cluster.cluster_template.labels.items():
+            cluster.labels.setdefault(key, value)
+
     def create_cluster(
         self, context, cluster: magnum_objects.Cluster, cluster_create_timeout: int
     ):
@@ -70,6 +75,7 @@ class BaseDriver(driver.Driver):
         cluster.stack_id = utils.generate_cluster_api_name(self.k8s_api)
         cluster.save()
 
+        self._merge_cluster_template_labels(cluster)
         self.rust_driver.create_cluster(cluster)
 
         utils.validate_cluster(context, cluster)

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -403,6 +403,65 @@ class TestDriver:
 
             ubuntu_driver.create_nodegroup(context, self.cluster, self.node_group)
 
+    def test_update_cluster_status_without_capi_conditions(
+        self,
+        context,
+        ubuntu_driver,
+        requests_mock,
+        mock_openstack_connection,
+        mock_rust_driver,
+        mocker,
+    ):
+        self.cluster.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        self.cluster.refresh = mocker.MagicMock()
+        ubuntu_driver._kube_client = mocker.MagicMock()
+        get_status_reason = mocker.patch.object(
+            ubuntu_driver,
+            "_get_cluster_status_reason",
+            return_value="Cluster conditions are not available yet",
+        )
+        mocker.patch.object(
+            ubuntu_driver,
+            "update_cluster_control_plane_status",
+            return_value=mocker.MagicMock(
+                status=fields.ClusterStatus.CREATE_IN_PROGRESS
+            ),
+        )
+        mocker.patch.object(ubuntu_driver, "update_nodegroups_status", return_value=[])
+
+        with requests_mock as rsps:
+            rsps.add(
+                responses.GET,
+                re.compile(
+                    f"http://localhost/apis/{objects.Cluster.version}/namespaces/magnum-system/{objects.Cluster.endpoint}/\\w+"  # noqa
+                ),
+                json={
+                    "metadata": {
+                        "name": self.cluster.stack_id,
+                        "namespace": "magnum-system",
+                    },
+                    "spec": {
+                        "topology": {
+                            "version": "v1.34.3",
+                        },
+                        "controlPlaneEndpoint": {
+                            "host": "192.0.2.10",
+                            "port": 6443,
+                        },
+                    },
+                    "status": {
+                        "phase": "Provisioned",
+                    },
+                },
+            )
+
+            ubuntu_driver.update_cluster_status(context, self.cluster)
+
+        assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
+        assert self.cluster.status_reason == "Cluster conditions are not available yet"
+        get_status_reason.assert_called_once()
+        self.cluster.save.assert_called_once()
+
     def test_update_nodegroup(self, context, ubuntu_driver, requests_mock):
         with requests_mock as rsps:
             self.setup_node_group_tests(

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -393,6 +393,12 @@ class TestDriver:
         ubuntu_driver.rust_driver = mock.MagicMock()
         self.cluster.stack_id = "kube-test"
         self.cluster.labels = {"audit_log_enabled": "true"}
+        self.cluster.labels_skipped = {
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "ovn",
+        }
+        self.cluster.cluster_template.labels = {}
 
         delete_loadbalancers = mocker.patch(
             "magnum_cluster_api.utils.delete_loadbalancers"
@@ -406,7 +412,9 @@ class TestDriver:
 
         assert self.cluster.labels == {
             "audit_log_enabled": "true",
-            "kube_tag": self.cluster.cluster_template.labels["kube_tag"],
+            "fixed_subnet_cidr": "192.168.24.0/24",
+            "kube_tag": "v1.34.3",
+            "octavia_provider": "ovn",
         }
         delete_loadbalancers.assert_called_once_with(context, self.cluster)
         ubuntu_driver.rust_driver.delete_cluster.assert_called_once_with(self.cluster)

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -245,7 +245,12 @@ class TestDriver:
         mock_rust_driver,
     ):
         ubuntu_driver._kube_client = mock.MagicMock()
+        ubuntu_driver.rust_driver = mock.MagicMock()
+        ubuntu_driver.rust_driver.resolve_immutable_fields.side_effect = (
+            lambda _name, _labels, variables: variables
+        )
         mock_openstack_connection.identity.create_application_credential.reset_mock()
+        self.cluster.labels = {"audit_log_enabled": "true"}
 
         with requests_mock as rsps:
             rsps.add(
@@ -283,6 +288,14 @@ class TestDriver:
             )
 
             ubuntu_driver.create_cluster(context, self.cluster, 60)
+
+            assert self.cluster.labels == {
+                "audit_log_enabled": "true",
+                "kube_tag": self.cluster.cluster_template.labels["kube_tag"],
+            }
+            ubuntu_driver.rust_driver.create_cluster.assert_called_once_with(
+                self.cluster
+            )
 
             assert ubuntu_driver._kube_client.create_or_update.call_args_list == [
                 mock.call(

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -383,6 +383,36 @@ class TestDriver:
         assert self.cluster.status == fields.ClusterStatus.CREATE_IN_PROGRESS
         self.cluster.save.assert_called_once()
 
+    def test_delete_cluster_merges_template_labels(
+        self,
+        context,
+        ubuntu_driver,
+        mocker,
+    ):
+        ubuntu_driver._kube_client = mock.MagicMock()
+        ubuntu_driver.rust_driver = mock.MagicMock()
+        self.cluster.stack_id = "kube-test"
+        self.cluster.labels = {"audit_log_enabled": "true"}
+
+        delete_loadbalancers = mocker.patch(
+            "magnum_cluster_api.utils.delete_loadbalancers"
+        )
+        cluster_resource = mocker.patch("magnum_cluster_api.resources.Cluster")
+        autoscaler_release = mocker.patch(
+            "magnum_cluster_api.resources.ClusterAutoscalerHelmRelease"
+        )
+
+        ubuntu_driver.delete_cluster(context, self.cluster)
+
+        assert self.cluster.labels == {
+            "audit_log_enabled": "true",
+            "kube_tag": self.cluster.cluster_template.labels["kube_tag"],
+        }
+        delete_loadbalancers.assert_called_once_with(context, self.cluster)
+        ubuntu_driver.rust_driver.delete_cluster.assert_called_once_with(self.cluster)
+        cluster_resource.return_value.delete.assert_called_once_with()
+        autoscaler_release.return_value.delete.assert_called_once_with()
+
     def setup_node_group_tests(self, rsps, before, after=None, machine_sets=False):
         rsps.add(
             self._response_for_cluster_with_machine_deployments(*before),


### PR DESCRIPTION
## Summary

This is a stacked draft PR targeting PR #1040 (`codex/sdk-validation-cleanup-on-1039`). It keeps the changes directly related to the mCAPI PR #1040 behavior separate from the broader Atmosphere v5.9.0 compatibility fixes.

Changes included here:

- treat CAPI Clusters without published status conditions as not ready yet instead of crashing Magnum status updates
- merge cluster-template labels before mCAPI create calls so template-only labels such as `kube_tag` reach the Rust driver
- merge template labels before mCAPI delete calls so stale failed clusters can still be cleaned up
- prefer `labels_skipped` before `cluster_template.labels` when reconstructing the effective label set for mCAPI driver calls

The broader v5.9.0 compatibility fixes discovered during validation, including containerd registry config, CCM chart changes, image-loader updates, and reusable code/config details, are documented at:

`notes/logs/atmosphere/v590-pr3809-mcapi-1039-1040-38-108-68-28/README.md`

## Validation

- `git diff --check 7c0dadc861ab858ebb3ff0f55ee00ce27a599b35..HEAD`
- The full Atmosphere v5.9.0 + PR3809 + PR1039/1040 lifecycle validation result is documented in the README path above.