### PR TITLE
fix: Update DevStack sample config file to main branch

### DIFF
--- a/devstack/local.conf.sample
+++ b/devstack/local.conf.sample
@@ -31,7 +31,7 @@ MANILA_USE_UWSGI=False
 enable_plugin magnum https://opendev.org/openstack/magnum
 MAGNUM_GUEST_IMAGE_URL=https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.36.1.qcow2
 
-enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api
+enable_plugin magnum-cluster-api https://github.com/vexxhost/magnum-cluster-api main
 
 [[post-config|/etc/manila/manila.conf]]
 [generic]


### PR DESCRIPTION
Hi team, I found this issue while trying to setup using Devstack so trying to submit a small fix. Please let me know if this isn't approriate and I should submit an Issue first.

Other plugins aren't impacted as they still have master. Error:
```console
+functions-common:git_timed:705            timeout -s SIGINT 0 git clone --no-checkout https://github.com/vexxhost/magnum-cluster-api /opt/stack/magnum-cluster-api
Cloning into '/opt/stack/magnum-cluster-api'...
remote: Enumerating objects: 8074, done.
remote: Counting objects: 100% (444/444), done.
remote: Compressing objects: 100% (209/209), done.
remote: Total 8074 (delta 313), reused 241 (delta 232), pack-reused 7630 (from 2)
Receiving objects: 100% (8074/8074), 6.56 MiB | 4.35 MiB/s, done.
Resolving deltas: 100% (5207/5207), done.
+functions-common:git_timed:719            time_stop git_timed
+functions-common:time_stop:2420           local name
+functions-common:time_stop:2421           local end_time
+functions-common:time_stop:2422           local elapsed_time
+functions-common:time_stop:2423           local total
+functions-common:time_stop:2424           local start_time
+functions-common:time_stop:2426           name=git_timed
+functions-common:time_stop:2427           start_time=1783950435236
+functions-common:time_stop:2429           [[ -z 1783950435236 ]]
++functions-common:time_stop:2432           date +%s%3N
+functions-common:time_stop:2432           end_time=1783950438168
+functions-common:time_stop:2433           elapsed_time=2932
+functions-common:time_stop:2434           total=0
+functions-common:time_stop:2436           _TIME_START[$name]=
+functions-common:time_stop:2437           _TIME_TOTAL[$name]=2932
+functions-common:git_clone:631            cd /opt/stack/magnum-cluster-api
+functions-common:git_clone:632            git_timed fetch origin master
+functions-common:git_timed:697            local count=0
+functions-common:git_timed:698            local timeout=0
+functions-common:git_timed:700            [[ -n 0 ]]
+functions-common:git_timed:701            timeout=0
+functions-common:git_timed:704            time_start git_timed
+functions-common:time_start:2406          local name=git_timed
+functions-common:time_start:2407          local start_time=
+functions-common:time_start:2408          [[ -n '' ]]
++functions-common:time_start:2411          date +%s%3N
+functions-common:time_start:2411          _TIME_START[$name]=1783950438279
+functions-common:git_timed:705            timeout -s SIGINT 0 git fetch origin master
fatal: couldn't find remote ref master
+functions-common:git_timed:708            [[ 128 -ne 124 ]]
+functions-common:git_timed:709            die 709 'git call failed: [git fetch' origin 'master]'
+functions-common:die:290                  local exitcode=0
+functions-common:die:291                  set +o xtrace
[Call Trace]
./stack.sh:600:fetch_plugins
/opt/stack/devstack/functions-common:1776:git_clone_by_name
/opt/stack/devstack/functions-common:685:git_clone
/opt/stack/devstack/functions-common:632:git_timed
/opt/stack/devstack/functions-common:709:die
[ERROR] /opt/stack/devstack/functions-common:709 git call failed: [git fetch origin master]
Error on exit
```