### PR TITLE
fix(addons): parse CSI enable labels from strings

### DIFF
--- a/src/addons/cinder_csi.rs
+++ b/src/addons/cinder_csi.rs
@@ -201,7 +201,7 @@ impl ClusterAddon for Addon {
     }
 
     fn enabled(&self) -> bool {
-        self.cluster.labels.cinder_csi_enabled
+        self.cluster.labels.is_cinder_csi_enabled()
     }
 
     fn secret_name(&self) -> Result<String, ClusterError> {

--- a/src/addons/manila_csi.rs
+++ b/src/addons/manila_csi.rs
@@ -129,7 +129,7 @@ impl ClusterAddon for Addon {
     }
 
     fn enabled(&self) -> bool {
-        self.cluster.labels.manila_csi_enabled
+        self.cluster.labels.is_manila_csi_enabled()
     }
 
     fn secret_name(&self) -> Result<String, ClusterError> {

--- a/src/magnum.rs
+++ b/src/magnum.rs
@@ -43,9 +43,10 @@ pub struct ClusterLabels {
     pub cilium_hubble_ui_enabled: String,
 
     /// Enable the use of the Cinder CSI driver for the cluster.
-    #[builder(default = true)]
-    #[pyo3(default = true)]
-    pub cinder_csi_enabled: bool,
+    /// Note: OpenStack labels are always strings, so this accepts "true"/"false".
+    #[builder(default="true".to_owned())]
+    #[pyo3(default="true".to_owned())]
+    pub cinder_csi_enabled: String,
 
     /// The tag of the Cinder CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
@@ -53,9 +54,10 @@ pub struct ClusterLabels {
     pub cinder_csi_plugin_tag: String,
 
     /// Enable the use of the Manila CSI driver for the cluster.
-    #[builder(default = true)]
-    #[pyo3(default = true)]
-    pub manila_csi_enabled: bool,
+    /// Note: OpenStack labels are always strings, so this accepts "true"/"false".
+    #[builder(default="true".to_owned())]
+    #[pyo3(default="true".to_owned())]
+    pub manila_csi_enabled: String,
 
     /// The tag of the Manila CSI container image to use for the cluster.
     #[builder(default="v1.32.0".to_owned())]
@@ -117,6 +119,14 @@ impl ClusterLabels {
     /// Parses the string label value "true"/"false" to a boolean.
     pub fn is_cilium_hubble_ui_enabled(&self) -> bool {
         self.cilium_hubble_ui_enabled.eq_ignore_ascii_case("true")
+    }
+
+    pub fn is_cinder_csi_enabled(&self) -> bool {
+        self.cinder_csi_enabled.eq_ignore_ascii_case("true")
+    }
+
+    pub fn is_manila_csi_enabled(&self) -> bool {
+        self.manila_csi_enabled.eq_ignore_ascii_case("true")
     }
 
     pub fn get_cloud_provider_tag(&self) -> String {
@@ -378,7 +388,7 @@ mod tests {
     use super::*;
     use crate::addons;
     use pretty_assertions::assert_eq;
-    use pyo3::types::PyString;
+    use pyo3::types::{PyDict, PyString};
     use rstest::rstest;
     use serde_yaml::{Mapping, Value};
     use std::path::PathBuf;
@@ -440,6 +450,28 @@ mod tests {
             .build();
 
         assert_eq!(labels.get_cloud_provider_tag(), "v1.29.5");
+    }
+
+    #[test]
+    fn test_cluster_labels_extract_openstack_bool_strings() {
+        Python::initialize();
+        Python::attach(|py| {
+            let labels = PyDict::new(py);
+            labels
+                .set_item("cinder_csi_enabled", "true")
+                .expect("label should be set");
+            labels
+                .set_item("manila_csi_enabled", "false")
+                .expect("label should be set");
+            labels
+                .set_item("kube_tag", "v1.34.3")
+                .expect("label should be set");
+
+            let labels: ClusterLabels = labels.extract().expect("labels should extract");
+
+            assert!(labels.is_cinder_csi_enabled());
+            assert!(!labels.is_manila_csi_enabled());
+        });
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary
- Model `cinder_csi_enabled` and `manila_csi_enabled` as OpenStack string labels instead of native booleans.
- Add helper methods that treat only case-insensitive `"true"` as enabled.
- Route the Cinder and Manila CSI addon `enabled()` methods through those helpers.

## Why
Magnum labels are delivered to the Rust driver as OpenStack label values, which are strings even when the label represents a boolean. The CSI enable labels were modeled as `bool`, so values such as `"true"` and `"false"` depended on Python extraction accepting native booleans instead of the string values users set on cluster templates or clusters.

Keeping Cinder and Manila together isolates this from PR #1071 because both addons share the same enable-label bug and both implementations need to return a bool from `enabled()`.

## Testing
- `cargo test` passed: 145 tests passed, doctest ignored.
- `git diff --check origin/main..HEAD` passed.
