### PR TITLE
feat(ci): add Ubuntu 24.04 hydrophone canaries

### DIFF
--- a/devstack/local.conf.sample
+++ b/devstack/local.conf.sample
@@ -29,7 +29,7 @@ MANILA_SERVICE_IMAGE_ENABLED=True
 MANILA_USE_UWSGI=False
 
 enable_plugin magnum https://opendev.org/openstack/magnum
-MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/latest/download/ubuntu-24.04-v1.36.1.qcow2
+MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.36.1.qcow2
 
 enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api
 

--- a/devstack/local.conf.sample
+++ b/devstack/local.conf.sample
@@ -29,7 +29,7 @@ MANILA_SERVICE_IMAGE_ENABLED=True
 MANILA_USE_UWSGI=False
 
 enable_plugin magnum https://opendev.org/openstack/magnum
-MAGNUM_GUEST_IMAGE_URL=https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-31-1-1728920853.qcow2
+MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/latest/download/ubuntu-24.04-v1.36.1.qcow2
 
 enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api
 

--- a/docs/developer/testing-and-development.md
+++ b/docs/developer/testing-and-development.md
@@ -15,10 +15,11 @@ steps to be able to test and develop the project.
    ```bash
    pushd /tmp
    source /opt/stack/openrc
-   export OS_DISTRO=ubuntu # you can change this to "flatcar" if you want to use Flatcar
-   for version in v1.24.16 v1.25.12 v1.26.7 v1.27.4; do \
-      [[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${version}" || IMAGE_NAME="flatcar-kube-${version}"; \
-      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${IMAGE_NAME}.qcow2; \
+   export OS_DISTRO=ubuntu
+   export IMAGE_FAMILY=ubuntu-24.04
+   for version in v1.33.12 v1.34.8 v1.35.5 v1.36.1; do \
+      IMAGE_NAME="${IMAGE_FAMILY}-${version}"; \
+      curl -LO https://github.com/vexxhost/capo-image-elements/releases/latest/download/${IMAGE_NAME}.qcow2; \
       openstack image create ${IMAGE_NAME} --disk-format=qcow2 --container-format=bare --property os_distro=${OS_DISTRO} --file=${IMAGE_NAME}.qcow2; \
       openstack coe cluster template create \
         --image $(openstack image show ${IMAGE_NAME} -c id -f value) \

--- a/docs/developer/testing-and-development.md
+++ b/docs/developer/testing-and-development.md
@@ -19,7 +19,7 @@ steps to be able to test and develop the project.
    export IMAGE_FAMILY=ubuntu-24.04
    for version in v1.33.12 v1.34.8 v1.35.5 v1.36.1; do \
       IMAGE_NAME="${IMAGE_FAMILY}-${version}"; \
-      curl -LO https://github.com/vexxhost/capo-image-elements/releases/latest/download/${IMAGE_NAME}.qcow2; \
+      curl -LO https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/${IMAGE_NAME}.qcow2; \
       openstack image create ${IMAGE_NAME} --disk-format=qcow2 --container-format=bare --property os_distro=${OS_DISTRO} --file=${IMAGE_NAME}.qcow2; \
       openstack coe cluster template create \
         --image $(openstack image show ${IMAGE_NAME} -c id -f value) \

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -47,10 +47,11 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     them using the OpenStack CLI:
 
     ```bash
-    export OS_DISTRO=ubuntu # you can change this to "flatcar" if you want to use Flatcar
-    for version in v1.24.16 v1.25.12 v1.26.7 v1.27.4; do \
-      [[ "${OS_DISTRO}" == "ubuntu" ]] && IMAGE_NAME="ubuntu-2204-kube-${version}" || IMAGE_NAME="flatcar-kube-${version}"; \
-      curl -LO https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/${IMAGE_NAME}.qcow2; \
+    export OS_DISTRO=ubuntu
+    export IMAGE_FAMILY=ubuntu-24.04
+    for version in v1.33.12 v1.34.8 v1.35.5 v1.36.1; do \
+      IMAGE_NAME="${IMAGE_FAMILY}-${version}"; \
+      curl -LO https://github.com/vexxhost/capo-image-elements/releases/latest/download/${IMAGE_NAME}.qcow2; \
       openstack image create ${IMAGE_NAME} --disk-format=qcow2 --container-format=bare --property os_distro=${OS_DISTRO} --file=${IMAGE_NAME}.qcow2; \
       openstack coe cluster template create \
           --image $(openstack image show ${IMAGE_NAME} -c id -f value) \

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -51,7 +51,7 @@ dashboard, Terraform, Ansible or the Magnum API directly.
     export IMAGE_FAMILY=ubuntu-24.04
     for version in v1.33.12 v1.34.8 v1.35.5 v1.36.1; do \
       IMAGE_NAME="${IMAGE_FAMILY}-${version}"; \
-      curl -LO https://github.com/vexxhost/capo-image-elements/releases/latest/download/${IMAGE_NAME}.qcow2; \
+      curl -LO https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/${IMAGE_NAME}.qcow2; \
       openstack image create ${IMAGE_NAME} --disk-format=qcow2 --container-format=bare --property os_distro=${OS_DISTRO} --file=${IMAGE_NAME}.qcow2; \
       openstack coe cluster template create \
           --image $(openstack image show ${IMAGE_NAME} -c id -f value) \

--- a/docs/user/images.md
+++ b/docs/user/images.md
@@ -14,8 +14,10 @@ The images used by the Cluster API driver for Magnum are built using the
 project. This project provides a comprehensive and flexible framework for
 constructing Kubernetes-specific images.
 
-You can find pre-built images by this projet at
-https://static.atmosphere.dev/artifacts/magnum-cluster-api/.
+You can find pre-built images by this project in the
+[`vexxhost/capo-image-elements` releases](https://github.com/vexxhost/capo-image-elements/releases).
+For Ubuntu 24.04 images, use the `ubuntu-24.04-v<kubernetes-version>.qcow2`
+assets and upload them to Glance with `--property os_distro=ubuntu`.
 
 #### Deprecated legacy builder
 

--- a/hack/bump/kubernetes.py
+++ b/hack/bump/kubernetes.py
@@ -25,6 +25,7 @@ from github.GithubException import GithubException, UnknownObjectException
 
 RELEASE_REPOSITORY = "vexxhost/capo-image-elements"
 IMAGE_PREFIX = "ubuntu-22.04"
+CANARY_IMAGE_PREFIXES = ("ubuntu-24.04",)
 
 BASE_JOB_NAME = "magnum-cluster-api-hydrophone"
 PROJECT_TEMPLATE_NAME = f"{BASE_JOB_NAME}-jobs"
@@ -32,7 +33,7 @@ VERSIONED_JOB_PREFIX = f"{BASE_JOB_NAME}-v"
 NETWORK_DRIVERS = ("calico", "cilium")
 IMAGE_URL = (
     "https://github.com/vexxhost/capo-image-elements/releases/download/"
-    "{{ image_release }}/ubuntu-22.04-{{ kube_tag }}.qcow2"
+    "{{ image_release }}/{{ image_prefix }}-{{ kube_tag }}.qcow2"
 )
 
 KUBERNETES_IMAGE_RE = re.compile(r"^.+-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\.qcow2$")
@@ -46,7 +47,9 @@ class ScriptError(RuntimeError):
 class Release:
     tag_name: str
     name: str
+    image_prefix: str
     versions: tuple[str, ...]
+    assets: tuple[str, ...]
 
 
 class IndentedDumper(yaml.SafeDumper):
@@ -74,7 +77,9 @@ def latest_release(repository: str, image_prefix: str) -> Release:
         return Release(
             tag_name=tag_name,
             name=release.name or tag_name,
+            image_prefix=image_prefix,
             versions=versions_from_assets(tag_name, assets, image_prefix),
+            assets=tuple(assets),
         )
     except UnknownObjectException as exc:
         raise ScriptError(
@@ -154,12 +159,21 @@ def hydrophone_jobs(release: Release) -> list[dict[str, Any]]:
         for version in release.versions
         for network_driver in NETWORK_DRIVERS
     ]
+    latest_version = release.versions[-1]
+    canary_prefixes = [
+        prefix for prefix in CANARY_IMAGE_PREFIXES if prefix != release.image_prefix
+    ]
+    canary_jobs = [
+        f"{BASE_JOB_NAME}-{prefix}-v{latest_version}-{network_driver}"
+        for prefix in canary_prefixes
+        for network_driver in NETWORK_DRIVERS
+    ]
     jobs = [
         {
             "project-template": {
                 "name": PROJECT_TEMPLATE_NAME,
-                "check": {"jobs": list(generated_jobs)},
-                "gate": {"jobs": list(generated_jobs)},
+                "check": {"jobs": list(generated_jobs) + list(canary_jobs)},
+                "gate": {"jobs": list(generated_jobs) + list(canary_jobs)},
             }
         },
         {
@@ -171,6 +185,7 @@ def hydrophone_jobs(release: Release) -> list[dict[str, Any]]:
                 "run": "zuul.d/playbooks/hydrophone/run.yml",
                 "post-run": "zuul.d/playbooks/hydrophone/post.yml",
                 "vars": {
+                    "image_prefix": release.image_prefix,
                     "image_url": IMAGE_URL,
                     "devstack_localrc": {
                         "MAGNUM_GUEST_IMAGE_URL": "{{ image_url }}",
@@ -207,6 +222,44 @@ def hydrophone_jobs(release: Release) -> list[dict[str, Any]]:
                 }
             )
 
+    for prefix in canary_prefixes:
+        canary_versions = set(
+            versions_from_assets(release.tag_name, list(release.assets), prefix)
+        )
+        if latest_version not in canary_versions:
+            raise ScriptError(
+                f"Release {release.tag_name} has no {prefix} image "
+                f"for v{latest_version}"
+            )
+
+        jobs.append(
+            {
+                "job": {
+                    "name": f"{BASE_JOB_NAME}-{prefix}-v{latest_version}",
+                    "parent": f"{VERSIONED_JOB_PREFIX}{latest_version}",
+                    "vars": {
+                        "image_prefix": prefix,
+                    },
+                }
+            }
+        )
+
+        for network_driver in NETWORK_DRIVERS:
+            jobs.append(
+                {
+                    "job": {
+                        "name": (
+                            f"{BASE_JOB_NAME}-{prefix}-v{latest_version}-"
+                            f"{network_driver}"
+                        ),
+                        "parent": f"{BASE_JOB_NAME}-{prefix}-v{latest_version}",
+                        "vars": {
+                            "network_driver": network_driver,
+                        },
+                    }
+                }
+            )
+
     return jobs
 
 
@@ -232,7 +285,7 @@ def prune_jobs_text(text: str) -> str:
                 break
 
         if name == BASE_JOB_NAME or (
-            name is not None and name.startswith(VERSIONED_JOB_PREFIX)
+            name is not None and name.startswith(f"{BASE_JOB_NAME}-")
         ):
             continue
         kept_blocks.append("".join(block))
@@ -316,7 +369,16 @@ class KubernetesBumpTests(unittest.TestCase):
     def test_hydrophone_jobs_include_template_base_release_and_network_jobs(
         self,
     ) -> None:
-        release = Release("2026.05-7", "2026.05-7", ("1.33.12",))
+        release = Release(
+            tag_name="2026.05-7",
+            name="2026.05-7",
+            image_prefix="ubuntu-22.04",
+            versions=("1.33.12",),
+            assets=(
+                "ubuntu-22.04-v1.33.12.qcow2",
+                "ubuntu-24.04-v1.33.12.qcow2",
+            ),
+        )
         document = hydrophone_jobs(release)
 
         template = document[0]["project-template"]
@@ -326,6 +388,8 @@ class KubernetesBumpTests(unittest.TestCase):
             [
                 "magnum-cluster-api-hydrophone-v1.33.12-calico",
                 "magnum-cluster-api-hydrophone-v1.33.12-cilium",
+                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-calico",
+                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-cilium",
             ],
         )
         self.assertEqual(template["gate"]["jobs"], template["check"]["jobs"])
@@ -340,15 +404,21 @@ class KubernetesBumpTests(unittest.TestCase):
 
         self.assertEqual(job_name(document[1]), BASE_JOB_NAME)
         self.assertIn("{{ image_release }}", document[1]["job"]["vars"]["image_url"])
+        self.assertIn("{{ image_prefix }}", document[1]["job"]["vars"]["image_url"])
+        self.assertEqual(document[1]["job"]["vars"]["image_prefix"], "ubuntu-22.04")
         self.assertEqual(
             [job_name(entry) for entry in document[2:]],
             [
                 "magnum-cluster-api-hydrophone-v1.33.12",
                 "magnum-cluster-api-hydrophone-v1.33.12-calico",
                 "magnum-cluster-api-hydrophone-v1.33.12-cilium",
+                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12",
+                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-calico",
+                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-cilium",
             ],
         )
         self.assertEqual(document[2]["job"]["vars"]["image_release"], "2026.05-7")
+        self.assertEqual(document[5]["job"]["vars"]["image_prefix"], "ubuntu-24.04")
 
     def test_prune_jobs_text_preserves_non_hydrophone_job_format(self) -> None:
         text = dedent(
@@ -367,6 +437,8 @@ class KubernetesBumpTests(unittest.TestCase):
                 name: magnum-cluster-api-hydrophone
             - job:
                 name: magnum-cluster-api-hydrophone-v1.32.9
+            - job:
+                name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.32.9
             """
         )
         expected = dedent(

--- a/hack/bump/kubernetes.py
+++ b/hack/bump/kubernetes.py
@@ -24,8 +24,7 @@ from github import Auth, Github
 from github.GithubException import GithubException, UnknownObjectException
 
 RELEASE_REPOSITORY = "vexxhost/capo-image-elements"
-IMAGE_PREFIX = "ubuntu-22.04"
-CANARY_IMAGE_PREFIXES = ("ubuntu-24.04",)
+IMAGE_PREFIX = "ubuntu-24.04"
 
 BASE_JOB_NAME = "magnum-cluster-api-hydrophone"
 PROJECT_TEMPLATE_NAME = f"{BASE_JOB_NAME}-jobs"
@@ -49,7 +48,6 @@ class Release:
     name: str
     image_prefix: str
     versions: tuple[str, ...]
-    assets: tuple[str, ...]
 
 
 class IndentedDumper(yaml.SafeDumper):
@@ -79,7 +77,6 @@ def latest_release(repository: str, image_prefix: str) -> Release:
             name=release.name or tag_name,
             image_prefix=image_prefix,
             versions=versions_from_assets(tag_name, assets, image_prefix),
-            assets=tuple(assets),
         )
     except UnknownObjectException as exc:
         raise ScriptError(
@@ -159,21 +156,12 @@ def hydrophone_jobs(release: Release) -> list[dict[str, Any]]:
         for version in release.versions
         for network_driver in NETWORK_DRIVERS
     ]
-    latest_version = release.versions[-1]
-    canary_prefixes = [
-        prefix for prefix in CANARY_IMAGE_PREFIXES if prefix != release.image_prefix
-    ]
-    canary_jobs = [
-        f"{BASE_JOB_NAME}-{prefix}-v{latest_version}-{network_driver}"
-        for prefix in canary_prefixes
-        for network_driver in NETWORK_DRIVERS
-    ]
     jobs = [
         {
             "project-template": {
                 "name": PROJECT_TEMPLATE_NAME,
-                "check": {"jobs": list(generated_jobs) + list(canary_jobs)},
-                "gate": {"jobs": list(generated_jobs) + list(canary_jobs)},
+                "check": {"jobs": list(generated_jobs)},
+                "gate": {"jobs": list(generated_jobs)},
             }
         },
         {
@@ -215,44 +203,6 @@ def hydrophone_jobs(release: Release) -> list[dict[str, Any]]:
                     "job": {
                         "name": f"{VERSIONED_JOB_PREFIX}{version}-{network_driver}",
                         "parent": f"{VERSIONED_JOB_PREFIX}{version}",
-                        "vars": {
-                            "network_driver": network_driver,
-                        },
-                    }
-                }
-            )
-
-    for prefix in canary_prefixes:
-        canary_versions = set(
-            versions_from_assets(release.tag_name, list(release.assets), prefix)
-        )
-        if latest_version not in canary_versions:
-            raise ScriptError(
-                f"Release {release.tag_name} has no {prefix} image "
-                f"for v{latest_version}"
-            )
-
-        jobs.append(
-            {
-                "job": {
-                    "name": f"{BASE_JOB_NAME}-{prefix}-v{latest_version}",
-                    "parent": f"{VERSIONED_JOB_PREFIX}{latest_version}",
-                    "vars": {
-                        "image_prefix": prefix,
-                    },
-                }
-            }
-        )
-
-        for network_driver in NETWORK_DRIVERS:
-            jobs.append(
-                {
-                    "job": {
-                        "name": (
-                            f"{BASE_JOB_NAME}-{prefix}-v{latest_version}-"
-                            f"{network_driver}"
-                        ),
-                        "parent": f"{BASE_JOB_NAME}-{prefix}-v{latest_version}",
                         "vars": {
                             "network_driver": network_driver,
                         },
@@ -351,7 +301,7 @@ class KubernetesBumpTests(unittest.TestCase):
         ]
 
         self.assertEqual(
-            versions_from_assets("2026.05-7", assets, "ubuntu-22.04"),
+            versions_from_assets("2026.05-7", assets, IMAGE_PREFIX),
             ("1.33.12", "1.34.8"),
         )
 
@@ -360,11 +310,11 @@ class KubernetesBumpTests(unittest.TestCase):
     ) -> None:
         assets = [
             "debian-13-v1.33.12.qcow2",
-            "ubuntu-22.04-v1.34.8.qcow2",
+            "ubuntu-24.04-v1.34.8.qcow2",
         ]
 
         with self.assertRaisesRegex(ScriptError, "v1.33.12"):
-            versions_from_assets("2026.05-7", assets, "ubuntu-22.04")
+            versions_from_assets("2026.05-7", assets, IMAGE_PREFIX)
 
     def test_hydrophone_jobs_include_template_base_release_and_network_jobs(
         self,
@@ -372,12 +322,8 @@ class KubernetesBumpTests(unittest.TestCase):
         release = Release(
             tag_name="2026.05-7",
             name="2026.05-7",
-            image_prefix="ubuntu-22.04",
+            image_prefix=IMAGE_PREFIX,
             versions=("1.33.12",),
-            assets=(
-                "ubuntu-22.04-v1.33.12.qcow2",
-                "ubuntu-24.04-v1.33.12.qcow2",
-            ),
         )
         document = hydrophone_jobs(release)
 
@@ -388,8 +334,6 @@ class KubernetesBumpTests(unittest.TestCase):
             [
                 "magnum-cluster-api-hydrophone-v1.33.12-calico",
                 "magnum-cluster-api-hydrophone-v1.33.12-cilium",
-                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-calico",
-                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-cilium",
             ],
         )
         self.assertEqual(template["gate"]["jobs"], template["check"]["jobs"])
@@ -405,20 +349,16 @@ class KubernetesBumpTests(unittest.TestCase):
         self.assertEqual(job_name(document[1]), BASE_JOB_NAME)
         self.assertIn("{{ image_release }}", document[1]["job"]["vars"]["image_url"])
         self.assertIn("{{ image_prefix }}", document[1]["job"]["vars"]["image_url"])
-        self.assertEqual(document[1]["job"]["vars"]["image_prefix"], "ubuntu-22.04")
+        self.assertEqual(document[1]["job"]["vars"]["image_prefix"], IMAGE_PREFIX)
         self.assertEqual(
             [job_name(entry) for entry in document[2:]],
             [
                 "magnum-cluster-api-hydrophone-v1.33.12",
                 "magnum-cluster-api-hydrophone-v1.33.12-calico",
                 "magnum-cluster-api-hydrophone-v1.33.12-cilium",
-                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12",
-                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-calico",
-                "magnum-cluster-api-hydrophone-ubuntu-24.04-v1.33.12-cilium",
             ],
         )
         self.assertEqual(document[2]["job"]["vars"]["image_release"], "2026.05-7")
-        self.assertEqual(document[5]["job"]["vars"]["image_prefix"], "ubuntu-24.04")
 
     def test_prune_jobs_text_preserves_non_hydrophone_job_format(self) -> None:
         text = dedent(

--- a/zuul.d/hydrophone-jobs.yaml
+++ b/zuul.d/hydrophone-jobs.yaml
@@ -10,6 +10,8 @@
         - magnum-cluster-api-hydrophone-v1.35.5-cilium
         - magnum-cluster-api-hydrophone-v1.36.1-calico
         - magnum-cluster-api-hydrophone-v1.36.1-cilium
+        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-calico
+        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-cilium
     gate:
       jobs:
         - magnum-cluster-api-hydrophone-v1.33.12-calico
@@ -20,6 +22,8 @@
         - magnum-cluster-api-hydrophone-v1.35.5-cilium
         - magnum-cluster-api-hydrophone-v1.36.1-calico
         - magnum-cluster-api-hydrophone-v1.36.1-cilium
+        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-calico
+        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-cilium
 - job:
     name: magnum-cluster-api-hydrophone
     parent: magnum-cluster-api-devstack
@@ -28,7 +32,8 @@
     run: zuul.d/playbooks/hydrophone/run.yml
     post-run: zuul.d/playbooks/hydrophone/post.yml
     vars:
-      image_url: https://github.com/vexxhost/capo-image-elements/releases/download/{{ image_release }}/ubuntu-22.04-{{ kube_tag }}.qcow2
+      image_prefix: ubuntu-22.04
+      image_url: https://github.com/vexxhost/capo-image-elements/releases/download/{{ image_release }}/{{ image_prefix }}-{{ kube_tag }}.qcow2
       devstack_localrc:
         MAGNUM_GUEST_IMAGE_URL: '{{ image_url }}'
 - job:
@@ -93,5 +98,20 @@
 - job:
     name: magnum-cluster-api-hydrophone-v1.36.1-cilium
     parent: magnum-cluster-api-hydrophone-v1.36.1
+    vars:
+      network_driver: cilium
+- job:
+    name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1
+    parent: magnum-cluster-api-hydrophone-v1.36.1
+    vars:
+      image_prefix: ubuntu-24.04
+- job:
+    name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-calico
+    parent: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1
+    vars:
+      network_driver: calico
+- job:
+    name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-cilium
+    parent: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1
     vars:
       network_driver: cilium

--- a/zuul.d/hydrophone-jobs.yaml
+++ b/zuul.d/hydrophone-jobs.yaml
@@ -10,8 +10,6 @@
         - magnum-cluster-api-hydrophone-v1.35.5-cilium
         - magnum-cluster-api-hydrophone-v1.36.1-calico
         - magnum-cluster-api-hydrophone-v1.36.1-cilium
-        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-calico
-        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-cilium
     gate:
       jobs:
         - magnum-cluster-api-hydrophone-v1.33.12-calico
@@ -22,8 +20,6 @@
         - magnum-cluster-api-hydrophone-v1.35.5-cilium
         - magnum-cluster-api-hydrophone-v1.36.1-calico
         - magnum-cluster-api-hydrophone-v1.36.1-cilium
-        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-calico
-        - magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-cilium
 - job:
     name: magnum-cluster-api-hydrophone
     parent: magnum-cluster-api-devstack
@@ -32,7 +28,7 @@
     run: zuul.d/playbooks/hydrophone/run.yml
     post-run: zuul.d/playbooks/hydrophone/post.yml
     vars:
-      image_prefix: ubuntu-22.04
+      image_prefix: ubuntu-24.04
       image_url: https://github.com/vexxhost/capo-image-elements/releases/download/{{ image_release }}/{{ image_prefix }}-{{ kube_tag }}.qcow2
       devstack_localrc:
         MAGNUM_GUEST_IMAGE_URL: '{{ image_url }}'
@@ -98,20 +94,5 @@
 - job:
     name: magnum-cluster-api-hydrophone-v1.36.1-cilium
     parent: magnum-cluster-api-hydrophone-v1.36.1
-    vars:
-      network_driver: cilium
-- job:
-    name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1
-    parent: magnum-cluster-api-hydrophone-v1.36.1
-    vars:
-      image_prefix: ubuntu-24.04
-- job:
-    name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-calico
-    parent: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1
-    vars:
-      network_driver: calico
-- job:
-    name: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1-cilium
-    parent: magnum-cluster-api-hydrophone-ubuntu-24.04-v1.36.1
     vars:
       network_driver: cilium


### PR DESCRIPTION
Depends-On: https://github.com/vexxhost/magnum-cluster-api/pull/1084

## Summary

- parameterize Hydrophone guest image URLs with an `image_prefix` variable
- add Ubuntu 24.04 Hydrophone canary jobs for the newest generated Kubernetes version, currently v1.36.1, for both Calico and Cilium
- update DevStack and user/developer image examples to consume `capo-image-elements` Ubuntu 24.04 artifacts with `os_distro=ubuntu`

## Rationale

`vexxhost/capo-image-elements` already publishes `ubuntu-24.04-v<version>.qcow2` artifacts. This keeps the existing Ubuntu 22.04 Hydrophone matrix intact while adding a narrow Magnum-specific Noble validation path before widening the CI matrix.

## Validation

- `uv run --no-project --script hack/bump/kubernetes.py --self-test`
- `bash -n hack/bump/kubernetes.sh hack/run-integration-tests.sh`
- YAML parse check for `zuul.d/jobs.yaml`, `zuul.d/project.yaml`, and `zuul.d/hydrophone-jobs.yaml`
- `git diff --check`
- `uvx --python 3.12 pre-commit run --all-files`
- dry run of `hack/bump/kubernetes.py --image-prefix ubuntu-24.04` against temporary output files

