### PR TITLE
feat(driver): add debian support

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -749,6 +749,14 @@ class UbuntuFocalDriver(UbuntuDriver):
         ]
 
 
+class DebianDriver(BaseDriver):
+    @property
+    def provides(self):
+        return [
+            {"server_type": "vm", "os": "debian", "coe": "kubernetes"},
+        ]
+
+
 class FlatcarDriver(BaseDriver):
     @property
     def provides(self):

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -27,7 +27,15 @@ from oslo_serialization import base64, jsonutils  # type: ignore
 from oslo_utils import uuidutils  # type: ignore
 from responses import matchers
 
-from magnum_cluster_api import objects, resources
+from magnum_cluster_api import driver, objects, resources
+
+
+def test_debian_driver_provides():
+    debian_driver = driver.DebianDriver.__new__(driver.DebianDriver)
+
+    assert debian_driver.provides == [
+        {"server_type": "vm", "os": "debian", "coe": "kubernetes"},
+    ]
 
 
 @pytest.mark.parametrize(

--- a/magnum_cluster_api/tests/unit/test_utils.py
+++ b/magnum_cluster_api/tests/unit/test_utils.py
@@ -299,6 +299,17 @@ class TestGenerateAptProxyConfig:
         assert config == ""
 
 
+@pytest.mark.parametrize("cluster_distro", ["debian", "debian-13"])
+def test_get_operating_system_for_debian(context, cluster_distro):
+    cluster = magnum_test_utils.get_test_cluster(context, labels={})
+    cluster.cluster_template = magnum_test_utils.get_test_cluster_template(
+        context,
+        cluster_distro=cluster_distro,
+    )
+
+    assert utils.get_operating_system(cluster) == "debian"
+
+
 class TestUtils(base.BaseTestCase):
     """Test case for utils."""
 

--- a/magnum_cluster_api/utils.py
+++ b/magnum_cluster_api/utils.py
@@ -39,7 +39,7 @@ from magnum_cluster_api import exceptions as mcapi_exceptions
 from magnum_cluster_api import image_utils, images, objects
 from magnum_cluster_api.cache import ServerGroupCache
 
-AVAILABLE_OPERATING_SYSTEMS = ["ubuntu", "flatcar", "rockylinux"]
+AVAILABLE_OPERATING_SYSTEMS = ["ubuntu", "debian", "flatcar", "rockylinux"]
 DEFAULT_SERVER_GROUP_POLICIES = ["soft-anti-affinity"]
 AVAILABLE_SERVER_GROUP_POLICIES = [
     "affinity",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ magnum-cluster-api-proxy = "magnum_cluster_api.cmd.proxy:main"
 [project.entry-points."magnum.drivers"]
 k8s_cluster_api_ubuntu = "magnum_cluster_api.driver:UbuntuDriver"
 k8s_cluster_api_ubuntu_focal = "magnum_cluster_api.driver:UbuntuFocalDriver"
+k8s_cluster_api_debian = "magnum_cluster_api.driver:DebianDriver"
 k8s_cluster_api_flatcar = "magnum_cluster_api.driver:FlatcarDriver"
 k8s_cluster_api_rockylinux = "magnum_cluster_api.driver:RockyLinuxDriver"
 

--- a/src/features/operating_system.rs
+++ b/src/features/operating_system.rs
@@ -40,6 +40,7 @@ use serde_json::json;
 #[serde(rename_all = "lowercase")]
 pub enum OperatingSystem {
     Ubuntu,
+    Debian,
     Flatcar,
     RockyLinux,
 }
@@ -61,7 +62,7 @@ impl ClusterFeaturePatches for Feature {
         vec![
             ClusterClassPatches {
                 name: "aptProxyConfig".into(),
-                enabled_if: Some(r#"{{ if and (eq .operatingSystem "ubuntu") (ne .aptProxyConfig "") }}true{{end}}"#.into()),
+                enabled_if: Some(r#"{{ if and (or (eq .operatingSystem "ubuntu") (eq .operatingSystem "debian")) (ne .aptProxyConfig "") }}true{{end}}"#.into()),
                 definitions: Some(vec![
                     ClusterClassPatchesDefinitions {
                         selector: ClusterClassPatchesDefinitionsSelector {
@@ -419,11 +420,120 @@ mod tests {
             );
         }
 
-        let kct_spec = resources
+        let kct_spec = resources.kubeadm_config_template.spec.template.spec;
+
+        if let Some(spec) = kct_spec {
+            if let Some(files) = spec.files {
+                assert!(
+                    files
+                        .iter()
+                        .find(|f| f.path == "/etc/apt/apt.conf.d/90proxy")
+                        .is_none(),
+                    "proxy file should not be set when proxy is empty"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_apply_patches_for_debian_with_proxy() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.operating_system = OperatingSystem::Debian;
+        values.apt_proxy_config = BASE64_STANDARD.encode(indoc!(
+            "
+            Acquire::http::Proxy \"http://proxy.example.com\";
+            Acquire::https::Proxy \"http://proxy.example.com\";
+            "
+        ));
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let kcpt_files = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .files
+            .expect("files should be set");
+
+        let kcpt_proxy_file = kcpt_files
+            .iter()
+            .find(|f| f.path == "/etc/apt/apt.conf.d/90proxy")
+            .expect("proxy file should be set when proxy is configured");
+        assert_eq!(kcpt_proxy_file.path, "/etc/apt/apt.conf.d/90proxy");
+        assert_eq!(kcpt_proxy_file.owner.as_deref(), Some("root:root"));
+        assert_eq!(kcpt_proxy_file.permissions.as_deref(), Some("0644"));
+        assert_eq!(
+            kcpt_proxy_file.encoding,
+            Some(KubeadmControlPlaneTemplateTemplateSpecKubeadmConfigSpecFilesEncoding::Base64)
+        );
+        assert_eq!(
+            kcpt_proxy_file.content,
+            Some(values.apt_proxy_config.clone())
+        );
+
+        let kct_files = resources
             .kubeadm_config_template
             .spec
             .template
-            .spec;
+            .spec
+            .expect("spec should be set")
+            .files
+            .expect("files should be set");
+
+        let kct_proxy_file = kct_files
+            .iter()
+            .find(|f| f.path == "/etc/apt/apt.conf.d/90proxy")
+            .expect("proxy file should be set when proxy is configured");
+        assert_eq!(kct_proxy_file.path, "/etc/apt/apt.conf.d/90proxy");
+        assert_eq!(kct_proxy_file.owner.as_deref(), Some("root:root"));
+        assert_eq!(kct_proxy_file.permissions.as_deref(), Some("0644"));
+        assert_eq!(
+            kct_proxy_file.encoding,
+            Some(KubeadmConfigTemplateTemplateSpecFilesEncoding::Base64)
+        );
+        assert_eq!(
+            kct_proxy_file.content,
+            Some(values.apt_proxy_config.clone())
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_for_debian_without_proxy() {
+        let feature = Feature {};
+
+        let mut values = default_values();
+        values.operating_system = OperatingSystem::Debian;
+        values.apt_proxy_config = "".to_string();
+
+        let patches = feature.patches();
+        let mut resources = TestClusterResources::new();
+        resources.apply_patches(&patches, &values);
+
+        let kcpt_files = resources
+            .kubeadm_control_plane_template
+            .spec
+            .template
+            .spec
+            .kubeadm_config_spec
+            .files;
+
+        if let Some(files) = kcpt_files {
+            assert!(
+                files
+                    .iter()
+                    .find(|f| f.path == "/etc/apt/apt.conf.d/90proxy")
+                    .is_none(),
+                "proxy file should not be set when proxy is empty"
+            );
+        }
+
+        let kct_spec = resources.kubeadm_config_template.spec.template.spec;
 
         if let Some(spec) = kct_spec {
             if let Some(files) = spec.files {


### PR DESCRIPTION
## Summary
- add a Debian Magnum driver entry point for (vm, debian, kubernetes)
- normalize Debian cluster distro values into the ClusterClass operatingSystem variable
- treat Debian like Ubuntu for apt proxy ClusterClass patches
- add focused Python and Rust coverage for Debian driver/OS behavior

Closes #1057

## Testing
- nix develop --command cargo test
- nix develop --command pre-commit run --all-files

Note: full tox -e unit was not rerun after keeping the diff Debian-only because the existing clean tox env is missing unrelated dependencies for legacy pkg_resources/lark imports.