### PR TITLE
fix: disable Keystone trust creation

### DIFF
--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -45,6 +45,8 @@ def cluster_lock_wrapper(func):
 
 
 class BaseDriver(driver.Driver):
+    needs_trust = False
+
     def __init__(self):
         self.k8s_api = clients.get_pykube_api()
         self.rust_driver = tpool.Proxy(magnum_cluster_api.Driver("magnum-system"))

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -30,6 +30,10 @@ from responses import matchers
 from magnum_cluster_api import driver, objects, resources
 
 
+def test_base_driver_does_not_need_trust():
+    assert driver.BaseDriver.needs_trust is False
+
+
 def test_debian_driver_provides():
     debian_driver = driver.DebianDriver.__new__(driver.DebianDriver)
 


### PR DESCRIPTION
## Summary

Declare `BaseDriver.needs_trust = False` so Magnum skips Keystone trustee and trust creation for Cluster API clusters.

Keystone blocks trust operations authenticated with application credentials after CVE-2026-43000. The Cluster API driver does not consume Magnum's trust credentials, so creating them is unnecessary and prevents application-credential-based cluster creation.

## Magnum support

The capability is provided by the stable-only Magnum backport chain:

- `stable/2026.1`: [OpenDev 990625](https://review.opendev.org/c/openstack/magnum/+/990625/6)
- `stable/2025.2`: [vexxhost/magnum#13](https://github.com/vexxhost/magnum/pull/13)
- `stable/2025.1`: [vexxhost/magnum#14](https://github.com/vexxhost/magnum/pull/14)

Both VEXXHOST backports are merged. Defining the class attribute remains harmless with Magnum versions that do not inspect it.

## Validation

- focused regression test: `test_base_driver_does_not_need_trust` passes
- full `pre-commit run --all-files` passes
- `git diff --check` passes

A broader local run of the existing `test_driver.py` completed 26 tests and exposed 12 unrelated baseline/environment failures: four require `helm` in `PATH`, and eight need MachineSet HTTP mocks for current `main`. None involve the new capability assertion.