### PR TITLE
fix: make legacy ClusterClass repair explicit

### DIFF
--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -174,7 +174,12 @@ configured. Newer Cluster API validation rejects the empty value and leaves
 clusters using the class with `TopologyReconciled=False`.
 
 Do not repair every legacy ClusterClass automatically. Changing a ClusterClass
-causes all Clusters using it to reconcile and may trigger Machine rollouts.
+causes all Clusters using it to reconcile and triggers control plane and worker
+Machine rollouts. Schedule a maintenance window for every affected Cluster and
+confirm sufficient infrastructure capacity for replacement Machines. A Cluster
+with a single control plane Machine can experience a brief Kubernetes API
+interruption during the replacement.
+
 First, identify the Clusters using the affected class and stop any cluster
 upgrades:
 
@@ -183,6 +188,14 @@ $ export CLUSTER_CLASS=magnum-v0.34.2
 $ kubectl -n magnum-system get clusters \
     -o custom-columns=NAME:.metadata.name,CLASS:.spec.topology.class \
     | grep "$CLUSTER_CLASS"
+```
+
+Pause every Cluster returned by the inventory before repairing the shared
+ClusterClass:
+
+```
+$ kubectl -n magnum-system annotate cluster <cluster-name> \
+    cluster.x-k8s.io/paused=true --overwrite
 ```
 
 Back up the ClusterClass before changing it:
@@ -199,10 +212,13 @@ Repair only that ClusterClass. The command asks for confirmation unless
 $ magnum-cluster-api-repair-legacy-cluster-class "$CLUSTER_CLASS"
 ```
 
-Monitor topology reconciliation and Machine identities after applying the
-repair:
+Unpause and monitor Clusters one at a time. Wait for each Cluster's topology,
+control plane, worker Machines, and workload Nodes to become healthy before
+unpausing the next Cluster:
 
 ```
+$ kubectl -n magnum-system annotate cluster <cluster-name> \
+    cluster.x-k8s.io/paused- --overwrite
 $ kubectl -n magnum-system get clusters \
     -o custom-columns=NAME:.metadata.name,CLASS:.spec.topology.class,TOPOLOGY:.status.conditions[?(@.type==\"TopologyReconciled\")].status
 $ kubectl -n magnum-system get machines \

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -165,3 +165,46 @@ Once the cluster is gone, you can clean up the project:
 $ unset OS_PROJECT_ID
 $ openstack project delete $CURRENT_PROJECT_ID
 ```
+
+## Legacy ClusterClass fails topology reconciliation after an upgrade
+
+ClusterClasses created by versions of the driver older than `v0.36.1` can
+contain proxy file patches whose rendered `content` is empty when no proxy is
+configured. Newer Cluster API validation rejects the empty value and leaves
+clusters using the class with `TopologyReconciled=False`.
+
+Do not repair every legacy ClusterClass automatically. Changing a ClusterClass
+causes all Clusters using it to reconcile and may trigger Machine rollouts.
+First, identify the Clusters using the affected class and stop any cluster
+upgrades:
+
+```
+$ export CLUSTER_CLASS=magnum-v0.34.2
+$ kubectl -n magnum-system get clusters \
+    -o custom-columns=NAME:.metadata.name,CLASS:.spec.topology.class \
+    | grep "$CLUSTER_CLASS"
+```
+
+Back up the ClusterClass before changing it:
+
+```
+$ kubectl -n magnum-system get clusterclass "$CLUSTER_CLASS" -o yaml \
+    > "$CLUSTER_CLASS.before-repair.yaml"
+```
+
+Repair only that ClusterClass. The command asks for confirmation unless
+`--yes` is supplied:
+
+```
+$ magnum-cluster-api-repair-legacy-cluster-class "$CLUSTER_CLASS"
+```
+
+Monitor topology reconciliation and Machine identities after applying the
+repair:
+
+```
+$ kubectl -n magnum-system get clusters \
+    -o custom-columns=NAME:.metadata.name,CLASS:.spec.topology.class,TOPOLOGY:.status.conditions[?(@.type==\"TopologyReconciled\")].status
+$ kubectl -n magnum-system get machines \
+    -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,CLUSTER:.metadata.labels.cluster\\.x-k8s\\.io/cluster-name
+```

--- a/magnum_cluster_api/cmd/repair_legacy_cluster_class.py
+++ b/magnum_cluster_api/cmd/repair_legacy_cluster_class.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import click
+
+from magnum_cluster_api import magnum_cluster_api
+
+
+@click.command()
+@click.argument("cluster_class_name")
+@click.option("--namespace", default="magnum-system", show_default=True)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Apply the repair without an interactive confirmation.",
+)
+def main(cluster_class_name: str, namespace: str, yes: bool) -> None:
+    """Repair proxy file patches in one legacy CLUSTER_CLASS_NAME."""
+    if not yes:
+        click.confirm(
+            "This changes the bootstrap configuration for every Cluster using "
+            f"{cluster_class_name} and may trigger Machine rollouts. Continue?",
+            abort=True,
+        )
+
+    repaired = magnum_cluster_api.Driver(namespace).repair_legacy_cluster_class(
+        cluster_class_name
+    )
+    if repaired:
+        click.echo(f"Repaired ClusterClass {namespace}/{cluster_class_name}.")
+    else:
+        click.echo(
+            f"No repair was needed for ClusterClass {namespace}/{cluster_class_name}."
+        )

--- a/magnum_cluster_api/cmd/repair_legacy_cluster_class.py
+++ b/magnum_cluster_api/cmd/repair_legacy_cluster_class.py
@@ -34,12 +34,19 @@ def main(cluster_class_name: str, namespace: str, yes: bool) -> None:
             abort=True,
         )
 
-    repaired = magnum_cluster_api.Driver(namespace).repair_legacy_cluster_class(
+    result = magnum_cluster_api.Driver(namespace).repair_legacy_cluster_class(
         cluster_class_name
     )
-    if repaired:
+    if result == magnum_cluster_api.LegacyClusterClassRepairResult.Repaired:
         click.echo(f"Repaired ClusterClass {namespace}/{cluster_class_name}.")
-    else:
+    elif result == magnum_cluster_api.LegacyClusterClassRepairResult.AlreadyFixed:
         click.echo(
-            f"No repair was needed for ClusterClass {namespace}/{cluster_class_name}."
+            f"ClusterClass {namespace}/{cluster_class_name} is already repaired."
         )
+    elif result == magnum_cluster_api.LegacyClusterClassRepairResult.OutOfScope:
+        click.echo(
+            f"ClusterClass {namespace}/{cluster_class_name} is outside the supported "
+            "legacy repair scope."
+        )
+    else:
+        raise click.ClickException(f"Unexpected repair result: {result!r}")

--- a/magnum_cluster_api/driver.py
+++ b/magnum_cluster_api/driver.py
@@ -50,10 +50,6 @@ class BaseDriver(driver.Driver):
     def __init__(self):
         self.k8s_api = clients.get_pykube_api()
         self.rust_driver = tpool.Proxy(magnum_cluster_api.Driver("magnum-system"))
-        # Ensure the current ClusterClass exists and legacy versioned
-        # ClusterClasses are compatible with the installed CAPI CRDs as soon as
-        # the conductor loads the driver, not only after a cluster operation.
-        self.rust_driver.apply_cluster_class()
 
     @property
     def kube_client(self):

--- a/magnum_cluster_api/tests/unit/test_driver.py
+++ b/magnum_cluster_api/tests/unit/test_driver.py
@@ -42,6 +42,18 @@ def test_debian_driver_provides():
     ]
 
 
+def test_driver_init_does_not_apply_cluster_class(mocker):
+    mocker.patch("magnum_cluster_api.driver.clients.get_pykube_api")
+    rust_driver = mocker.patch(
+        "magnum_cluster_api.driver.magnum_cluster_api.Driver"
+    ).return_value
+    mocker.patch("magnum_cluster_api.driver.tpool.Proxy", side_effect=lambda obj: obj)
+
+    driver.UbuntuDriver()
+
+    rust_driver.apply_cluster_class.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "auto_scaling_enabled", [True, False], ids=lambda x: f"auto_scaling_enabled={x}"
 )

--- a/magnum_cluster_api/tests/unit/test_repair_legacy_cluster_class.py
+++ b/magnum_cluster_api/tests/unit/test_repair_legacy_cluster_class.py
@@ -12,17 +12,37 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from enum import Enum
+
+import pytest
 from click.testing import CliRunner
 
 from magnum_cluster_api.cmd import repair_legacy_cluster_class
 
 
-def test_repairs_one_cluster_class(mocker):
+class RepairResult(Enum):
+    Repaired = "repaired"
+    AlreadyFixed = "already-fixed"
+    OutOfScope = "out-of-scope"
+
+
+@pytest.fixture()
+def repair_results(mocker):
+    mocker.patch.object(
+        repair_legacy_cluster_class.magnum_cluster_api,
+        "LegacyClusterClassRepairResult",
+        RepairResult,
+        create=True,
+    )
+    return RepairResult
+
+
+def invoke_repair(mocker, repair_result):
     driver = mocker.patch(
         "magnum_cluster_api.cmd.repair_legacy_cluster_class."
         "magnum_cluster_api.Driver"
     ).return_value
-    driver.repair_legacy_cluster_class.return_value = True
+    driver.repair_legacy_cluster_class.return_value = repair_result
 
     result = CliRunner().invoke(
         repair_legacy_cluster_class.main,
@@ -31,7 +51,27 @@ def test_repairs_one_cluster_class(mocker):
 
     assert result.exit_code == 0
     driver.repair_legacy_cluster_class.assert_called_once_with("magnum-v0.34.2")
+    return result
+
+
+def test_repairs_one_cluster_class(mocker, repair_results):
+    result = invoke_repair(mocker, repair_results.Repaired)
+
     assert "Repaired ClusterClass test-system/magnum-v0.34.2." in result.output
+
+
+def test_reports_already_repaired_cluster_class(mocker, repair_results):
+    result = invoke_repair(mocker, repair_results.AlreadyFixed)
+
+    assert (
+        "ClusterClass test-system/magnum-v0.34.2 is already repaired." in result.output
+    )
+
+
+def test_reports_cluster_class_outside_repair_scope(mocker, repair_results):
+    result = invoke_repair(mocker, repair_results.OutOfScope)
+
+    assert "is outside the supported legacy repair scope." in result.output
 
 
 def test_warns_before_repair(mocker):

--- a/magnum_cluster_api/tests/unit/test_repair_legacy_cluster_class.py
+++ b/magnum_cluster_api/tests/unit/test_repair_legacy_cluster_class.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from click.testing import CliRunner
+
+from magnum_cluster_api.cmd import repair_legacy_cluster_class
+
+
+def test_repairs_one_cluster_class(mocker):
+    driver = mocker.patch(
+        "magnum_cluster_api.cmd.repair_legacy_cluster_class."
+        "magnum_cluster_api.Driver"
+    ).return_value
+    driver.repair_legacy_cluster_class.return_value = True
+
+    result = CliRunner().invoke(
+        repair_legacy_cluster_class.main,
+        ["--yes", "--namespace", "test-system", "magnum-v0.34.2"],
+    )
+
+    assert result.exit_code == 0
+    driver.repair_legacy_cluster_class.assert_called_once_with("magnum-v0.34.2")
+    assert "Repaired ClusterClass test-system/magnum-v0.34.2." in result.output
+
+
+def test_warns_before_repair(mocker):
+    driver = mocker.patch(
+        "magnum_cluster_api.cmd.repair_legacy_cluster_class."
+        "magnum_cluster_api.Driver"
+    )
+
+    result = CliRunner().invoke(
+        repair_legacy_cluster_class.main,
+        ["magnum-v0.34.2"],
+        input="n\n",
+    )
+
+    assert result.exit_code == 1
+    assert "may trigger Machine rollouts" in result.output
+    driver.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
 [project.scripts]
 magnum-cluster-api-image-builder = "magnum_cluster_api.cmd.image_builder:main"
 magnum-cluster-api-proxy = "magnum_cluster_api.cmd.proxy:main"
+magnum-cluster-api-repair-legacy-cluster-class = "magnum_cluster_api.cmd.repair_legacy_cluster_class:main"
 
 [project.entry-points."magnum.drivers"]
 k8s_cluster_api_ubuntu = "magnum_cluster_api.driver:UbuntuDriver"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -234,14 +234,27 @@ impl Driver {
                 self.client
                     .create_or_update_namespaced_resource(&self.namespace, cluster_class)
                     .await?;
-                crate::legacy_cluster_class::repair_legacy_proxy_file_patches(
-                    self.client.clone(),
-                    &self.namespace,
-                )
-                .await?;
 
                 Ok(())
             })
+        })
+    }
+
+    fn repair_legacy_cluster_class(
+        &self,
+        py: Python<'_>,
+        cluster_class_name: String,
+    ) -> Result<bool, kubernetes::Error> {
+        // This operation is intentionally explicit: changing bootstrap
+        // configuration can trigger rollouts for every Cluster using the class.
+        Python::detach(py, || {
+            get_runtime().block_on(
+                crate::legacy_cluster_class::repair_legacy_proxy_file_patches(
+                    self.client.clone(),
+                    &self.namespace,
+                    &cluster_class_name,
+                ),
+            )
         })
     }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -244,7 +244,10 @@ impl Driver {
         &self,
         py: Python<'_>,
         cluster_class_name: String,
-    ) -> Result<bool, kubernetes::Error> {
+    ) -> Result<
+        crate::legacy_cluster_class::LegacyClusterClassRepairResult,
+        kubernetes::Error,
+    > {
         // This operation is intentionally explicit: changing bootstrap
         // configuration can trigger rollouts for every Cluster using the class.
         Python::detach(py, || {

--- a/src/legacy_cluster_class.rs
+++ b/src/legacy_cluster_class.rs
@@ -4,6 +4,7 @@ use kube::{
     Client,
 };
 use log::debug;
+use pyo3::prelude::*;
 use semver::Version;
 use serde_yaml::{Mapping, Value};
 
@@ -16,19 +17,27 @@ const SYSTEMD_PROXY_VARIABLE: &str = "systemdProxyConfig";
 const SYSTEMD_PROXY_PLACEHOLDER_TEMPLATE: &str =
     r#"{{ if ne .systemdProxyConfig "" }}{{ .systemdProxyConfig }}{{ else }}Iw=={{ end }}"#;
 
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LegacyClusterClassRepairResult {
+    Repaired,
+    AlreadyFixed,
+    OutOfScope,
+}
+
 pub async fn repair_legacy_proxy_file_patches(
     client: Client,
     namespace: &str,
     cluster_class_name: &str,
-) -> Result<bool, kubernetes::Error> {
+) -> Result<LegacyClusterClassRepairResult, kubernetes::Error> {
     let api: Api<ClusterClass> = Api::namespaced(client, namespace);
     if !should_repair_cluster_class(cluster_class_name) {
-        return Ok(false);
+        return Ok(LegacyClusterClassRepairResult::OutOfScope);
     }
 
     let mut cluster_class = api.get(cluster_class_name).await?;
     if !repair_proxy_file_content_templates(&mut cluster_class) {
-        return Ok(false);
+        return Ok(LegacyClusterClassRepairResult::AlreadyFixed);
     }
 
     let patch = serde_json::json!({
@@ -44,7 +53,7 @@ pub async fn repair_legacy_proxy_file_patches(
     .await?;
     debug!("repaired legacy proxy file patches in ClusterClass {cluster_class_name}");
 
-    Ok(true)
+    Ok(LegacyClusterClassRepairResult::Repaired)
 }
 
 fn should_repair_cluster_class(name: &str) -> bool {

--- a/src/legacy_cluster_class.rs
+++ b/src/legacy_cluster_class.rs
@@ -17,7 +17,7 @@ const SYSTEMD_PROXY_VARIABLE: &str = "systemdProxyConfig";
 const SYSTEMD_PROXY_PLACEHOLDER_TEMPLATE: &str =
     r#"{{ if ne .systemdProxyConfig "" }}{{ .systemdProxyConfig }}{{ else }}Iw=={{ end }}"#;
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LegacyClusterClassRepairResult {
     Repaired,

--- a/src/legacy_cluster_class.rs
+++ b/src/legacy_cluster_class.rs
@@ -1,7 +1,7 @@
 use crate::{clients::kubernetes, cluster_api::clusterclasses::ClusterClass};
 use kube::{
-    api::{Api, ListParams, Patch, PatchParams},
-    Client, ResourceExt,
+    api::{Api, Patch, PatchParams},
+    Client,
 };
 use log::debug;
 use semver::Version;
@@ -19,30 +19,32 @@ const SYSTEMD_PROXY_PLACEHOLDER_TEMPLATE: &str =
 pub async fn repair_legacy_proxy_file_patches(
     client: Client,
     namespace: &str,
-) -> Result<usize, kubernetes::Error> {
+    cluster_class_name: &str,
+) -> Result<bool, kubernetes::Error> {
     let api: Api<ClusterClass> = Api::namespaced(client, namespace);
-    let mut repaired = 0;
-
-    for mut cluster_class in api.list(&ListParams::default()).await?.items {
-        let name = cluster_class.name_any();
-        if !should_repair_cluster_class(&name) {
-            continue;
-        }
-
-        if repair_proxy_file_content_templates(&mut cluster_class) {
-            let patch = serde_json::json!({
-                "spec": {
-                    "patches": cluster_class.spec.patches,
-                },
-            });
-            api.patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
-                .await?;
-            repaired += 1;
-            debug!("repaired legacy proxy file patches in ClusterClass {name}");
-        }
+    if !should_repair_cluster_class(cluster_class_name) {
+        return Ok(false);
     }
 
-    Ok(repaired)
+    let mut cluster_class = api.get(cluster_class_name).await?;
+    if !repair_proxy_file_content_templates(&mut cluster_class) {
+        return Ok(false);
+    }
+
+    let patch = serde_json::json!({
+        "spec": {
+            "patches": cluster_class.spec.patches,
+        },
+    });
+    api.patch(
+        cluster_class_name,
+        &PatchParams::default(),
+        &Patch::Merge(&patch),
+    )
+    .await?;
+    debug!("repaired legacy proxy file patches in ClusterClass {cluster_class_name}");
+
+    Ok(true)
 }
 
 fn should_repair_cluster_class(name: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ fn magnum_cluster_api(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("CLUSTER_CLASS_NAME", CLUSTER_CLASS_NAME.as_str())?;
     m.add_class::<client::KubeClient>()?;
     m.add_class::<driver::Driver>()?;
+    m.add_class::<legacy_cluster_class::LegacyClusterClassRepairResult>()?;
     m.add_class::<monitor::Monitor>()?;
 
     Ok(())


### PR DESCRIPTION
> Stacked on #1121. This follow-up changes the repair introduced there from
> automatic reconciliation to an explicit administrator operation.

## What changed from #1121

- Remove automatic legacy ClusterClass repair from driver startup and normal ClusterClass application.
- Add an explicit `magnum-cluster-api-repair-legacy-cluster-class` administrator CLI for the scoped repair implemented by #1121.
- Require interactive confirmation by default and support `--yes` for planned automation.
- Return a clear message when the class is already repaired or is outside the legacy scope.
- Document inventory, backup, repair, and rollout-monitoring steps.

## Why

As described in #1121, Clusters remain pinned to the ClusterClass recorded in `spec.topology.class`. Some ClusterClasses generated before `v0.36.1` render empty `files[].content` values when no proxy is configured. Newer Cluster API validation rejects those values, which can leave topology reconciliation blocked after an upgrade.

Changing a shared ClusterClass can also update bootstrap templates for every Cluster using it and trigger Machine rollouts. For that reason, this PR makes the repair an explicit, one-class-at-a-time administrator action instead of applying it automatically during conductor startup.

## Operator workflow

```bash
magnum-cluster-api-repair-legacy-cluster-class \
  --yes \
  magnum-v0.34.2
```

Before running the command:

1. Inventory every Cluster using the target ClusterClass.
2. Pause affected Clusters and stop concurrent upgrades.
3. Back up the ClusterClass.
4. Confirm sufficient Nova capacity for control-plane and worker surge.
5. Repair the shared class, then unpause and monitor Clusters one at a time.

## Validation

### Unit and source checks

- `uv run --no-sync pytest magnum_cluster_api/tests/unit/test_repair_legacy_cluster_class.py magnum_cluster_api/tests/unit/test_driver.py::test_driver_init_does_not_apply_cluster_class magnum_cluster_api/tests/unit/test_driver.py::TestDriver::test_create_cluster -q`
  - `7 passed`
- `git diff --check origin/codex/fix-legacy-clusterclass-proxy-content...HEAD`
- The final source tree was successfully built into a wheel and installed in the AIO environment.

The local Mac currently has Rust `1.90.0`, while this repository requires Rust `1.95`, so the final local `cargo test` invocation could not start. Rust tests should run in CI with the repository-supported toolchain.

### Active legacy AIO test

The test used a healthy, active one-control-plane/one-worker Cluster on a deliberately vulnerable `magnum-v0.36.0-aio-active` ClusterClass. Both Machines and workload Nodes were Running before executing the exact repair CLI.

| Role | State | Machine UID | Nova server ID |
| --- | --- | --- | --- |
| Control plane | Before repair | `2f815010-84ff-487c-bcd1-a90f6b4d3e4e` | `a11164e3-f54e-450e-929a-c80ecd2e26ea` |
| Control plane | After repair | `a5c6a5fc-96a0-4fd4-9db4-ce500238d365` | `686c6709-e5e5-4263-86cd-14be8075bf16` |
| Worker | Before repair | `acb127c4-b7cf-422a-aa9e-4748e97a0300` | `f4d9f563-4085-4134-a3ef-d47f843bb6a9` |
| Worker | After repair | `12df708b-7c49-4bcb-bf04-dba899ffbf36` | `4fccacfc-6e3d-4d13-89ac-e08ead444ea6` |

Observed result:

- The CLI reported `Repaired ClusterClass magnum-system/magnum-v0.36.0-aio-active.`
- All four affected proxy templates matched the repaired content.
- KubeadmControlPlane and MachineDeployment each surged from one to two Machines.
- New Machines became Running before their legacy counterparts were removed.
- Both original Nova server IDs were deleted.
- Final KubeadmControlPlane and MachineDeployment status was `1/1 Ready`, `1 updated`, and `0 unavailable`.
- Both workload Nodes were Ready and all 22 `kube-system` pods were Running.
- Magnum remained `CREATE_COMPLETE / HEALTHY`.
- One workload API poll returned no data during the single-control-plane handoff and recovered on the next poll. A maintenance window is therefore recommended for single-control-plane clusters.
- The disposable AIO resources were removed after validation.

## Merge, release, and backport

Merge this stacked change into the #1121 branch so the main PR contains the explicit workflow before it lands. Then identify the exact magnum-cluster-api release branch used by the target deployment before backporting. Do not infer the branch from deployment dates. The deployed package should include this CLI before operators repair affected legacy ClusterClasses.
