### PR TITLE
fix: omit empty CAPI failure domains

### DIFF
--- a/magnum_cluster_api/resources.py
+++ b/magnum_cluster_api/resources.py
@@ -778,7 +778,7 @@ def mutate_machine_deployment(
         if current_failure_domain == "" and (
             new_failure_domain is None or new_failure_domain == ""
         ):
-            machine_deployment["failureDomain"] = None
+            machine_deployment.pop("failureDomain", None)
         if current_failure_domain == "" and new_failure_domain:
             machine_deployment["failureDomain"] = new_failure_domain
 
@@ -792,7 +792,6 @@ def mutate_machine_deployment(
         {
             "class": "default-worker",
             "name": node_group.name,
-            "failureDomain": node_group.labels.get("availability_zone"),
             "machineHealthCheck": {"enable": utils.get_auto_healing_enabled(cluster)},
             "variables": {
                 "overrides": [
@@ -846,6 +845,9 @@ def mutate_machine_deployment(
             },
         }
     )
+    failure_domain = node_group.labels.get("availability_zone")
+    if failure_domain:
+        machine_deployment["failureDomain"] = failure_domain
     return machine_deployment
 
 
@@ -858,8 +860,8 @@ def migrate_machineset_failure_domain(
     """
     Migrate MachineSet failureDomain fields to fix Cluster API v1.10+ validation issues.
 
-    This function directly patches MachineSet resources to convert empty string
-    failureDomain values to None/null, avoiding rolling updates that would occur
+    This function directly patches MachineSet resources to remove empty string
+    failureDomain values, avoiding rolling updates that would occur
     if we modified the MachineDeployment spec.
     """
     machine_sets = objects.MachineSet.for_node_group(pykube_api, cluster, node_group)
@@ -874,9 +876,9 @@ def migrate_machineset_failure_domain(
         )
 
         if current_failure_domain == "":
-            # Patch the MachineSet to set failureDomain to None
+            # Patch the MachineSet to remove failureDomain.
             # This avoids the validation error without triggering rolling updates
-            ms.obj["spec"]["template"]["spec"]["failureDomain"] = None
+            ms.obj["spec"]["template"]["spec"].pop("failureDomain", None)
             ms.update()
 
 
@@ -887,8 +889,8 @@ def migrate_cluster_failure_domain(
     """
     Migrate Cluster MachineDeployment failureDomain fields to fix Cluster API v1.10+ validation issues.
 
-    This function directly patches the Cluster resource to convert empty string
-    failureDomain values to None/null in MachineDeployment specs, avoiding rolling updates.
+    This function directly patches the Cluster resource to remove empty string
+    failureDomain values from MachineDeployment specs, avoiding rolling updates.
     """
 
     # Get the current machine deployment spec
@@ -898,7 +900,7 @@ def migrate_cluster_failure_domain(
     if current_failure_domain == "":
         # Update the machine deployment spec to remove the failureDomain field
         # We'll use obj.update() which should handle the field removal properly
-        current_md_spec["failureDomain"] = None
+        current_md_spec.pop("failureDomain", None)
         cluster_resource.set_machine_deployment_spec(node_group.name, current_md_spec)
 
         # Use obj.update() to apply the change

--- a/magnum_cluster_api/tests/unit/test_resources.py
+++ b/magnum_cluster_api/tests/unit/test_resources.py
@@ -161,3 +161,124 @@ class TestExistingMutateMachineDeployment:
         else:
             assert md["replicas"] == self.node_group.node_count
             assert md["metadata"]["annotations"] == {}
+
+    def test_mutate_machine_deployment_removes_empty_failure_domain(self, context):
+        md = resources.mutate_machine_deployment(
+            context,
+            self.cluster,
+            self.node_group,
+            {
+                "name": self.node_group.name,
+                "failureDomain": "",
+            },
+        )
+
+        assert "failureDomain" not in md
+
+    def test_mutate_machine_deployment_updates_empty_failure_domain(self, context):
+        self.node_group.labels["availability_zone"] = "nova"
+
+        md = resources.mutate_machine_deployment(
+            context,
+            self.cluster,
+            self.node_group,
+            {
+                "name": self.node_group.name,
+                "failureDomain": "",
+            },
+        )
+
+        assert md["failureDomain"] == "nova"
+
+
+def _patch_new_machine_deployment_dependencies(mocker):
+    mocker.patch("magnum_cluster_api.utils.lookup_image", return_value={"id": "foo"})
+    mocker.patch(
+        "magnum_cluster_api.utils.lookup_flavor",
+        return_value=flavors.Flavor(
+            None,
+            {"name": "bm-flavor", "disk": 0, "ram": 4096, "vcpus": 4},
+        ),
+    )
+    mocker.patch(
+        "magnum_cluster_api.integrations.cinder.get_default_boot_volume_type",
+        return_value="rbd1",
+    )
+    mocker.patch(
+        "magnum_cluster_api.utils.ensure_worker_server_group",
+        return_value="server-group",
+    )
+
+
+def test_new_machine_deployment_omits_unset_failure_domain(context, mocker):
+    cluster = utils.get_test_cluster(context, labels={})
+    node_group = utils.get_test_nodegroup(context, labels={})
+    _patch_new_machine_deployment_dependencies(mocker)
+
+    md = resources.mutate_machine_deployment(context, cluster, node_group)
+
+    assert "failureDomain" not in md
+
+
+def test_new_machine_deployment_sets_failure_domain(context, mocker):
+    cluster = utils.get_test_cluster(context, labels={})
+    node_group = utils.get_test_nodegroup(
+        context,
+        labels={"availability_zone": "nova"},
+    )
+    _patch_new_machine_deployment_dependencies(mocker)
+
+    md = resources.mutate_machine_deployment(context, cluster, node_group)
+
+    assert md["failureDomain"] == "nova"
+
+
+def test_migrate_machineset_failure_domain_removes_empty_value(
+    context,
+    mocker,
+):
+    cluster = utils.get_test_cluster(context, labels={})
+    node_group = utils.get_test_nodegroup(context, labels={})
+    machine_set = mocker.Mock()
+    machine_set.obj = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "failureDomain": "",
+                },
+            },
+        },
+    }
+    mocker.patch(
+        "magnum_cluster_api.objects.MachineSet.for_node_group",
+        return_value=[machine_set],
+    )
+
+    resources.migrate_machineset_failure_domain(
+        context,
+        cluster,
+        node_group,
+        mocker.Mock(),
+    )
+
+    assert "failureDomain" not in machine_set.obj["spec"]["template"]["spec"]
+    machine_set.update.assert_called_once_with()
+
+
+def test_migrate_cluster_failure_domain_removes_empty_value(context, mocker):
+    node_group = utils.get_test_nodegroup(context, labels={})
+    machine_deployment = {
+        "name": node_group.name,
+        "failureDomain": "",
+    }
+    cluster_resource = mocker.Mock()
+    cluster_resource.get_machine_deployment_spec.return_value = machine_deployment
+
+    resources.migrate_cluster_failure_domain(node_group, cluster_resource)
+
+    assert "failureDomain" not in machine_deployment
+    cluster_resource.set_machine_deployment_spec.assert_called_once_with(
+        node_group.name,
+        machine_deployment,
+    )
+    cluster_resource.update.assert_called_once_with()


### PR DESCRIPTION
## Summary

- omit `failureDomain` from new worker MachineDeployments when the nodegroup has no availability zone
- remove empty-string `failureDomain` values during MachineSet and Cluster topology migration instead of setting them to JSON null
- add regression coverage for new MachineDeployments and both migration helpers

## Why

Cluster API v1beta2 rejects `failureDomain: null` in topology worker MachineDeployments. The AIO OVN bare-metal POC hit this when creating a BM worker nodegroup without an availability zone label.

## Similar issue scan

Checked `failureDomain` use in `magnum_cluster_api/`, `src/`, and `tests/`.

- Python resource mutation had the relevant problematic paths and is fixed here.
- Generated Rust Cluster API structs already use optional fields with `skip_serializing_if = "Option::is_none"`, so they do not serialize unset values as null.
- Remaining Python `failureDomain` assignments are explicit non-empty values or `pop(..., None)` removals.

## Validation

- `tox -e py310 -- magnum_cluster_api/tests/unit/test_resources.py` currently cannot select a focused file because `tox.ini` hardcodes `pytest magnum_cluster_api/tests/unit/` and also fails with latest `setuptools` because `pkg_resources` is no longer provided.
- Validation workaround used for this branch:
  - `.tox/py310/bin/python -m pip install 'setuptools<81'`
  - run pytest from outside the repo tree so the installed Rust extension is imported:
    `/home/rico/dev/worktrees/mcapi-failuredomain/.tox/py310/bin/python -m pytest /home/rico/dev/worktrees/mcapi-failuredomain/magnum_cluster_api/tests/unit/test_resources.py`

Result: `32 passed`.
